### PR TITLE
feat: manual flight entry form (#37)

### DIFF
--- a/apps/web/src/components/ManualEntryForm.module.css
+++ b/apps/web/src/components/ManualEntryForm.module.css
@@ -116,6 +116,42 @@
   font-weight: 600;
 }
 
+.advancedToggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.75rem 0;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.advancedToggle:hover {
+  color: var(--text-secondary);
+}
+
+.chevron {
+  color: var(--muted);
+  transition: transform 0.3s ease;
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+.advancedPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-bottom: 0.25rem;
+}
+
 .actions {
   display: flex;
   gap: 0.75rem;

--- a/apps/web/src/components/ManualEntryForm.module.css
+++ b/apps/web/src/components/ManualEntryForm.module.css
@@ -1,0 +1,166 @@
+.root {
+  width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  animation: slideUp 0.3s ease-out;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.sectionLabel {
+  font-family: var(--font-display);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.fieldRow {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.fieldGrow {
+  flex: 2;
+}
+
+.label {
+  font-family: var(--font-display);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.input {
+  width: 100%;
+  padding: 0.625rem 0.875rem;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  color: var(--text);
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.input::placeholder {
+  color: var(--muted);
+}
+
+.input:focus {
+  border-color: var(--accent);
+}
+
+.inputError {
+  border-color: var(--price-up);
+}
+
+.errorText {
+  font-size: 0.75rem;
+  color: var(--price-up);
+  font-family: var(--font-mono);
+}
+
+.tripToggle {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  overflow: hidden;
+  width: fit-content;
+}
+
+.tripOption {
+  padding: 0.375rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.tripOption:hover:not(.tripOptionActive) {
+  color: var(--text-secondary);
+}
+
+.tripOptionActive {
+  background: var(--accent);
+  color: var(--bg);
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.submitButton {
+  flex: 1;
+  padding: 0.75rem 1.5rem;
+  font-family: var(--font-display);
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--bg);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.submitButton:hover {
+  opacity: 0.85;
+}
+
+.cancelButton {
+  padding: 0.75rem 1.25rem;
+  font-family: var(--font-display);
+  font-size: 0.9375rem;
+  font-weight: 400;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.cancelButton:hover {
+  border-color: var(--text-secondary);
+  color: var(--text);
+}
+
+@media (max-width: 480px) {
+  .fieldRow {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}

--- a/apps/web/src/components/ManualEntryForm.module.css
+++ b/apps/web/src/components/ManualEntryForm.module.css
@@ -68,12 +68,25 @@
   transition: border-color 0.2s;
 }
 
+select.input {
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%236b7280' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  padding-right: 2rem;
+}
+
 .input::placeholder {
   color: var(--muted);
 }
 
 .input:focus {
   border-color: var(--accent);
+}
+
+.input:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
 .inputError {

--- a/apps/web/src/components/ManualEntryForm.tsx
+++ b/apps/web/src/components/ManualEntryForm.tsx
@@ -43,6 +43,16 @@ export function ManualEntryForm({ onSubmit, onCancel, adminCurrency }: ManualEnt
   const [tripType, setTripType] = useState<'one_way' | 'round_trip'>('round_trip');
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
+  // Advanced fields
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [flexibility, setFlexibility] = useState(0);
+  const [maxPrice, setMaxPrice] = useState('');
+  const [maxStops, setMaxStops] = useState('');
+  const [airlines, setAirlines] = useState('');
+  const [timePreference, setTimePreference] = useState<'any' | 'morning' | 'afternoon' | 'evening' | 'redeye'>('any');
+  const [cabinClass, setCabinClass] = useState<'economy' | 'premium_economy' | 'business' | 'first'>('economy');
+  const [currency, setCurrency] = useState('');
+
   const clearError = (field: string) => {
     setFieldErrors((prev) => {
       const next = { ...prev };
@@ -99,17 +109,27 @@ export function ManualEntryForm({ onSubmit, onCancel, adminCurrency }: ManualEnt
       destinations: [{ code: dest, name: dName }],
       dateFrom,
       dateTo: tripType === 'round_trip' ? dateTo : dateFrom,
-      flexibility: 0,
-      maxPrice: null,
-      maxStops: null,
-      preferredAirlines: [],
-      timePreference: 'any',
-      cabinClass: 'economy',
+      flexibility,
+      maxPrice: maxPrice ? parseInt(maxPrice, 10) : null,
+      maxStops: maxStops === '' ? null : parseInt(maxStops, 10),
+      preferredAirlines: airlines ? airlines.split(',').map((s) => s.trim()).filter(Boolean) : [],
+      timePreference,
+      cabinClass,
       tripType,
-      currency: adminCurrency || detectLocaleCurrency(),
+      currency: currency || adminCurrency || detectLocaleCurrency(),
     };
 
-    const rawInput = synthesizeRawInput(code, oName, dest, dName, dateFrom, dateTo, tripType, 'economy');
+    // Adjust date window for flexibility
+    if (flexibility > 0) {
+      const from = new Date(dateFrom + 'T00:00:00');
+      from.setDate(from.getDate() - flexibility);
+      query.dateFrom = from.toISOString().split('T')[0]!;
+      const to = new Date((tripType === 'round_trip' ? dateTo : dateFrom) + 'T00:00:00');
+      to.setDate(to.getDate() + flexibility);
+      query.dateTo = to.toISOString().split('T')[0]!;
+    }
+
+    const rawInput = synthesizeRawInput(code, oName, dest, dName, dateFrom, dateTo, tripType, cabinClass);
     onSubmit(query, rawInput);
   };
 
@@ -233,6 +253,127 @@ export function ManualEntryForm({ onSubmit, onCancel, adminCurrency }: ManualEnt
           </div>
         )}
       </div>
+
+      <button
+        type="button"
+        className={styles.advancedToggle}
+        onClick={() => setShowAdvanced(!showAdvanced)}
+        aria-expanded={showAdvanced}
+      >
+        <span>Advanced options</span>
+        <svg
+          className={`${styles.chevron} ${showAdvanced ? styles.chevronOpen : ''}`}
+          width="16" height="16" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" strokeWidth="2"
+          aria-hidden="true"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+
+      {showAdvanced && (
+        <div className={styles.advancedPanel}>
+          <div className={styles.fieldRow}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="me-flexibility">Flexibility (days)</label>
+              <input
+                id="me-flexibility"
+                className={styles.input}
+                type="number"
+                min={0}
+                max={7}
+                value={flexibility}
+                onChange={(e) => setFlexibility(Math.max(0, Math.min(7, parseInt(e.target.value, 10) || 0)))}
+              />
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="me-max-price">Max price</label>
+              <input
+                id="me-max-price"
+                className={styles.input}
+                type="number"
+                min={0}
+                placeholder="No limit"
+                value={maxPrice}
+                onChange={(e) => setMaxPrice(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className={styles.fieldRow}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="me-max-stops">Max stops</label>
+              <select
+                id="me-max-stops"
+                className={styles.input}
+                value={maxStops}
+                onChange={(e) => setMaxStops(e.target.value)}
+              >
+                <option value="">Any</option>
+                <option value="0">Nonstop only</option>
+                <option value="1">Max 1 stop</option>
+                <option value="2">Max 2 stops</option>
+              </select>
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="me-cabin">Cabin class</label>
+              <select
+                id="me-cabin"
+                className={styles.input}
+                value={cabinClass}
+                onChange={(e) => setCabinClass(e.target.value as typeof cabinClass)}
+              >
+                <option value="economy">Economy</option>
+                <option value="premium_economy">Premium Economy</option>
+                <option value="business">Business</option>
+                <option value="first">First</option>
+              </select>
+            </div>
+          </div>
+
+          <div className={styles.fieldRow}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="me-time">Time preference</label>
+              <select
+                id="me-time"
+                className={styles.input}
+                value={timePreference}
+                onChange={(e) => setTimePreference(e.target.value as typeof timePreference)}
+              >
+                <option value="any">Any</option>
+                <option value="morning">Morning</option>
+                <option value="afternoon">Afternoon</option>
+                <option value="evening">Evening</option>
+                <option value="redeye">Red-eye</option>
+              </select>
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="me-currency">Currency</label>
+              <input
+                id="me-currency"
+                className={styles.input}
+                type="text"
+                placeholder="Auto-detect"
+                maxLength={3}
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value.toUpperCase())}
+              />
+            </div>
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="me-airlines">Preferred airlines</label>
+            <input
+              id="me-airlines"
+              className={styles.input}
+              type="text"
+              placeholder="e.g. Delta, United"
+              value={airlines}
+              onChange={(e) => setAirlines(e.target.value)}
+            />
+          </div>
+        </div>
+      )}
 
       <div className={styles.actions}>
         <button type="submit" className={styles.submitButton}>

--- a/apps/web/src/components/ManualEntryForm.tsx
+++ b/apps/web/src/components/ManualEntryForm.tsx
@@ -69,17 +69,19 @@ export function ManualEntryForm({ onSubmit, onCancel, adminCurrency }: ManualEnt
     if (!/^[A-Z]{3}$/.test(code)) errors.originCode = 'Enter a 3-letter IATA code';
     if (!originName.trim()) errors.originName = 'Enter airport or city name';
     if (!/^[A-Z]{3}$/.test(dest)) errors.destCode = 'Enter a 3-letter IATA code';
+    else if (code && code === dest) errors.destCode = 'Must differ from origin';
     if (!destName.trim()) errors.destName = 'Enter airport or city name';
+    const today = new Date();
+    const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
     if (!dateFrom) {
       errors.dateFrom = 'Select a departure date';
-    } else {
-      const today = new Date().toISOString().split('T')[0]!;
-      if (dateFrom < today) errors.dateFrom = 'Date cannot be in the past';
+    } else if (dateFrom < todayStr) {
+      errors.dateFrom = 'Date cannot be in the past';
     }
     if (tripType === 'round_trip') {
       if (!dateTo) {
         errors.dateTo = 'Select a return date';
-      } else if (dateFrom && dateTo < dateFrom) {
+      } else if (dateFrom && dateTo <= dateFrom) {
         errors.dateTo = 'Return must be after departure';
       }
     }
@@ -133,7 +135,8 @@ export function ManualEntryForm({ onSubmit, onCancel, adminCurrency }: ManualEnt
     onSubmit(query, rawInput);
   };
 
-  const today = new Date().toISOString().split('T')[0]!;
+  const now = new Date();
+  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
   return (
     <form className={styles.root} onSubmit={handleSubmit} noValidate>

--- a/apps/web/src/components/ManualEntryForm.tsx
+++ b/apps/web/src/components/ManualEntryForm.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useState } from 'react';
+import type { ParsedQuery } from './ConfirmationCard';
+import { detectLocaleCurrency } from '@/lib/currency';
+import styles from './ManualEntryForm.module.css';
+
+interface ManualEntryFormProps {
+  onSubmit: (query: ParsedQuery, rawInput: string) => void;
+  onCancel: () => void;
+  adminCurrency: string | null;
+}
+
+function synthesizeRawInput(
+  originCode: string,
+  originName: string,
+  destCode: string,
+  destName: string,
+  dateFrom: string,
+  dateTo: string,
+  tripType: 'one_way' | 'round_trip',
+  cabinClass: string,
+): string {
+  const parts = [`${originCode} ${originName} to ${destCode} ${destName}`];
+  parts.push(dateFrom);
+  if (tripType === 'round_trip' && dateTo) {
+    parts.push(`to ${dateTo}`);
+  }
+  parts.push(tripType === 'round_trip' ? 'round trip' : 'one way');
+  if (cabinClass !== 'economy') {
+    parts.push(cabinClass.replace('_', ' '));
+  }
+  return parts.join(' ');
+}
+
+export function ManualEntryForm({ onSubmit, onCancel, adminCurrency }: ManualEntryFormProps) {
+  const [originCode, setOriginCode] = useState('');
+  const [originName, setOriginName] = useState('');
+  const [destCode, setDestCode] = useState('');
+  const [destName, setDestName] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [tripType, setTripType] = useState<'one_way' | 'round_trip'>('round_trip');
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const clearError = (field: string) => {
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  };
+
+  const validate = (): Record<string, string> | null => {
+    const errors: Record<string, string> = {};
+    const code = originCode.trim();
+    const dest = destCode.trim();
+
+    if (!/^[A-Z]{3}$/.test(code)) errors.originCode = 'Enter a 3-letter IATA code';
+    if (!originName.trim()) errors.originName = 'Enter airport or city name';
+    if (!/^[A-Z]{3}$/.test(dest)) errors.destCode = 'Enter a 3-letter IATA code';
+    if (!destName.trim()) errors.destName = 'Enter airport or city name';
+    if (!dateFrom) {
+      errors.dateFrom = 'Select a departure date';
+    } else {
+      const today = new Date().toISOString().split('T')[0]!;
+      if (dateFrom < today) errors.dateFrom = 'Date cannot be in the past';
+    }
+    if (tripType === 'round_trip') {
+      if (!dateTo) {
+        errors.dateTo = 'Select a return date';
+      } else if (dateFrom && dateTo < dateFrom) {
+        errors.dateTo = 'Return must be after departure';
+      }
+    }
+
+    return Object.keys(errors).length > 0 ? errors : null;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const errors = validate();
+    if (errors) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    const code = originCode.trim();
+    const dest = destCode.trim();
+    const oName = originName.trim();
+    const dName = destName.trim();
+
+    const query: ParsedQuery = {
+      origin: code,
+      originName: oName,
+      destination: dest,
+      destinationName: dName,
+      origins: [{ code, name: oName }],
+      destinations: [{ code: dest, name: dName }],
+      dateFrom,
+      dateTo: tripType === 'round_trip' ? dateTo : dateFrom,
+      flexibility: 0,
+      maxPrice: null,
+      maxStops: null,
+      preferredAirlines: [],
+      timePreference: 'any',
+      cabinClass: 'economy',
+      tripType,
+      currency: adminCurrency || detectLocaleCurrency(),
+    };
+
+    const rawInput = synthesizeRawInput(code, oName, dest, dName, dateFrom, dateTo, tripType, 'economy');
+    onSubmit(query, rawInput);
+  };
+
+  const today = new Date().toISOString().split('T')[0]!;
+
+  return (
+    <form className={styles.root} onSubmit={handleSubmit} noValidate>
+      <div className={styles.sectionLabel}>Origin</div>
+      <div className={styles.fieldRow}>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="me-origin-code">IATA Code</label>
+          <input
+            id="me-origin-code"
+            className={`${styles.input} ${fieldErrors.originCode ? styles.inputError : ''}`}
+            type="text"
+            placeholder="JFK"
+            maxLength={3}
+            value={originCode}
+            onChange={(e) => { setOriginCode(e.target.value.toUpperCase()); clearError('originCode'); }}
+            autoFocus
+            aria-required
+            aria-invalid={!!fieldErrors.originCode}
+          />
+          {fieldErrors.originCode && <span className={styles.errorText}>{fieldErrors.originCode}</span>}
+        </div>
+        <div className={`${styles.field} ${styles.fieldGrow}`}>
+          <label className={styles.label} htmlFor="me-origin-name">City / Airport</label>
+          <input
+            id="me-origin-name"
+            className={`${styles.input} ${fieldErrors.originName ? styles.inputError : ''}`}
+            type="text"
+            placeholder="New York JFK"
+            value={originName}
+            onChange={(e) => { setOriginName(e.target.value); clearError('originName'); }}
+            aria-required
+            aria-invalid={!!fieldErrors.originName}
+          />
+          {fieldErrors.originName && <span className={styles.errorText}>{fieldErrors.originName}</span>}
+        </div>
+      </div>
+
+      <div className={styles.sectionLabel}>Destination</div>
+      <div className={styles.fieldRow}>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="me-dest-code">IATA Code</label>
+          <input
+            id="me-dest-code"
+            className={`${styles.input} ${fieldErrors.destCode ? styles.inputError : ''}`}
+            type="text"
+            placeholder="CDG"
+            maxLength={3}
+            value={destCode}
+            onChange={(e) => { setDestCode(e.target.value.toUpperCase()); clearError('destCode'); }}
+            aria-required
+            aria-invalid={!!fieldErrors.destCode}
+          />
+          {fieldErrors.destCode && <span className={styles.errorText}>{fieldErrors.destCode}</span>}
+        </div>
+        <div className={`${styles.field} ${styles.fieldGrow}`}>
+          <label className={styles.label} htmlFor="me-dest-name">City / Airport</label>
+          <input
+            id="me-dest-name"
+            className={`${styles.input} ${fieldErrors.destName ? styles.inputError : ''}`}
+            type="text"
+            placeholder="Paris CDG"
+            value={destName}
+            onChange={(e) => { setDestName(e.target.value); clearError('destName'); }}
+            aria-required
+            aria-invalid={!!fieldErrors.destName}
+          />
+          {fieldErrors.destName && <span className={styles.errorText}>{fieldErrors.destName}</span>}
+        </div>
+      </div>
+
+      <div className={styles.tripToggle}>
+        <button
+          type="button"
+          className={`${styles.tripOption} ${tripType === 'round_trip' ? styles.tripOptionActive : ''}`}
+          onClick={() => setTripType('round_trip')}
+        >
+          Round trip
+        </button>
+        <button
+          type="button"
+          className={`${styles.tripOption} ${tripType === 'one_way' ? styles.tripOptionActive : ''}`}
+          onClick={() => setTripType('one_way')}
+        >
+          One way
+        </button>
+      </div>
+
+      <div className={styles.fieldRow}>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="me-date-from">Departure</label>
+          <input
+            id="me-date-from"
+            className={`${styles.input} ${fieldErrors.dateFrom ? styles.inputError : ''}`}
+            type="date"
+            min={today}
+            value={dateFrom}
+            onChange={(e) => { setDateFrom(e.target.value); clearError('dateFrom'); }}
+            aria-required
+            aria-invalid={!!fieldErrors.dateFrom}
+          />
+          {fieldErrors.dateFrom && <span className={styles.errorText}>{fieldErrors.dateFrom}</span>}
+        </div>
+        {tripType === 'round_trip' && (
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="me-date-to">Return</label>
+            <input
+              id="me-date-to"
+              className={`${styles.input} ${fieldErrors.dateTo ? styles.inputError : ''}`}
+              type="date"
+              min={dateFrom || today}
+              value={dateTo}
+              onChange={(e) => { setDateTo(e.target.value); clearError('dateTo'); }}
+              aria-required
+              aria-invalid={!!fieldErrors.dateTo}
+            />
+            {fieldErrors.dateTo && <span className={styles.errorText}>{fieldErrors.dateTo}</span>}
+          </div>
+        )}
+      </div>
+
+      <div className={styles.actions}>
+        <button type="submit" className={styles.submitButton}>
+          Show available flights
+        </button>
+        <button type="button" className={styles.cancelButton} onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/components/SearchBar.module.css
+++ b/apps/web/src/components/SearchBar.module.css
@@ -135,6 +135,26 @@
   box-shadow: 0 0 12px rgba(6, 182, 212, 0.15);
 }
 
+.manualToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.875rem;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.manualToggle:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 .inviteHint {
   font-size: 0.8125rem;
   color: var(--muted);

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -274,6 +274,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setCreatedTrackers(null);
     setManualMode(false);
     setManualRawInput('');
+    setVpnCountries([]);
     inputRef.current?.focus();
   };
 
@@ -376,7 +377,12 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
               <button
                 type="button"
                 className={styles.manualToggle}
-                onClick={() => setManualMode(true)}
+                onClick={() => {
+                  setError(null);
+                  setAmbiguities([]);
+                  setPartialParsed(null);
+                  setManualMode(true);
+                }}
               >
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
                   <rect x="3" y="3" width="7" height="7" rx="1" />

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -8,6 +8,7 @@ import { ConfirmationCard, type ParsedQuery } from './ConfirmationCard';
 import { ClarificationCard } from './ClarificationCard';
 import { FlightPicker, type RouteFlights } from './FlightPicker';
 import { LinkBanner, type CreatedTracker } from './LinkBanner';
+import { ManualEntryForm } from './ManualEntryForm';
 import type { PriceData } from '@/lib/scraper/extract-prices';
 import { detectLocaleCurrency } from '@/lib/currency';
 
@@ -65,6 +66,10 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
 
   // Link banner state — multiple trackers
   const [createdTrackers, setCreatedTrackers] = useState<CreatedTracker[] | null>(null);
+
+  // Manual entry mode
+  const [manualMode, setManualMode] = useState(false);
+  const [manualRawInput, setManualRawInput] = useState('');
 
   const doParse = useCallback(async (input: string, history: ConversationMessage[]) => {
     setLoading(true);
@@ -192,7 +197,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          rawInput: query.trim(),
+          rawInput: manualRawInput || query.trim(),
           dateFrom: parsed.dateFrom,
           dateTo: parsed.dateTo,
           flexibility: parsed.flexibility,
@@ -267,6 +272,8 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setPreviewRoutes(null);
     setPreviewLoading(false);
     setCreatedTrackers(null);
+    setManualMode(false);
+    setManualRawInput('');
     inputRef.current?.focus();
   };
 
@@ -277,83 +284,111 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
 
   return (
     <div className={styles.root}>
-      <div className={styles.inputWrapper}>
-        <input
-          ref={inputRef}
-          type="text"
-          className={styles.input}
-          placeholder='NYC to Paris around June 15 ± 3 days'
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={handleKeyDown}
-          disabled={loading}
-          autoFocus
-        />
-        <button
-          className={styles.searchButton}
-          onClick={handleParse}
-          disabled={loading || query.trim().length < 5}
-        >
-          {loading ? (
-            <span className={styles.spinner} />
-          ) : (
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M5 12h14M12 5l7 7-7 7" />
-            </svg>
-          )}
-        </button>
-      </div>
-
-      <div className={styles.hints}>
-        {['JFK to CDG June 15-20', 'London to Tokyo next month flexible', 'SFO to LAX March 20 ± 2 days'].map((example, i) => (
-          <span key={i}>
-            {i > 0 && <span className={styles.hintSep}>&middot; </span>}
-            <button
-              type="button"
-              className={styles.hintBtn}
-              onClick={() => { setQuery(example); inputRef.current?.focus(); }}
-            >
-              {example}
-            </button>
-          </span>
-        ))}
-      </div>
-
-      {!parsed && !loading && (
-        <button
-          type="button"
-          className={styles.randomFlight}
-          onClick={() => {
-            // Generate dates 3-6 weeks from now for realistic searches
-            const base = new Date();
-            base.setDate(base.getDate() + 21 + Math.floor(Math.random() * 21));
-            const dep = base.toISOString().split('T')[0]!;
-            const ret = new Date(base);
-            ret.setDate(ret.getDate() + 5 + Math.floor(Math.random() * 5));
-            const retStr = ret.toISOString().split('T')[0]!;
-
-            const routes = [
-              `JFK to CDG ${dep} to ${retStr} round trip economy`,
-              `LAX to NRT ${dep} to ${retStr} round trip economy`,
-              `ORD to FCO ${dep} to ${retStr} round trip economy`,
-              `MIA to BOG ${dep} one way economy`,
-              `SFO to LHR ${dep} to ${retStr} round trip economy`,
-              `BOS to BCN ${dep} to ${retStr} round trip economy`,
-              `SEA to ICN ${dep} to ${retStr} round trip economy`,
-              `DEN to AMS ${dep} to ${retStr} round trip economy`,
-              `DFW to CUN ${dep} to ${retStr} round trip economy`,
-              `ATL to DUB ${dep} to ${retStr} round trip economy`,
-            ];
-            const pick = routes[Math.floor(Math.random() * routes.length)]!;
-            setQuery(pick);
-            doParse(pick, []);
+      {manualMode ? (
+        <ManualEntryForm
+          onSubmit={(q, rawInput) => {
+            setParsed(q);
+            setManualRawInput(rawInput);
+            setManualMode(false);
           }}
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-            <path d="M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22M22 6l-4-4M22 6l-4 4M2 6h1.4c1.3 0 2.5.6 3.3 1.7l6.1 8.6c.7 1.1 2 1.7 3.3 1.7H22M22 18l-4-4M22 18l-4 4" />
-          </svg>
-          Try a random flight
-        </button>
+          onCancel={() => setManualMode(false)}
+          adminCurrency={adminCurrency}
+        />
+      ) : (
+        <>
+          <div className={styles.inputWrapper}>
+            <input
+              ref={inputRef}
+              type="text"
+              className={styles.input}
+              placeholder='NYC to Paris around June 15 ± 3 days'
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={loading}
+              autoFocus
+            />
+            <button
+              className={styles.searchButton}
+              onClick={handleParse}
+              disabled={loading || query.trim().length < 5}
+            >
+              {loading ? (
+                <span className={styles.spinner} />
+              ) : (
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M5 12h14M12 5l7 7-7 7" />
+                </svg>
+              )}
+            </button>
+          </div>
+
+          <div className={styles.hints}>
+            {['JFK to CDG June 15-20', 'London to Tokyo next month flexible', 'SFO to LAX March 20 ± 2 days'].map((example, i) => (
+              <span key={i}>
+                {i > 0 && <span className={styles.hintSep}>&middot; </span>}
+                <button
+                  type="button"
+                  className={styles.hintBtn}
+                  onClick={() => { setQuery(example); inputRef.current?.focus(); }}
+                >
+                  {example}
+                </button>
+              </span>
+            ))}
+          </div>
+
+          {!parsed && !loading && (
+            <>
+              <button
+                type="button"
+                className={styles.randomFlight}
+                onClick={() => {
+                  const base = new Date();
+                  base.setDate(base.getDate() + 21 + Math.floor(Math.random() * 21));
+                  const dep = base.toISOString().split('T')[0]!;
+                  const ret = new Date(base);
+                  ret.setDate(ret.getDate() + 5 + Math.floor(Math.random() * 5));
+                  const retStr = ret.toISOString().split('T')[0]!;
+
+                  const routes = [
+                    `JFK to CDG ${dep} to ${retStr} round trip economy`,
+                    `LAX to NRT ${dep} to ${retStr} round trip economy`,
+                    `ORD to FCO ${dep} to ${retStr} round trip economy`,
+                    `MIA to BOG ${dep} one way economy`,
+                    `SFO to LHR ${dep} to ${retStr} round trip economy`,
+                    `BOS to BCN ${dep} to ${retStr} round trip economy`,
+                    `SEA to ICN ${dep} to ${retStr} round trip economy`,
+                    `DEN to AMS ${dep} to ${retStr} round trip economy`,
+                    `DFW to CUN ${dep} to ${retStr} round trip economy`,
+                    `ATL to DUB ${dep} to ${retStr} round trip economy`,
+                  ];
+                  const pick = routes[Math.floor(Math.random() * routes.length)]!;
+                  setQuery(pick);
+                  doParse(pick, []);
+                }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                  <path d="M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22M22 6l-4-4M22 6l-4 4M2 6h1.4c1.3 0 2.5.6 3.3 1.7l6.1 8.6c.7 1.1 2 1.7 3.3 1.7H22M22 18l-4-4M22 18l-4 4" />
+                </svg>
+                Try a random flight
+              </button>
+              <button
+                type="button"
+                className={styles.manualToggle}
+                onClick={() => setManualMode(true)}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                  <rect x="3" y="3" width="7" height="7" rx="1" />
+                  <rect x="14" y="3" width="7" height="7" rx="1" />
+                  <rect x="3" y="14" width="7" height="7" rx="1" />
+                  <rect x="14" y="14" width="7" height="7" rx="1" />
+                </svg>
+                Enter flight details manually
+              </button>
+            </>
+          )}
+        </>
       )}
 
       {error && (


### PR DESCRIPTION
## Summary
- Adds a "Enter flight details manually" button below the search bar that opens a structured form, bypassing the LLM parse step entirely
- Form collects origin/destination airports (IATA code + name), dates, trip type, with collapsible advanced options (flexibility, max price, stops, cabin class, time preference, currency, airlines)
- Produces the same `ParsedQuery` object as the LLM path, so the entire downstream flow (ConfirmationCard, FlightPicker, tracker creation) works unchanged
- Includes inline validation, keyboard accessibility, dark/light theme support, and mobile responsive layout

## Bug fixes (from Codex audit)
- Reject same-day round trips (API requires `dateTo > dateFrom`)
- Block same origin and destination airport
- Use local timezone for date validation instead of UTC
- Clear stale error/clarification UI when entering manual mode
- Reset VPN country selections in `handleReset`

Closes #37

## Test plan
- [ ] Toggle to manual mode, fill in valid flight details, verify ConfirmationCard appears
- [ ] Submit with missing fields, verify inline errors appear and clear on input
- [ ] Try same origin/destination, verify rejection
- [ ] Try same-day round trip, verify rejection
- [ ] Expand advanced options, set cabin class + max price, verify they appear in ConfirmationCard
- [ ] Complete full flow through FlightPicker to tracker creation
- [ ] Toggle back to natural language mode, verify it works normally
- [ ] Test on mobile viewport