### PR TITLE
fix: enforce LF line endings for shell scripts via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for shell scripts (prevents CRLF on Windows clones)
+*.sh text eol=lf


### PR DESCRIPTION
## Summary

- Adds `.gitattributes` with `*.sh text eol=lf` to enforce LF line endings for all shell scripts at checkout time
- Prevents CRLF from breaking `docker-entrypoint.sh` (and other scripts) on Windows where `core.autocrlf=true` is the default
- Root-cause fix for #22, supersedes #23

**Why this was never caught:** all development and CI runs on macOS/Linux where LF is native. The bug only triggers on Windows, silently converting LF to CRLF on checkout.

## Test plan

- [x] `git check-attr eol docker-entrypoint.sh` returns `lf`
- [x] `git check-attr eol scripts/docker-smoke-test.sh` returns `lf`
- [x] `npm run ci` passes
- [x] `git add --renormalize .` produces no changes (all files already LF)