### PR TITLE
fix: always show delete button for tracked queries

### DIFF
--- a/apps/web/src/app/api/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/route.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockQueryFindUnique = vi.fn();
+const mockQueryDelete = vi.fn();
+const mockQueryFindMany = vi.fn();
+const mockQueryUpdateMany = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    query: {
+      findUnique: (...args: unknown[]) => mockQueryFindUnique(...args),
+      delete: (...args: unknown[]) => mockQueryDelete(...args),
+      findMany: (...args: unknown[]) => mockQueryFindMany(...args),
+      updateMany: (...args: unknown[]) => mockQueryUpdateMany(...args),
+    },
+  },
+}));
+
+import { DELETE, PATCH } from './route';
+
+function makeDeleteRequest(id: string, body?: Record<string, unknown>): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost/api/queries/${id}`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : '{}',
+    }),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+describe('DELETE /api/queries/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryDelete.mockResolvedValue({});
+    delete process.env.SELF_HOSTED;
+  });
+
+  afterEach(() => {
+    delete process.env.SELF_HOSTED;
+  });
+
+  it('returns 404 when query does not exist', async () => {
+    mockQueryFindUnique.mockResolvedValue(null);
+    const res = await DELETE(...makeDeleteRequest('missing', { deleteToken: 'tok' }));
+    const data = await res.json();
+    expect(res.status).toBe(404);
+    expect(data.error).toContain('not found');
+  });
+
+  it('returns 401 when token is missing (hosted)', async () => {
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token' });
+    const res = await DELETE(...makeDeleteRequest('q1', {}));
+    const data = await res.json();
+    expect(res.status).toBe(401);
+    expect(data.error).toContain('token');
+  });
+
+  it('returns 403 when token is wrong (hosted)', async () => {
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token' });
+    const res = await DELETE(...makeDeleteRequest('q1', { deleteToken: 'wrong' }));
+    const data = await res.json();
+    expect(res.status).toBe(403);
+    expect(data.error).toContain('Invalid');
+  });
+
+  it('deletes with valid token (hosted)', async () => {
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token' });
+    const res = await DELETE(...makeDeleteRequest('q1', { deleteToken: 'real-token' }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.deleted).toBe(true);
+    expect(mockQueryDelete).toHaveBeenCalledWith({ where: { id: 'q1' } });
+  });
+
+  it('deletes without token when SELF_HOSTED=true', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token' });
+    const res = await DELETE(...makeDeleteRequest('q1', {}));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.deleted).toBe(true);
+    expect(mockQueryDelete).toHaveBeenCalledWith({ where: { id: 'q1' } });
+  });
+
+  it('deletes with null token when SELF_HOSTED=true', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: null });
+    const res = await DELETE(...makeDeleteRequest('q1'));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.deleted).toBe(true);
+  });
+
+  it('deletes with valid token when SELF_HOSTED=true', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token' });
+    const res = await DELETE(...makeDeleteRequest('q1', { deleteToken: 'real-token' }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.deleted).toBe(true);
+    expect(mockQueryDelete).toHaveBeenCalledWith({ where: { id: 'q1' } });
+  });
+
+  it('still requires token when SELF_HOSTED is not set', async () => {
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token' });
+    const res = await DELETE(...makeDeleteRequest('q1', {}));
+    expect(res.status).toBe(401);
+  });
+});
+
+function makePatchRequest(id: string, body: Record<string, unknown>): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost/api/queries/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+describe('PATCH /api/queries/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryFindMany.mockResolvedValue([]);
+    mockQueryUpdateMany.mockResolvedValue({ count: 1 });
+    delete process.env.SELF_HOSTED;
+  });
+
+  afterEach(() => {
+    delete process.env.SELF_HOSTED;
+  });
+
+  it('returns 401 when token is missing (hosted)', async () => {
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: null });
+    const res = await PATCH(...makePatchRequest('q1', { scrapeInterval: 6 }));
+    expect(res.status).toBe(401);
+  });
+
+  it('updates interval with valid token (hosted)', async () => {
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: null });
+    const res = await PATCH(...makePatchRequest('q1', { deleteToken: 'real-token', scrapeInterval: 6 }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.scrapeInterval).toBe(6);
+  });
+
+  it('updates interval without token when SELF_HOSTED=true', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: null });
+    const res = await PATCH(...makePatchRequest('q1', { scrapeInterval: 3 }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.scrapeInterval).toBe(3);
+  });
+
+  it('rejects invalid interval even when SELF_HOSTED=true', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null });
+    const res = await PATCH(...makePatchRequest('q1', { scrapeInterval: 99 }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/queries/[id]/route.ts
+++ b/apps/web/src/app/api/queries/[id]/route.ts
@@ -9,12 +9,10 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
+  const isSelfHosted = process.env.SELF_HOSTED === 'true';
 
   const body = await request.json().catch(() => null);
   const token = body?.deleteToken;
-  if (!token || typeof token !== 'string') {
-    return apiError('Missing delete token', 401);
-  }
 
   const query = await prisma.query.findUnique({
     where: { id },
@@ -22,8 +20,14 @@ export async function PATCH(
   });
 
   if (!query) return apiError('Tracker not found', 404);
-  if (!query.deleteToken || query.deleteToken !== token) {
-    return apiError('Invalid delete token', 403);
+
+  if (!isSelfHosted) {
+    if (!token || typeof token !== 'string') {
+      return apiError('Missing delete token', 401);
+    }
+    if (!query.deleteToken || query.deleteToken !== token) {
+      return apiError('Invalid delete token', 403);
+    }
   }
 
   const interval = Number(body.scrapeInterval);
@@ -54,12 +58,10 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
+  const isSelfHosted = process.env.SELF_HOSTED === 'true';
 
   const body = await request.json().catch(() => null);
   const token = body?.deleteToken;
-  if (!token || typeof token !== 'string') {
-    return apiError('Missing delete token', 401);
-  }
 
   const query = await prisma.query.findUnique({
     where: { id },
@@ -70,8 +72,14 @@ export async function DELETE(
     return apiError('Tracker not found', 404);
   }
 
-  if (!query.deleteToken || query.deleteToken !== token) {
-    return apiError('Invalid delete token', 403);
+  // Self-hosted instances can delete without a token
+  if (!isSelfHosted) {
+    if (!token || typeof token !== 'string') {
+      return apiError('Missing delete token', 401);
+    }
+    if (!query.deleteToken || query.deleteToken !== token) {
+      return apiError('Invalid delete token', 403);
+    }
   }
 
   await prisma.query.delete({ where: { id } });

--- a/apps/web/src/components/DeleteTracker.tsx
+++ b/apps/web/src/components/DeleteTracker.tsx
@@ -17,8 +17,6 @@ export function DeleteTracker({ queryId }: Props) {
 
   const token = typeof window !== 'undefined' ? getDeleteToken(queryId) : null;
 
-  if (!token) return null;
-
   const handleDelete = async () => {
     setDeleting(true);
     setError(null);
@@ -66,7 +64,7 @@ export function DeleteTracker({ queryId }: Props) {
             onClick={handleDelete}
             disabled={deleting}
           >
-            {deleting ? 'Deleting…' : 'Yes, delete'}
+            {deleting ? 'Deleting...' : 'Yes, delete'}
           </button>
         </div>
       </div>

--- a/apps/web/src/components/SavedTrackers.module.css
+++ b/apps/web/src/components/SavedTrackers.module.css
@@ -53,7 +53,7 @@
   border: none;
   cursor: pointer;
   border-radius: 50%;
-  opacity: 0;
+  opacity: 0.5;
   transition: opacity 0.15s, color 0.15s;
   z-index: 1;
 }

--- a/apps/web/src/components/SavedTrackers.tsx
+++ b/apps/web/src/components/SavedTrackers.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { getSavedTrackers, removeSavedTracker } from '@/lib/tracker-storage';
+import { getSavedTrackers, getDeleteToken, removeSavedTracker } from '@/lib/tracker-storage';
 import styles from './SavedTrackers.module.css';
 
 interface ActiveQuery {
@@ -134,7 +134,22 @@ export function SavedTrackers() {
     }
   }, []);
 
-  const handleRemove = (id: string) => {
+  const handleRemove = async (id: string) => {
+    const token = getDeleteToken(id);
+    try {
+      const res = await fetch(`/api/queries/${id}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deleteToken: token }),
+      });
+      const data = await res.json();
+      if (!data.ok) {
+        // API rejected -- still remove from local view
+        console.warn(`Delete API returned: ${data.error}`);
+      }
+    } catch {
+      // Network error -- still remove from local view
+    }
     removeSavedTracker(id);
     setTrackers((prev) => prev.filter((t) => t.id !== id));
   };
@@ -173,16 +188,14 @@ export function SavedTrackers() {
       <div className={styles.list}>
         {trackers.map((t) => (
           <div key={t.id} className={styles.card}>
-            {t.hasDeleteToken && (
-              <button
-                className={styles.remove}
-                onClick={() => handleRemove(t.id)}
-                title="Remove"
-                aria-label="Remove tracker"
-              >
-                &times;
-              </button>
-            )}
+            <button
+              className={styles.remove}
+              onClick={() => handleRemove(t.id)}
+              title="Remove"
+              aria-label="Remove tracker"
+            >
+              &times;
+            </button>
 
             {t.status === 'deleted' ? (
               <div className={styles.content}>


### PR DESCRIPTION
## Summary

Related to #8. Addresses the comment on #8 where a user reported the delete button (red X) disappearing. Also addresses the deeper issue: self-hosted users who lost their localStorage token had no way to delete trackers.

## Changes

- **CSS**: `.remove` opacity `0` -> `0.5` (visible by default, `1` on hover). No longer invisible on touch devices.
- **SavedTrackers.tsx**: Remove `hasDeleteToken` gate so delete button always renders. `handleRemove` now calls the DELETE API before removing from localStorage.
- **DeleteTracker.tsx**: Always show the delete flow regardless of token presence (works on self-hosted without token).
- **DELETE /api/queries/[id]**: Allow token-less deletion when `SELF_HOSTED=true`.
- **PATCH /api/queries/[id]**: Same self-hosted bypass for scrape interval changes.

## Tests added

- DELETE endpoint: 8 tests covering hosted/self-hosted with/without token, 404, 401, 403
- PATCH endpoint: 4 tests covering hosted/self-hosted with/without token, invalid interval

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] 193 vitest tests pass, 0 failures
- [x] Codex review: all 4 auth combos verified