### PR TITLE
test: add LLMock server, fix 16 broken tests

### DIFF
--- a/apps/web/src/lib/scraper/ai-registry.test.ts
+++ b/apps/web/src/lib/scraper/ai-registry.test.ts
@@ -34,12 +34,22 @@ describe('ai-registry', () => {
   });
 
   describe('detectAvailableProviders', () => {
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      // Save and clear LLM env vars (setup.ts sets dummy keys globally)
+      for (const key of ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_AI_API_KEY', 'CLAUDE_CODE_ENABLED', 'CODEX_ENABLED']) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
     afterEach(() => {
-      delete process.env.ANTHROPIC_API_KEY;
-      delete process.env.OPENAI_API_KEY;
-      delete process.env.GOOGLE_AI_API_KEY;
-      delete process.env.CLAUDE_CODE_ENABLED;
-      delete process.env.CODEX_ENABLED;
+      // Restore original env
+      for (const [key, val] of Object.entries(savedEnv)) {
+        if (val === undefined) delete process.env[key];
+        else process.env[key] = val;
+      }
     });
 
     it('detects API-key providers when env vars are set', async () => {

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/lib/prisma', () => ({
   },
 }));
 
-vi.mock('@/lib/scraper/ai-registry', () => ({
+vi.mock('./ai-registry', () => ({
   EXTRACTION_PROVIDERS: {
     anthropic: {
       displayName: 'Anthropic',

--- a/apps/web/src/lib/scraper/parse-query.test.ts
+++ b/apps/web/src/lib/scraper/parse-query.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/lib/prisma', () => ({
   },
 }));
 
-vi.mock('@/lib/scraper/ai-registry', () => ({
+vi.mock('./ai-registry', () => ({
   EXTRACTION_PROVIDERS: {
     anthropic: {
       displayName: 'Anthropic',

--- a/apps/web/src/test/llmock-setup.ts
+++ b/apps/web/src/test/llmock-setup.ts
@@ -1,0 +1,28 @@
+/**
+ * Global vitest setup — starts an LLMock server that catches any real SDK
+ * calls that escape vi.mock(). This prevents 401 errors from leaked API
+ * requests during tests.
+ */
+import { LLMock } from '@copilotkit/llmock';
+
+const LLMOCK_PORT = 19876;
+
+let mock: LLMock | null = null;
+
+export async function setup() {
+  mock = new LLMock({ port: LLMOCK_PORT });
+
+  // Default fallback: return a valid but empty response for any unmatched request
+  mock.onMessage(/./, {
+    content: '[]',
+  });
+
+  await mock.start();
+}
+
+export async function teardown() {
+  if (mock) {
+    await mock.stop();
+    mock = null;
+  }
+}

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -4,4 +4,14 @@ process.env.ADMIN_PASSWORD = 'test-admin-pw';
 process.env.CRON_SECRET = 'test-cron-secret';
 // NODE_ENV is read-only in @types/node, but we need it for test setup
 (process.env as Record<string, string>).NODE_ENV = 'test';
-// No DATABASE_URL, REDIS_URL, or LLM keys — forces mocks to be required
+
+// LLMock server runs on this port (started in llmock-setup.ts globalSetup).
+// Point all SDK clients at it so leaked requests don't hit real APIs.
+const LLMOCK_URL = 'http://127.0.0.1:19876';
+process.env.ANTHROPIC_BASE_URL = `${LLMOCK_URL}/v1`;
+process.env.OPENAI_BASE_URL = `${LLMOCK_URL}/v1`;
+
+// Dummy API keys — SDK constructors need these to not throw.
+process.env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || 'test-mock-key';
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || 'test-mock-key';
+process.env.GOOGLE_AI_API_KEY = process.env.GOOGLE_AI_API_KEY || 'test-mock-key';

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    globalSetup: ['src/test/llmock-setup.ts'],
     setupFiles: ['src/test/setup.ts'],
     coverage: {
       provider: 'v8',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "apps/web"
       ],
+      "devDependencies": {
+        "@copilotkit/llmock": "^1.3.1"
+      },
       "engines": {
         "node": ">=22"
       }
@@ -150,6 +153,16 @@
       },
       "bin": {
         "findup": "bin/findup.js"
+      }
+    },
+    "node_modules/@copilotkit/llmock": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/llmock/-/llmock-1.3.1.tgz",
+      "integrity": "sha512-9PL5AzGAqxAK0iJk0vBSfJF5azgrXvEC9yVCwysdahKXEeJds9VuZ4NSy+qfZgrgKTCXYXa8ap8S5LQHdor+WA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "llmock": "dist/cli.js"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "engines": {
     "node": ">=22"
   },
-  "version": "0.2.0"
+  "version": "0.2.0",
+  "devDependencies": {
+    "@copilotkit/llmock": "^1.3.1"
+  }
 }


### PR DESCRIPTION
## Summary

- Adds [`@copilotkit/llmock`](https://github.com/CopilotKit/llmock) as a mock LLM HTTP server for tests
- Fixes 16 tests that were hitting the real Anthropic API and failing with 401 errors
- Root cause: `vi.mock('@/lib/scraper/ai-registry')` didn't match the relative `./ai-registry` import used in source files

**Before:** 53 pass / 16 fail
**After:** 69 pass / 0 fail

## How it works

1. **LLMock global setup** (`llmock-setup.ts`) starts a mock HTTP server on port 19876
2. **Test setup** (`setup.ts`) points `ANTHROPIC_BASE_URL` at the mock + sets dummy API keys
3. **Unit tests** use `vi.mock('./ai-registry')` (fixed path) for fast mocking
4. **LLMock** acts as a safety net — any SDK call that escapes `vi.mock` hits the mock server instead of the real API

## Test plan

- [x] `npm run ci` passes (lint + typecheck + 69 tests + build)
- [x] All 16 previously-failing tests now pass
- [x] No tests hit real APIs