### PR TITLE
fix: resolve Ubuntu install issues (#1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,13 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3003
 ENV HOSTNAME="0.0.0.0"
 ENV CHROME_PATH=/usr/bin/chromium-browser
-RUN mkdir -p /home/node/.claude && chown node:node /home/node/.claude
+
+# CLI provider support: writable npm global prefix for node user
+RUN mkdir -p /home/node/.npm-global /home/node/.claude /home/node/.codex && \
+    chown -R node:node /home/node/.npm-global /home/node/.claude /home/node/.codex
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH="/home/node/.npm-global/bin:$PATH"
+
 WORKDIR /app
 
 # Standalone server (includes traced node_modules)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Track flight prices over time. Self-hosted. Open source. Bring your own LLM.
 ## Quick Start
 
 ```bash
-curl -fsSL https://fairtrail.org/install.sh | sh
+curl -fsSL https://fairtrail.org/install.sh | bash
 ```
 
 If you have [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex](https://github.com/openai/codex) installed, the setup script detects it automatically — **no API key needed**. Otherwise, it asks you to paste one.

--- a/apps/web/public/fairtrail-cli
+++ b/apps/web/public/fairtrail-cli
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Fairtrail CLI — wraps Docker so you never have to think about it.
-# Installed by: curl -fsSL https://fairtrail.org/install.sh | sh
+# Installed by: curl -fsSL https://fairtrail.org/install.sh | bash
 #
 # Usage:
 #   fairtrail          Start Fairtrail (Ctrl+C to stop)
@@ -27,7 +27,7 @@ BASE_URL="${FAIRTRAIL_URL:-https://fairtrail.org}"
 
 if [ ! -f "$FAIRTRAIL_DIR/docker-compose.yml" ]; then
   printf "${RED}${BOLD}✗${RESET} Fairtrail not found. Run the installer first:\n"
-  printf "  curl -fsSL https://fairtrail.org/install.sh | sh\n"
+  printf "  curl -fsSL https://fairtrail.org/install.sh | bash\n"
   exit 1
 fi
 
@@ -105,8 +105,8 @@ cmd_start_foreground() {
     # Open browser
     if command -v open &>/dev/null; then
       open "http://localhost:${PORT}"
-    elif command -v xdg-open &>/dev/null; then
-      xdg-open "http://localhost:${PORT}" 2>/dev/null &
+    elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
+      xdg-open "http://localhost:${PORT}" >/dev/null 2>&1 &
     fi
   fi
 
@@ -133,8 +133,8 @@ cmd_start_background() {
   # Open browser
   if command -v open &>/dev/null; then
     open "http://localhost:${PORT}"
-  elif command -v xdg-open &>/dev/null; then
-    xdg-open "http://localhost:${PORT}" 2>/dev/null &
+  elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
+    xdg-open "http://localhost:${PORT}" >/dev/null 2>&1 &
   fi
 }
 
@@ -348,8 +348,8 @@ print(json.dumps(body))
 
   if command -v open &>/dev/null; then
     open "http://localhost:${PORT}/q/${query_id}"
-  elif command -v xdg-open &>/dev/null; then
-    xdg-open "http://localhost:${PORT}/q/${query_id}" 2>/dev/null &
+  elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
+    xdg-open "http://localhost:${PORT}/q/${query_id}" >/dev/null 2>&1 &
   fi
 }
 

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Fairtrail — One-command installer
-# Usage: curl -fsSL https://fairtrail.org/install.sh | sh
+# Usage: curl -fsSL https://fairtrail.org/install.sh | bash
 #
 # Installs the fairtrail CLI and Docker services to ~/.fairtrail
 # No git clone, no build — pulls a pre-built image from GHCR.
@@ -94,7 +94,7 @@ install_docker_linux() {
 if ! command -v docker &>/dev/null; then
   case "$OS" in
     macos)
-      fail "Docker Desktop is required.\n\n  Install it from: ${BOLD}https://docs.docker.com/desktop/setup/install/mac-install/${RESET}\n\n  Then re-run: ${BOLD}curl -fsSL https://fairtrail.org/install.sh | sh${RESET}"
+      fail "Docker Desktop is required.\n\n  Install it from: ${BOLD}https://docs.docker.com/desktop/setup/install/mac-install/${RESET}\n\n  Then re-run: ${BOLD}curl -fsSL https://fairtrail.org/install.sh | bash${RESET}"
       ;;
     linux|wsl)
       warn "Docker is not installed."
@@ -115,7 +115,7 @@ fi
 if ! docker info &>/dev/null 2>&1; then
   case "$OS" in
     macos)
-      fail "Docker Desktop is not running.\n\n  Open Docker Desktop from Applications, wait for it to start, then re-run:\n  ${BOLD}curl -fsSL https://fairtrail.org/install.sh | sh${RESET}"
+      fail "Docker Desktop is not running.\n\n  Open Docker Desktop from Applications, wait for it to start, then re-run:\n  ${BOLD}curl -fsSL https://fairtrail.org/install.sh | bash${RESET}"
       ;;
     linux|wsl)
       warn "Docker daemon is not running."
@@ -225,11 +225,13 @@ services:
       SELF_HOSTED: "true"
     volumes:
       - app-data:/app/data
+      - cli-cache:/home/node/.npm-global
 
 volumes:
   pgdata:
   redisdata:
   app-data:
+  cli-cache:
 COMPOSE
 
 ok "Created ~/.fairtrail"
@@ -270,13 +272,35 @@ else
   fail "Failed to download CLI from $BASE_URL/fairtrail-cli"
 fi
 
-# Check if ~/.local/bin is in PATH
+# Ensure ~/.local/bin is in PATH
 if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_BIN"; then
-  warn "$INSTALL_BIN is not in your PATH"
-  echo ""
-  printf "  Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):\n"
-  printf "  ${BOLD}export PATH=\"\$HOME/.local/bin:\$PATH\"${RESET}\n"
-  echo ""
+  EXPORT_LINE='export PATH="$HOME/.local/bin:$PATH"'
+  SHELL_PROFILE=""
+
+  # Find the right shell profile to patch
+  if [ -n "${ZSH_VERSION:-}" ] || [ "$(basename "${SHELL:-}")" = "zsh" ]; then
+    [ -f "$HOME/.zshrc" ] && SHELL_PROFILE="$HOME/.zshrc"
+  elif [ -f "$HOME/.bashrc" ]; then
+    SHELL_PROFILE="$HOME/.bashrc"
+  elif [ -f "$HOME/.profile" ]; then
+    SHELL_PROFILE="$HOME/.profile"
+  fi
+
+  if [ -n "$SHELL_PROFILE" ]; then
+    # Only add if not already present
+    if ! grep -qF '.local/bin' "$SHELL_PROFILE" 2>/dev/null; then
+      printf '\n# Added by Fairtrail installer\n%s\n' "$EXPORT_LINE" >> "$SHELL_PROFILE"
+      ok "Added $INSTALL_BIN to PATH in $SHELL_PROFILE"
+    fi
+  else
+    warn "$INSTALL_BIN is not in your PATH"
+    printf "  Add this to your shell profile:\n"
+    printf "  ${BOLD}export PATH=\"\$HOME/.local/bin:\$PATH\"${RESET}\n"
+    echo ""
+  fi
+
+  # Make it available for the rest of this script
+  export PATH="$INSTALL_BIN:$PATH"
 fi
 
 # ---------------------------------------------------------------------------
@@ -496,9 +520,9 @@ printf "  Next time, just run: ${BOLD}fairtrail${RESET}\n"
 printf "  ${DIM}Ctrl+C to stop  |  fairtrail stop  |  fairtrail help${RESET}\n"
 echo ""
 
-# Open browser automatically
+# Open browser automatically (skip on headless systems)
 if command -v open &>/dev/null; then
   open "http://localhost:${PORT}"
-elif command -v xdg-open &>/dev/null; then
-  xdg-open "http://localhost:${PORT}" 2>/dev/null &
+elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
+  xdg-open "http://localhost:${PORT}" >/dev/null 2>&1 &
 fi

--- a/apps/web/src/components/InstallCommand.tsx
+++ b/apps/web/src/components/InstallCommand.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import styles from './InstallCommand.module.css';
 
-const COMMAND = 'curl -fsSL https://fairtrail.org/install.sh | sh';
+const COMMAND = 'curl -fsSL https://fairtrail.org/install.sh | bash';
 
 export function InstallCommand() {
   const [copied, setCopied] = useState(false);

--- a/apps/web/src/lib/scraper/ai-registry.test.ts
+++ b/apps/web/src/lib/scraper/ai-registry.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type { ChildProcess } from 'child_process';
+
+// Mock child_process — vi.mock handles both static and dynamic imports
+const mockSpawn = vi.fn();
+const mockExecSync = vi.fn();
+
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
+// Must import after mocks
+const { EXTRACTION_PROVIDERS, detectAvailableProviders } = await import(
+  './ai-registry'
+);
+
+/** Create a fake ChildProcess-like EventEmitter with stdin/stdout/stderr */
+function createFakeProc() {
+  const proc = new EventEmitter() as EventEmitter & Pick<ChildProcess, 'stdin' | 'stdout' | 'stderr'>;
+  proc.stdout = new EventEmitter() as ChildProcess['stdout'];
+  proc.stderr = new EventEmitter() as ChildProcess['stderr'];
+  proc.stdin = {
+    write: vi.fn(),
+    end: vi.fn(),
+  } as unknown as ChildProcess['stdin'];
+  return proc;
+}
+
+describe('ai-registry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('detectAvailableProviders', () => {
+    afterEach(() => {
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+      delete process.env.GOOGLE_AI_API_KEY;
+      delete process.env.CLAUDE_CODE_ENABLED;
+      delete process.env.CODEX_ENABLED;
+    });
+
+    it('detects API-key providers when env vars are set', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+      process.env.OPENAI_API_KEY = 'sk-test';
+
+      const providers = await detectAvailableProviders();
+
+      expect(providers).toContain('anthropic');
+      expect(providers).toContain('openai');
+      expect(providers).not.toContain('google');
+    });
+
+    it('detects CLI providers when enabled and binary exists', async () => {
+      process.env.CLAUDE_CODE_ENABLED = 'true';
+      mockExecSync.mockReturnValue(Buffer.from('/usr/local/bin/claude'));
+
+      const providers = await detectAvailableProviders();
+
+      expect(providers).toContain('claude-code');
+      expect(mockExecSync).toHaveBeenCalledWith('which claude', {
+        stdio: 'ignore',
+      });
+    });
+
+    it('skips CLI providers when binary is not found', async () => {
+      process.env.CODEX_ENABLED = 'true';
+      mockExecSync.mockImplementation(() => {
+        throw new Error('not found');
+      });
+
+      const providers = await detectAvailableProviders();
+
+      expect(providers).not.toContain('codex');
+    });
+
+    it('skips CLI providers when not enabled even if binary exists', async () => {
+      const providers = await detectAvailableProviders();
+
+      expect(providers).not.toContain('codex');
+      expect(providers).not.toContain('claude-code');
+    });
+  });
+
+  describe('codex extract — ENOENT handling', () => {
+    it('rejects with actionable message when codex binary is missing', async () => {
+      const fakeProc = createFakeProc();
+      mockSpawn.mockReturnValue(fakeProc);
+
+      const extractPromise = EXTRACTION_PROVIDERS.codex!.extract(
+        '',
+        'codex',
+        'system',
+        'user'
+      );
+
+      // Give the dynamic import a tick to resolve
+      await vi.waitFor(() => {
+        expect(mockSpawn).toHaveBeenCalled();
+      });
+
+      // Simulate ENOENT error
+      const err = new Error('spawn codex ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      fakeProc.emit('error', err);
+
+      await expect(extractPromise).rejects.toThrow(
+        /codex CLI not found.*Restart the container/
+      );
+    });
+  });
+
+  describe('claude-code extract — ENOENT handling', () => {
+    it('rejects with actionable message when claude binary is missing', async () => {
+      const fakeProc = createFakeProc();
+      mockSpawn.mockReturnValue(fakeProc);
+
+      const extractPromise = EXTRACTION_PROVIDERS['claude-code']!.extract(
+        '',
+        'sonnet',
+        'system',
+        'user'
+      );
+
+      await vi.waitFor(() => {
+        expect(mockSpawn).toHaveBeenCalled();
+      });
+
+      const err = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      fakeProc.emit('error', err);
+
+      await expect(extractPromise).rejects.toThrow(
+        /claude CLI not found.*Restart the container/
+      );
+    });
+  });
+
+  describe('codex extract passes env to spawn', () => {
+    it('includes process.env in spawn options', async () => {
+      const fakeProc = createFakeProc();
+      mockSpawn.mockReturnValue(fakeProc);
+
+      const extractPromise = EXTRACTION_PROVIDERS.codex!.extract(
+        '',
+        'codex',
+        'system',
+        'user'
+      );
+
+      await vi.waitFor(() => {
+        expect(mockSpawn).toHaveBeenCalled();
+      });
+
+      // Verify spawn was called with env containing PATH
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'codex',
+        ['--print'],
+        expect.objectContaining({
+          env: expect.objectContaining({ PATH: expect.any(String) }),
+        })
+      );
+
+      // Clean up: resolve the promise
+      fakeProc.emit('close', 0);
+      await extractPromise.catch(() => {});
+    });
+  });
+});

--- a/apps/web/src/lib/scraper/ai-registry.ts
+++ b/apps/web/src/lib/scraper/ai-registry.ts
@@ -165,7 +165,13 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
           if (code !== 0) reject(new Error(`claude CLI exited ${code}: ${stderr}`));
           else resolve(stdout.trim());
         });
-        proc.on('error', reject);
+        proc.on('error', (err: NodeJS.ErrnoException) => {
+          if (err.code === 'ENOENT') {
+            reject(new Error('claude CLI not found. Restart the container to trigger install, or disable CLAUDE_CODE_ENABLED.'));
+          } else {
+            reject(err);
+          }
+        });
         proc.stdin.write(fullPrompt);
         proc.stdin.end();
       });
@@ -190,6 +196,7 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
       const result = await new Promise<string>((resolve, reject) => {
         const proc = spawn('codex', ['--print'], {
           timeout: 240_000,
+          env: { ...process.env },
         });
 
         let stdout = '';
@@ -204,7 +211,13 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
           if (code !== 0) reject(new Error(`codex CLI exited ${code}: ${stderr}`));
           else resolve(stdout.trim());
         });
-        proc.on('error', reject);
+        proc.on('error', (err: NodeJS.ErrnoException) => {
+          if (err.code === 'ENOENT') {
+            reject(new Error('codex CLI not found. Restart the container to trigger install, or disable CODEX_ENABLED.'));
+          } else {
+            reject(err);
+          }
+        });
         proc.stdin.write(fullPrompt);
         proc.stdin.end();
       });

--- a/apps/web/src/lib/scraper/install-scripts.test.ts
+++ b/apps/web/src/lib/scraper/install-scripts.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const INSTALL_SH = readFileSync(
+  resolve(__dirname, '../../../public/install.sh'),
+  'utf-8'
+);
+const CLI_SH = readFileSync(
+  resolve(__dirname, '../../../public/fairtrail-cli'),
+  'utf-8'
+);
+
+describe('install.sh', () => {
+  it('uses bash shebang, not sh', () => {
+    expect(INSTALL_SH).toMatch(/^#!\/usr\/bin\/env bash/);
+  });
+
+  it('documents | bash in usage comment, not | sh', () => {
+    const usageLine = INSTALL_SH.split('\n').find((l) =>
+      l.includes('Usage:')
+    );
+    expect(usageLine).toContain('| bash');
+    expect(usageLine).not.toMatch(/\| sh\b/);
+  });
+
+  it('does not reference | sh in user-facing messages', () => {
+    // Find all lines that show the install command to users (printf/echo with curl)
+    const userFacingLines = INSTALL_SH.split('\n').filter(
+      (l) => l.includes('fairtrail.org/install.sh') && !l.startsWith('#')
+    );
+    for (const line of userFacingLines) {
+      expect(line, `Line references | sh: ${line.trim()}`).not.toMatch(
+        /\| sh\b/
+      );
+    }
+  });
+
+  it('auto-adds ~/.local/bin to shell profile when not in PATH', () => {
+    // Should modify a shell profile, not just print a warning
+    expect(INSTALL_SH).toContain('>> "$SHELL_PROFILE"');
+  });
+
+  it('exports PATH for the rest of the script after adding it', () => {
+    expect(INSTALL_SH).toContain('export PATH="$INSTALL_BIN:$PATH"');
+  });
+
+  it('guards xdg-open behind DISPLAY/WAYLAND_DISPLAY check', () => {
+    const xdgLines = INSTALL_SH.split('\n').filter((l) =>
+      l.includes('xdg-open')
+    );
+    expect(xdgLines.length).toBeGreaterThan(0);
+    for (const line of xdgLines) {
+      // The guard should be on the same line or the line before (elif)
+      const lineIdx = INSTALL_SH.split('\n').indexOf(line);
+      const context = INSTALL_SH.split('\n')
+        .slice(Math.max(0, lineIdx - 1), lineIdx + 1)
+        .join('\n');
+      expect(
+        context,
+        `xdg-open not guarded: ${line.trim()}`
+      ).toMatch(/DISPLAY|WAYLAND_DISPLAY/);
+    }
+  });
+
+  it('redirects both stdout and stderr for xdg-open', () => {
+    const xdgExecLines = INSTALL_SH.split('\n').filter(
+      (l) => l.includes('xdg-open') && !l.includes('command -v')
+    );
+    for (const line of xdgExecLines) {
+      expect(line, `xdg-open stderr not redirected: ${line.trim()}`).toMatch(
+        />[^ ]* 2>&1/
+      );
+    }
+  });
+
+  it('includes cli-cache volume for persisting CLI installs', () => {
+    expect(INSTALL_SH).toContain('cli-cache:/home/node/.npm-global');
+  });
+});
+
+describe('fairtrail-cli', () => {
+  it('uses bash shebang', () => {
+    expect(CLI_SH).toMatch(/^#!\/usr\/bin\/env bash/);
+  });
+
+  it('guards xdg-open behind DISPLAY/WAYLAND_DISPLAY check', () => {
+    const xdgLines = CLI_SH.split('\n').filter((l) =>
+      l.includes('xdg-open')
+    );
+    expect(xdgLines.length).toBeGreaterThan(0);
+    for (const line of xdgLines) {
+      const lineIdx = CLI_SH.split('\n').indexOf(line);
+      const context = CLI_SH.split('\n')
+        .slice(Math.max(0, lineIdx - 1), lineIdx + 1)
+        .join('\n');
+      expect(
+        context,
+        `xdg-open not guarded: ${line.trim()}`
+      ).toMatch(/DISPLAY|WAYLAND_DISPLAY/);
+    }
+  });
+
+  it('does not reference | sh for install command', () => {
+    const installLines = CLI_SH.split('\n').filter(
+      (l) => l.includes('fairtrail.org/install.sh') && !l.startsWith('#')
+    );
+    for (const line of installLines) {
+      expect(line, `Line references | sh: ${line.trim()}`).not.toMatch(
+        /\| sh\b/
+      );
+    }
+  });
+});

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,6 +30,7 @@ services:
     volumes:
       - /home/sotto/.claude:/home/node/.claude
       - analytics-data:/app/data
+      - cli-cache:/home/node/.npm-global
     environment:
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@db:5432/fairtrail
       REDIS_URL: redis://redis:6379
@@ -47,3 +48,4 @@ volumes:
   pgdata:
   redisdata:
   analytics-data:
+  cli-cache:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,6 +59,27 @@ echo "[setup] Applying database schema..."
 npx prisma@6 db push --schema=apps/web/prisma/schema.prisma --skip-generate --accept-data-loss 2>&1 | tail -1
 echo "[setup] Schema ready"
 
+# --- Install CLI providers if enabled ---
+if [ "${CLAUDE_CODE_ENABLED:-}" = "true" ] && ! command -v claude >/dev/null 2>&1; then
+  echo "[setup] Installing Claude Code CLI..."
+  npm install -g @anthropic-ai/claude-code --prefer-offline --no-audit --no-fund 2>&1 | tail -1
+  if command -v claude >/dev/null 2>&1; then
+    echo "[setup] Claude Code CLI ready"
+  else
+    echo "[setup] WARNING: Claude Code CLI install failed — provider unavailable"
+  fi
+fi
+
+if [ "${CODEX_ENABLED:-}" = "true" ] && ! command -v codex >/dev/null 2>&1; then
+  echo "[setup] Installing Codex CLI..."
+  npm install -g @openai/codex --prefer-offline --no-audit --no-fund 2>&1 | tail -1
+  if command -v codex >/dev/null 2>&1; then
+    echo "[setup] Codex CLI ready"
+  else
+    echo "[setup] WARNING: Codex CLI install failed — provider unavailable"
+  fi
+fi
+
 # --- Start the app ---
 echo "[setup] Starting Fairtrail on port ${PORT:-3003}..."
 exec node apps/web/server.js


### PR DESCRIPTION
## Summary

Fixes #1 — three bugs reported on fresh Ubuntu LXC install:

- **`fairtrail: command not found`** — installer now auto-patches `~/.bashrc` / `~/.zshrc` / `~/.profile` to add `~/.local/bin` to PATH (was only printing a warning)
- **`spawn codex ENOENT`** — Docker entrypoint now installs CLI providers (`codex`, `claude`) inside the container when enabled, persisted via `cli-cache` volume
- **`xdg-open` error spam** — all `xdg-open` calls guarded behind `DISPLAY`/`WAYLAND_DISPLAY` check for headless systems
- **`| sh` → `| bash`** — the installer uses bash-specific syntax that breaks under dash (Ubuntu default `sh`)

## Test plan

- [x] `npm run ci` passes (lint + typecheck + build)
- [x] 18 new tests pass: `ai-registry.test.ts` (ENOENT handling, env passthrough, provider detection) + `install-scripts.test.ts` (static analysis of shell scripts)
- [ ] Test on Ubuntu LXC: `curl -fsSL https://fairtrail.org/install.sh | bash`
- [ ] Verify `fairtrail` command works in a new terminal
- [ ] Verify Codex provider works in WebUI after container restart