### PR TITLE
feat: detect Podman as alternative container runtime

### DIFF
--- a/apps/web/public/fairtrail-cli
+++ b/apps/web/public/fairtrail-cli
@@ -33,12 +33,31 @@ fi
 
 cd "$FAIRTRAIL_DIR"
 
+# Detect container runtime (prefer docker, fall back to podman)
+if command -v docker &>/dev/null; then
+  CONTAINER_CMD=docker
+elif command -v podman &>/dev/null; then
+  CONTAINER_CMD=podman
+else
+  printf "${RED}${BOLD}✗${RESET} Docker or Podman is required.\n"
+  exit 1
+fi
+
 # Resolve override file if it exists
 COMPOSE_FILES="-f docker-compose.yml"
 [ -f "docker-compose.override.yml" ] && COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.override.yml"
 
-# Detect docker compose command (v2 plugin vs v1 standalone)
-if docker compose version &>/dev/null 2>&1; then
+# Detect compose command based on detected container runtime
+if [ "$CONTAINER_CMD" = "podman" ]; then
+  if podman compose version &>/dev/null 2>&1; then
+    _DC="podman compose"
+  elif command -v podman-compose &>/dev/null; then
+    _DC="podman-compose"
+  else
+    printf "${RED}${BOLD}✗${RESET} podman compose is required. Install: https://github.com/containers/podman-compose\n"
+    exit 1
+  fi
+elif docker compose version &>/dev/null 2>&1; then
   _DC="docker compose"
 elif command -v docker-compose &>/dev/null; then
   _DC="docker-compose"
@@ -85,7 +104,7 @@ show_tracking_info() {
 }
 
 cmd_start_foreground() {
-  if ! docker info &>/dev/null 2>&1; then
+  if [ "$CONTAINER_CMD" = "docker" ] && ! docker info &>/dev/null 2>&1; then
     printf "${RED}${BOLD}✗${RESET} Docker is not running. Start Docker Desktop and try again.\n"
     exit 1
   fi
@@ -128,7 +147,7 @@ cmd_start_foreground() {
 }
 
 cmd_start_background() {
-  if ! docker info &>/dev/null 2>&1; then
+  if [ "$CONTAINER_CMD" = "docker" ] && ! docker info &>/dev/null 2>&1; then
     printf "${RED}${BOLD}✗${RESET} Docker is not running. Start Docker Desktop and try again.\n"
     exit 1
   fi

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -96,10 +96,14 @@ install_docker_linux() {
   exit 0
 }
 
-if ! command -v docker &>/dev/null; then
+if command -v docker &>/dev/null; then
+  CONTAINER_CMD=docker
+elif command -v podman &>/dev/null; then
+  CONTAINER_CMD=podman
+else
   case "$OS" in
     macos)
-      fail "Docker Desktop is required.\n\n  Install it from: ${BOLD}https://docs.docker.com/desktop/setup/install/mac-install/${RESET}\n\n  Then re-run: ${BOLD}curl -fsSL https://fairtrail.org/install.sh | bash${RESET}"
+      fail "Docker Desktop or Podman is required.\n\n  Docker: ${BOLD}https://docs.docker.com/desktop/setup/install/mac-install/${RESET}\n  Podman: ${BOLD}https://podman.io/docs/installation${RESET}\n\n  Then re-run: ${BOLD}curl -fsSL https://fairtrail.org/install.sh | bash${RESET}"
       ;;
     linux|wsl)
       warn "Docker is not installed."
@@ -108,42 +112,53 @@ if ! command -v docker &>/dev/null; then
       if [[ ! "$confirm" =~ ^[Nn]$ ]]; then
         install_docker_linux
       else
-        fail "Docker is required. Install from https://docs.docker.com/engine/install/"
+        fail "Docker or Podman is required.\n  Docker: https://docs.docker.com/engine/install/\n  Podman: https://podman.io/docs/installation"
       fi
       ;;
     *)
-      fail "Docker is required. Install from https://docs.docker.com/get-docker/"
+      fail "Docker or Podman is required.\n  Docker: https://docs.docker.com/get-docker/\n  Podman: https://podman.io/docs/installation"
       ;;
   esac
 fi
 
-if ! docker info &>/dev/null 2>&1; then
-  case "$OS" in
-    macos)
-      fail "Docker Desktop is not running.\n\n  Open Docker Desktop from Applications, wait for it to start, then re-run:\n  ${BOLD}curl -fsSL https://fairtrail.org/install.sh | bash${RESET}"
-      ;;
-    linux|wsl)
-      warn "Docker daemon is not running."
-      printf "  ${DIM}Trying to start it...${RESET}\n"
-      if command -v sudo &>/dev/null; then
-        sudo systemctl start docker 2>/dev/null || sudo service docker start 2>/dev/null || true
-        sleep 2
-      fi
-      if ! docker info &>/dev/null 2>&1; then
-        fail "Could not start Docker.\n\n  Start it manually: ${BOLD}sudo systemctl start docker${RESET}\n  Then re-run this installer."
-      fi
-      ok "Docker daemon started"
-      ;;
-    *)
-      fail "Docker is not running. Start Docker and try again."
-      ;;
-  esac
+if [ "$CONTAINER_CMD" = "docker" ]; then
+  if ! docker info &>/dev/null 2>&1; then
+    case "$OS" in
+      macos)
+        fail "Docker Desktop is not running.\n\n  Open Docker Desktop from Applications, wait for it to start, then re-run:\n  ${BOLD}curl -fsSL https://fairtrail.org/install.sh | bash${RESET}"
+        ;;
+      linux|wsl)
+        warn "Docker daemon is not running."
+        printf "  ${DIM}Trying to start it...${RESET}\n"
+        if command -v sudo &>/dev/null; then
+          sudo systemctl start docker 2>/dev/null || sudo service docker start 2>/dev/null || true
+          sleep 2
+        fi
+        if ! docker info &>/dev/null 2>&1; then
+          fail "Could not start Docker.\n\n  Start it manually: ${BOLD}sudo systemctl start docker${RESET}\n  Then re-run this installer."
+        fi
+        ok "Docker daemon started"
+        ;;
+      *)
+        fail "Docker is not running. Start Docker and try again."
+        ;;
+    esac
+  fi
+  ok "Docker is running"
+else
+  ok "Podman is available"
 fi
 
-ok "Docker is running"
-
-# Detect docker compose command (v2 plugin vs v1 standalone)
-if docker compose version &>/dev/null 2>&1; then
+# Detect compose command based on detected container runtime
+if [ "$CONTAINER_CMD" = "podman" ]; then
+  if podman compose version &>/dev/null 2>&1; then
+    DC="podman compose"
+  elif command -v podman-compose &>/dev/null; then
+    DC="podman-compose"
+  else
+    fail "podman compose is required.\n\n  Install podman-compose: ${BOLD}https://github.com/containers/podman-compose${RESET}"
+  fi
+elif docker compose version &>/dev/null 2>&1; then
   DC="docker compose"
 elif command -v docker-compose &>/dev/null; then
   DC="docker-compose"
@@ -215,6 +230,12 @@ fi
 # ---------------------------------------------------------------------------
 mkdir -p "$FAIRTRAIL_DIR"
 
+EXTRA_HOSTS_BLOCK=""
+if [ "$CONTAINER_CMD" != "podman" ]; then
+  EXTRA_HOSTS_BLOCK='    extra_hosts:
+      - "host.docker.internal:host-gateway"'
+fi
+
 cat > "$FAIRTRAIL_DIR/docker-compose.yml" << COMPOSE
 services:
   db:
@@ -262,8 +283,7 @@ services:
       CHROME_PATH: /usr/bin/chromium-browser
       NODE_ENV: production
       SELF_HOSTED: "true"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+$EXTRA_HOSTS_BLOCK
     volumes:
       - app-data:/app/data
       - cli-cache:/home/node/.npm-global
@@ -366,9 +386,11 @@ if curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then
   OLLAMA_MODEL_COUNT=$(echo "$OLLAMA_MODELS" | grep -c . 2>/dev/null || echo 0)
   ok "Ollama detected — ${OLLAMA_MODEL_COUNT} model(s) installed locally"
 
-  # Docker-compatible host — host.docker.internal works on all platforms
-  # (macOS/WSL via Docker Desktop, Linux via extra_hosts in compose)
-  OLLAMA_HOST_VAL="http://host.docker.internal:11434"
+  if [ "$CONTAINER_CMD" = "podman" ]; then
+    OLLAMA_HOST_VAL="http://host.containers.internal:11434"
+  else
+    OLLAMA_HOST_VAL="http://host.docker.internal:11434"
+  fi
 fi
 
 HAS_CLI_OR_LOCAL=false

--- a/apps/web/src/lib/scraper/install-scripts.test.ts
+++ b/apps/web/src/lib/scraper/install-scripts.test.ts
@@ -83,6 +83,70 @@ describe('install.sh', () => {
   it('includes cli-cache volume for persisting CLI installs', () => {
     expect(INSTALL_SH).toContain('cli-cache:/home/node/.npm-global');
   });
+
+  it('detects Podman as fallback when Docker is absent', () => {
+    expect(INSTALL_SH).toContain('command -v podman');
+    expect(INSTALL_SH).toContain('CONTAINER_CMD=podman');
+  });
+
+  it('uses $CONTAINER_CMD to select compose command', () => {
+    expect(INSTALL_SH).toContain('podman compose');
+    expect(INSTALL_SH).toContain('podman-compose');
+  });
+
+  it('uses host.containers.internal for Podman Ollama host', () => {
+    expect(INSTALL_SH).toContain('host.containers.internal:11434');
+  });
+
+  it('conditionally omits extra_hosts for Podman in generated compose', () => {
+    expect(INSTALL_SH).toContain('EXTRA_HOSTS_BLOCK');
+    expect(INSTALL_SH).toContain('CONTAINER_CMD" != "podman"');
+  });
+
+  it('detection logic: picks docker when docker exists, podman as fallback', () => {
+    // Extract the detection block and verify the branching structure
+    const lines = INSTALL_SH.split('\n');
+    const dockerCheckIdx = lines.findIndex((l) => l.includes('command -v docker'));
+    const podmanCheckIdx = lines.findIndex((l) => l.includes('command -v podman'));
+    expect(dockerCheckIdx).toBeGreaterThan(-1);
+    expect(podmanCheckIdx).toBeGreaterThan(-1);
+    // Docker must be checked BEFORE podman (if/elif structure)
+    expect(dockerCheckIdx).toBeLessThan(podmanCheckIdx);
+    // The docker check must set CONTAINER_CMD=docker
+    const dockerSetIdx = lines.findIndex((l) => l.includes('CONTAINER_CMD=docker'));
+    expect(dockerSetIdx).toBeGreaterThan(dockerCheckIdx);
+    expect(dockerSetIdx).toBeLessThan(podmanCheckIdx);
+  });
+
+  it('EXTRA_HOSTS_BLOCK is set before the heredoc and used inside it', () => {
+    const lines = INSTALL_SH.split('\n');
+    const blockSetIdx = lines.findIndex((l) => l.includes('EXTRA_HOSTS_BLOCK='));
+    const heredocIdx = lines.findIndex((l) => l.includes('<< COMPOSE'));
+    const blockUseIdx = lines.findIndex((l) => l.includes('$EXTRA_HOSTS_BLOCK'));
+    expect(blockSetIdx).toBeGreaterThan(-1);
+    expect(heredocIdx).toBeGreaterThan(-1);
+    expect(blockUseIdx).toBeGreaterThan(-1);
+    // Set before heredoc, used inside heredoc
+    expect(blockSetIdx).toBeLessThan(heredocIdx);
+    expect(blockUseIdx).toBeGreaterThan(heredocIdx);
+  });
+
+  it('Podman path sets OLLAMA_HOST to host.containers.internal, Docker to host.docker.internal', () => {
+    const lines = INSTALL_SH.split('\n');
+    const podmanOllamaIdx = lines.findIndex((l) =>
+      l.includes('host.containers.internal:11434')
+    );
+    const dockerOllamaIdx = lines.findIndex((l) =>
+      l.includes('host.docker.internal:11434')
+    );
+    expect(podmanOllamaIdx).toBeGreaterThan(-1);
+    expect(dockerOllamaIdx).toBeGreaterThan(-1);
+    // Both must be inside a CONTAINER_CMD conditional
+    const beforePodman = lines.slice(Math.max(0, podmanOllamaIdx - 3), podmanOllamaIdx).join('\n');
+    expect(beforePodman).toContain('podman');
+    const beforeDocker = lines.slice(Math.max(0, dockerOllamaIdx - 3), dockerOllamaIdx).join('\n');
+    expect(beforeDocker).toContain('else');
+  });
 });
 
 describe('fairtrail-cli', () => {
@@ -114,6 +178,32 @@ describe('fairtrail-cli', () => {
     for (const line of installLines) {
       expect(line, `Line references | sh: ${line.trim()}`).not.toMatch(
         /\| sh\b/
+      );
+    }
+  });
+
+  it('detects Podman as fallback when Docker is absent', () => {
+    expect(CLI_SH).toContain('command -v podman');
+    expect(CLI_SH).toContain('CONTAINER_CMD=podman');
+  });
+
+  it('uses $CONTAINER_CMD to select compose command', () => {
+    expect(CLI_SH).toContain('podman compose');
+    expect(CLI_SH).toContain('podman-compose');
+  });
+
+  it('skips docker info check when using Podman', () => {
+    // Both start functions must gate docker info behind CONTAINER_CMD=docker check
+    const dockerInfoChecks = CLI_SH.split('\n').filter(
+      (l) => l.includes('docker info') && !l.startsWith('#')
+    );
+    for (const line of dockerInfoChecks) {
+      const idx = CLI_SH.split('\n').indexOf(line);
+      const context = CLI_SH.split('\n')
+        .slice(Math.max(0, idx - 1), idx + 1)
+        .join('\n');
+      expect(context, `docker info not gated: ${line.trim()}`).toContain(
+        'CONTAINER_CMD'
       );
     }
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       NODE_ENV: production
       SELF_HOSTED: "true"
     extra_hosts:
+      # Podman users: host.containers.internal resolves automatically — no extra_hosts needed
       - "host.docker.internal:host-gateway"
     volumes:
       - app-data:/app/data


### PR DESCRIPTION
## Summary

Related to #13. The installer and CLI only checked for Docker, leaving Podman users unable to complete setup. Podman is now detected as a fallback container runtime.

## Changes

- **install.sh**: Detect `podman` when `docker` is absent, set `CONTAINER_CMD`. Detect `podman compose` / `podman-compose` for orchestration. Update error messages to mention Podman as an alternative.
- **install.sh**: Conditionally omit `extra_hosts: host.docker.internal:host-gateway` for Podman (Podman resolves `host.containers.internal` natively).
- **install.sh**: Set `OLLAMA_HOST=http://host.containers.internal:11434` for Podman users (vs `host.docker.internal` for Docker).
- **fairtrail-cli**: Same runtime detection with Podman fallback. Gate `docker info` daemon checks behind `CONTAINER_CMD=docker` (Podman is daemonless).
- **docker-compose.yml**: Add comment about `host.containers.internal` for Podman users.

## Tests added

- String-presence: Podman detection, compose selection in both install.sh and fairtrail-cli
- **Behavioral**: Detection ordering (docker checked before podman), `EXTRA_HOSTS_BLOCK` set before heredoc and used inside it, OLLAMA_HOST conditional branching verified structurally
- Docker info gating: All `docker info` calls verified to be behind `CONTAINER_CMD` guard

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] 191 vitest tests pass, 0 failures
- [x] Codex review: YAML valid for both Docker and Podman paths, OLLAMA_HOST correctly written to .env