### PR TITLE
fix: gate open command behind Darwin check for Linux compatibility

### DIFF
--- a/apps/web/public/fairtrail-cli
+++ b/apps/web/public/fairtrail-cli
@@ -137,7 +137,7 @@ cmd_start_foreground() {
   if [ "$RETRIES" -gt 0 ]; then
     printf "${GREEN}${BOLD}✓${RESET} Running at ${BOLD}http://localhost:${PORT}${RESET}\n"
     # Open browser
-    if command -v open &>/dev/null; then
+    if [ "$(uname)" = "Darwin" ] && command -v open &>/dev/null; then
       open "http://localhost:${PORT}"
     elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
       xdg-open "http://localhost:${PORT}" >/dev/null 2>&1 &
@@ -166,7 +166,7 @@ cmd_start_background() {
   printf "  ${DIM}Stop with: fairtrail stop${RESET}\n"
 
   # Open browser
-  if command -v open &>/dev/null; then
+  if [ "$(uname)" = "Darwin" ] && command -v open &>/dev/null; then
     open "http://localhost:${PORT}"
   elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
     xdg-open "http://localhost:${PORT}" >/dev/null 2>&1 &
@@ -399,7 +399,7 @@ print(json.dumps(body))
   printf "${GREEN}${BOLD}✓${RESET} Tracking ${BOLD}%s${RESET} route(s) — prices checked every 3h\n" "$num_queries"
   printf "  ${BOLD}http://localhost:%s/q/%s${RESET}\n" "$PORT" "$query_id"
 
-  if command -v open &>/dev/null; then
+  if [ "$(uname)" = "Darwin" ] && command -v open &>/dev/null; then
     open "http://localhost:${PORT}/q/${query_id}"
   elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
     xdg-open "http://localhost:${PORT}/q/${query_id}" >/dev/null 2>&1 &

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -741,7 +741,7 @@ printf "  ${DIM}Ctrl+C to stop  |  fairtrail stop  |  fairtrail help${RESET}\n"
 echo ""
 
 # Open browser automatically (skip on headless systems)
-if command -v open &>/dev/null; then
+if [ "$(uname)" = "Darwin" ] && command -v open &>/dev/null; then
   open "http://localhost:${HOST_PORT}"
 elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
   xdg-open "http://localhost:${HOST_PORT}" >/dev/null 2>&1 &

--- a/apps/web/src/lib/scraper/install-scripts.test.ts
+++ b/apps/web/src/lib/scraper/install-scripts.test.ts
@@ -69,6 +69,27 @@ describe('install.sh', () => {
     }
   });
 
+  it('gates macOS open command behind uname Darwin check', () => {
+    const lines = INSTALL_SH.split('\n');
+    const openLines = lines.filter(
+      (l) =>
+        /\bopen\s+"http/.test(l) &&
+        !l.includes('xdg-open') &&
+        !l.trimStart().startsWith('#')
+    );
+    expect(openLines.length).toBeGreaterThan(0);
+    for (const line of openLines) {
+      const idx = lines.indexOf(line);
+      const context = lines
+        .slice(Math.max(0, idx - 1), idx + 1)
+        .join('\n');
+      expect(
+        context,
+        `open not gated behind Darwin: ${line.trim()}`
+      ).toContain('Darwin');
+    }
+  });
+
   it('redirects both stdout and stderr for xdg-open', () => {
     const xdgExecLines = INSTALL_SH.split('\n').filter(
       (l) => l.includes('xdg-open') && !l.includes('command -v')
@@ -168,6 +189,27 @@ describe('fairtrail-cli', () => {
         context,
         `xdg-open not guarded: ${line.trim()}`
       ).toMatch(/DISPLAY|WAYLAND_DISPLAY/);
+    }
+  });
+
+  it('gates macOS open command behind uname Darwin check', () => {
+    const lines = CLI_SH.split('\n');
+    const openLines = lines.filter(
+      (l) =>
+        /\bopen\s+"http/.test(l) &&
+        !l.includes('xdg-open') &&
+        !l.trimStart().startsWith('#')
+    );
+    expect(openLines.length).toBeGreaterThan(0);
+    for (const line of openLines) {
+      const idx = lines.indexOf(line);
+      const context = lines
+        .slice(Math.max(0, idx - 1), idx + 1)
+        .join('\n');
+      expect(
+        context,
+        `open not gated behind Darwin: ${line.trim()}`
+      ).toContain('Darwin');
     }
   });
 


### PR DESCRIPTION
## Summary

- On Debian-based Linux (including Proxmox LXC), the `open` command exists but comes from the `mime-support` package (`run-mailcap`), not a browser opener. Passing it a URL produces `Warning: unknown mime-type` and `Error: no such file` errors.
- Gates all 4 browser-open callsites behind `[ "$(uname)" = "Darwin" ]` so `open` only runs on macOS. The existing `xdg-open` path (guarded by `DISPLAY`/`WAYLAND_DISPLAY`) handles Linux correctly.
- Adds regression tests for both `install.sh` and `fairtrail-cli` ensuring `open` is always gated behind a Darwin check.

Closes #48

## Test plan

- [x] 203 tests pass (including 2 new regression tests)
- [x] Full CI green (lint + typecheck + build)
- [ ] Verify on a Proxmox LXC that the warning/error lines no longer appear after `fairtrail start`