### PR TITLE
fix: preserve manual entry data when clicking Edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Both approaches share the same risk: Google can break either one at any time. We
 | Project | Description |
 |---------|-------------|
 | [**fli**](https://github.com/punitarani/fli) | Google Flights API reverse-engineering (Python) |
+| [**jetlog**](https://github.com/pbogre/jetlog) | Self-hosted personal flight journal with world map and stats |
 | [**PriceToken**](https://github.com/affromero/pricetoken) | Real-time LLM pricing API, npm/PyPI packages, and live dashboard |
 | [**gitpane**](https://github.com/affromero/gitpane) | Multi-repo Git workspace dashboard for the terminal |
 | [**kin3o**](https://github.com/affromero/kin3o) | AI-powered Lottie animation generator CLI |

--- a/apps/web/src/components/ManualEntryForm.tsx
+++ b/apps/web/src/components/ManualEntryForm.tsx
@@ -6,12 +6,27 @@ import { AirportCombobox } from './AirportCombobox';
 import { detectLocaleCurrency } from '@/lib/currency';
 import styles from './ManualEntryForm.module.css';
 
+export interface ManualFormValues {
+  origin: { code: string; name: string } | null;
+  destination: { code: string; name: string } | null;
+  dateFrom: string;
+  dateTo: string;
+  tripType: 'one_way' | 'round_trip';
+  flexibility: number;
+  maxPrice: string;
+  maxStops: string;
+  airlines: string;
+  timePreference: 'any' | 'morning' | 'afternoon' | 'evening' | 'redeye';
+  cabinClass: 'economy' | 'premium_economy' | 'business' | 'first';
+  currency: string;
+}
+
 interface ManualEntryFormProps {
-  onSubmit: (query: ParsedQuery, rawInput: string) => void;
+  onSubmit: (query: ParsedQuery, rawInput: string, formValues: ManualFormValues) => void;
   onCancel: () => void;
   adminCurrency: string | null;
   cancelLabel?: string;
-  initialValues?: ParsedQuery;
+  initialValues?: ManualFormValues;
 }
 
 interface SelectedAirport {
@@ -47,38 +62,31 @@ export function ManualEntryForm({
   initialValues,
 }: ManualEntryFormProps) {
   const iv = initialValues;
-  const [origin, setOrigin] = useState<SelectedAirport | null>(
-    iv ? { code: iv.origin, name: iv.originName } : null,
-  );
-  const [destination, setDestination] = useState<SelectedAirport | null>(
-    iv ? { code: iv.destination, name: iv.destinationName } : null,
-  );
+  const [origin, setOrigin] = useState<SelectedAirport | null>(iv?.origin ?? null);
+  const [destination, setDestination] = useState<SelectedAirport | null>(iv?.destination ?? null);
   const [dateFrom, setDateFrom] = useState(iv?.dateFrom ?? '');
   const [dateTo, setDateTo] = useState(iv?.dateTo ?? '');
-  const [tripType, setTripType] = useState<'one_way' | 'round_trip'>(
-    (iv?.tripType as 'one_way' | 'round_trip') ?? 'round_trip',
-  );
+  const [tripType, setTripType] = useState<'one_way' | 'round_trip'>(iv?.tripType ?? 'round_trip');
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   const hasAdvancedInitial = iv ? !!(
     iv.flexibility > 0 ||
     iv.maxPrice ||
-    (iv.maxStops !== null && iv.maxStops !== undefined) ||
-    iv.preferredAirlines.length > 0 ||
+    iv.maxStops ||
+    iv.airlines ||
     iv.timePreference !== 'any' ||
-    iv.cabinClass !== 'economy' ||
-    iv.currency
+    iv.cabinClass !== 'economy'
   ) : false;
   const [showAdvanced, setShowAdvanced] = useState(hasAdvancedInitial);
   const [flexibility, setFlexibility] = useState(iv?.flexibility ?? 0);
-  const [maxPrice, setMaxPrice] = useState(iv?.maxPrice ? String(iv.maxPrice) : '');
-  const [maxStops, setMaxStops] = useState(iv?.maxStops !== null && iv?.maxStops !== undefined ? String(iv.maxStops) : '');
-  const [airlines, setAirlines] = useState(iv?.preferredAirlines?.join(', ') ?? '');
+  const [maxPrice, setMaxPrice] = useState(iv?.maxPrice ?? '');
+  const [maxStops, setMaxStops] = useState(iv?.maxStops ?? '');
+  const [airlines, setAirlines] = useState(iv?.airlines ?? '');
   const [timePreference, setTimePreference] = useState<'any' | 'morning' | 'afternoon' | 'evening' | 'redeye'>(
-    (iv?.timePreference as 'any' | 'morning' | 'afternoon' | 'evening' | 'redeye') ?? 'any',
+    iv?.timePreference ?? 'any',
   );
   const [cabinClass, setCabinClass] = useState<'economy' | 'premium_economy' | 'business' | 'first'>(
-    (iv?.cabinClass as 'economy' | 'premium_economy' | 'business' | 'first') ?? 'economy',
+    iv?.cabinClass ?? 'economy',
   );
   const [currency, setCurrency] = useState(iv?.currency ?? '');
 
@@ -156,7 +164,21 @@ export function ManualEntryForm({
     }
 
     const rawInput = synthesizeRawInput(o, d, dateFrom, dateTo, tripType, cabinClass);
-    onSubmit(query, rawInput);
+    const formValues: ManualFormValues = {
+      origin: o,
+      destination: d,
+      dateFrom,
+      dateTo: tripType === 'round_trip' ? dateTo : dateFrom,
+      tripType,
+      flexibility,
+      maxPrice,
+      maxStops,
+      airlines,
+      timePreference,
+      cabinClass,
+      currency,
+    };
+    onSubmit(query, rawInput, formValues);
   };
 
   const now = new Date();

--- a/apps/web/src/components/ManualEntryForm.tsx
+++ b/apps/web/src/components/ManualEntryForm.tsx
@@ -11,6 +11,7 @@ interface ManualEntryFormProps {
   onCancel: () => void;
   adminCurrency: string | null;
   cancelLabel?: string;
+  initialValues?: ParsedQuery;
 }
 
 interface SelectedAirport {
@@ -43,22 +44,43 @@ export function ManualEntryForm({
   onCancel,
   adminCurrency,
   cancelLabel = 'Cancel',
+  initialValues,
 }: ManualEntryFormProps) {
-  const [origin, setOrigin] = useState<SelectedAirport | null>(null);
-  const [destination, setDestination] = useState<SelectedAirport | null>(null);
-  const [dateFrom, setDateFrom] = useState('');
-  const [dateTo, setDateTo] = useState('');
-  const [tripType, setTripType] = useState<'one_way' | 'round_trip'>('round_trip');
+  const iv = initialValues;
+  const [origin, setOrigin] = useState<SelectedAirport | null>(
+    iv ? { code: iv.origin, name: iv.originName } : null,
+  );
+  const [destination, setDestination] = useState<SelectedAirport | null>(
+    iv ? { code: iv.destination, name: iv.destinationName } : null,
+  );
+  const [dateFrom, setDateFrom] = useState(iv?.dateFrom ?? '');
+  const [dateTo, setDateTo] = useState(iv?.dateTo ?? '');
+  const [tripType, setTripType] = useState<'one_way' | 'round_trip'>(
+    (iv?.tripType as 'one_way' | 'round_trip') ?? 'round_trip',
+  );
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
-  const [showAdvanced, setShowAdvanced] = useState(false);
-  const [flexibility, setFlexibility] = useState(0);
-  const [maxPrice, setMaxPrice] = useState('');
-  const [maxStops, setMaxStops] = useState('');
-  const [airlines, setAirlines] = useState('');
-  const [timePreference, setTimePreference] = useState<'any' | 'morning' | 'afternoon' | 'evening' | 'redeye'>('any');
-  const [cabinClass, setCabinClass] = useState<'economy' | 'premium_economy' | 'business' | 'first'>('economy');
-  const [currency, setCurrency] = useState('');
+  const hasAdvancedInitial = iv ? !!(
+    iv.flexibility > 0 ||
+    iv.maxPrice ||
+    (iv.maxStops !== null && iv.maxStops !== undefined) ||
+    iv.preferredAirlines.length > 0 ||
+    iv.timePreference !== 'any' ||
+    iv.cabinClass !== 'economy' ||
+    iv.currency
+  ) : false;
+  const [showAdvanced, setShowAdvanced] = useState(hasAdvancedInitial);
+  const [flexibility, setFlexibility] = useState(iv?.flexibility ?? 0);
+  const [maxPrice, setMaxPrice] = useState(iv?.maxPrice ? String(iv.maxPrice) : '');
+  const [maxStops, setMaxStops] = useState(iv?.maxStops !== null && iv?.maxStops !== undefined ? String(iv.maxStops) : '');
+  const [airlines, setAirlines] = useState(iv?.preferredAirlines?.join(', ') ?? '');
+  const [timePreference, setTimePreference] = useState<'any' | 'morning' | 'afternoon' | 'evening' | 'redeye'>(
+    (iv?.timePreference as 'any' | 'morning' | 'afternoon' | 'evening' | 'redeye') ?? 'any',
+  );
+  const [cabinClass, setCabinClass] = useState<'economy' | 'premium_economy' | 'business' | 'first'>(
+    (iv?.cabinClass as 'economy' | 'premium_economy' | 'business' | 'first') ?? 'economy',
+  );
+  const [currency, setCurrency] = useState(iv?.currency ?? '');
 
   const clearError = (field: string) => {
     setFieldErrors((prev) => {

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -11,7 +11,7 @@ import { ClarificationCard } from './ClarificationCard';
 import { ConfirmationCard, type ParsedQuery } from './ConfirmationCard';
 import { FlightPicker, type RouteFlights } from './FlightPicker';
 import { LinkBanner, type CreatedTracker } from './LinkBanner';
-import { ManualEntryForm } from './ManualEntryForm';
+import { ManualEntryForm, type ManualFormValues } from './ManualEntryForm';
 
 const PREVIEW_STORAGE_KEY = 'ft-preview-run';
 const PREVIEW_POLL_TIMEOUT_MS = 5 * 60 * 1000;
@@ -103,6 +103,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
   const [activeSearchMethod, setActiveSearchMethod] = useState<'ai' | 'manual'>('ai');
   const [manualMode, setManualMode] = useState(false);
   const [manualRawInput, setManualRawInput] = useState('');
+  const [manualFormValues, setManualFormValues] = useState<ManualFormValues | null>(null);
 
   useEffect(() => {
     fetch('/api/admin/config')
@@ -256,6 +257,8 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setPreviewRoutes(null);
     setPreviewRunId(null);
     setCreatedTrackers(null);
+    setManualRawInput('');
+    setManualFormValues(null);
     clearSavedPreview();
 
     await doParse(trimmed, []);
@@ -408,7 +411,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     clearSavedPreview();
   };
 
-  const [editingValues, setEditingValues] = useState<ParsedQuery | null>(null);
+  const [editingValues, setEditingValues] = useState<ManualFormValues | null>(null);
 
   const handleReset = () => {
     setParsed(null);
@@ -422,6 +425,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setCreatedTrackers(null);
     setManualMode(activeSearchMethod === 'manual');
     setManualRawInput('');
+    setManualFormValues(null);
     setVpnCountries([]);
     setEditingValues(null);
     clearSavedPreview();
@@ -429,8 +433,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
   };
 
   const handleEdit = () => {
-    const wasManual = !!manualRawInput;
-    const currentParsed = parsed;
+    const wasManual = !!manualFormValues;
 
     setError(null);
     setConversation([]);
@@ -442,8 +445,8 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setCreatedTrackers(null);
     clearSavedPreview();
 
-    if (wasManual && currentParsed) {
-      setEditingValues(currentParsed);
+    if (wasManual) {
+      setEditingValues(manualFormValues);
       setParsed(null);
       setManualMode(true);
     } else {
@@ -462,9 +465,10 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     <div className={styles.root}>
       {manualMode ? (
         <ManualEntryForm
-          onSubmit={(nextParsed, rawInput) => {
+          onSubmit={(nextParsed, rawInput, formValues) => {
             setParsed(nextParsed);
             setManualRawInput(rawInput);
+            setManualFormValues(formValues);
             setManualMode(false);
             setEditingValues(null);
           }}

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -408,6 +408,8 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     clearSavedPreview();
   };
 
+  const [editingValues, setEditingValues] = useState<ParsedQuery | null>(null);
+
   const handleReset = () => {
     setParsed(null);
     setError(null);
@@ -421,8 +423,34 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setManualMode(activeSearchMethod === 'manual');
     setManualRawInput('');
     setVpnCountries([]);
+    setEditingValues(null);
     clearSavedPreview();
     inputRef.current?.focus();
+  };
+
+  const handleEdit = () => {
+    const wasManual = !!manualRawInput;
+    const currentParsed = parsed;
+
+    setError(null);
+    setConversation([]);
+    setAmbiguities([]);
+    setPartialParsed(null);
+    setPreviewRoutes(null);
+    setPreviewLoading(false);
+    setPreviewRunId(null);
+    setCreatedTrackers(null);
+    clearSavedPreview();
+
+    if (wasManual && currentParsed) {
+      setEditingValues(currentParsed);
+      setParsed(null);
+      setManualMode(true);
+    } else {
+      setParsed(null);
+      setEditingValues(null);
+      inputRef.current?.focus();
+    }
   };
 
   const showClarification = ambiguities.length > 0 && !parsed;
@@ -438,13 +466,16 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
             setParsed(nextParsed);
             setManualRawInput(rawInput);
             setManualMode(false);
+            setEditingValues(null);
           }}
           onCancel={() => {
             setActiveSearchMethod('ai');
             setManualMode(false);
+            setEditingValues(null);
           }}
           adminCurrency={adminCurrency}
           cancelLabel="Use AI search"
+          initialValues={editingValues ?? undefined}
         />
       ) : (
         <>
@@ -568,7 +599,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
         <ConfirmationCard
           parsed={parsed}
           onTrack={handlePreview}
-          onEdit={handleReset}
+          onEdit={handleEdit}
           loading={loading}
           vpnCountries={vpnCountries}
           onVpnCountriesChange={setVpnCountries}
@@ -591,7 +622,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
           routes={previewRoutes}
           onTrack={handleTrackSelected}
           onBack={handleBackFromPicker}
-          onEdit={handleReset}
+          onEdit={handleEdit}
           loading={loading}
         />
       )}


### PR DESCRIPTION
## Summary

- Clicking "Edit" on the confirmation card after filling in the manual entry form now returns you to the form with all your data intact instead of clearing it
- Introduced `ManualFormValues` type to store raw form state (pre-flexibility-expanded dates), preventing flexibility from being applied twice on re-submit
- Cleared stale manual state when switching to AI search, so "Edit" on an AI result no longer incorrectly reopens the manual form
- Fixed advanced options panel always expanding on edit by excluding auto-detected currency from the check

Closes #46

## Test plan

- [ ] Fill in manual entry form with origin, destination, dates, and submit
- [ ] Click "Edit" on confirmation card -- verify all fields are preserved
- [ ] Set flexibility > 0, submit, click Edit, re-submit -- verify date range does not expand further
- [ ] After a manual search, switch to AI search, submit, click Edit -- verify it returns to AI input (not manual form)
- [ ] Fill only required fields (no advanced options), submit, click Edit -- verify advanced panel stays collapsed
- [ ] Set advanced options (cabin class, max stops), submit, click Edit -- verify advanced panel opens with values intact
