### PR TITLE
fix: add ipc: host to prevent Chromium crashes in Docker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,8 @@ services:
   web:
     image: ghcr.io/affromero/fairtrail:latest
     restart: unless-stopped
+    init: true
+    ipc: host
     depends_on:
       - db
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
   web:
     build: .
     restart: unless-stopped
+    init: true
+    ipc: host
     depends_on:
       db:
         condition: service_healthy

--- a/scripts/docker-compose.integration.yml
+++ b/scripts/docker-compose.integration.yml
@@ -21,6 +21,8 @@ services:
 
   web:
     image: fairtrail-test:latest
+    init: true
+    ipc: host
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Adds `ipc: host` and `init: true` to the `web` service in all Docker Compose files
- `ipc: host` is the [Playwright-recommended Docker configuration](https://playwright.dev/docs/docker) for running Chromium
- Prevents page crashes on platforms with restrictive `/dev/shm` defaults (e.g. Unraid)
- `init: true` ensures proper zombie process reaping for Chromium child processes

**Why this was not needed before:** the production server (Hetzner, standard Linux) has enough RAM and default IPC settings for Chromium to work. The crash only surfaces on Unraid and similar platforms with stricter Docker IPC/seccomp defaults. The existing `--disable-dev-shm-usage` flag was insufficient.

Ref #19

## Files changed

| File | Change |
|------|--------|
| `docker-compose.yml` | Added `init: true` + `ipc: host` to web service |
| `docker-compose.prod.yml` | Same |
| `scripts/docker-compose.integration.yml` | Same |

## Test plan

- [x] `npm run ci` passes
- [ ] @luciodaou to verify on Unraid: rebuild and check if scraping works without page crashes