### PR TITLE
fix: cron scheduler now respects DB-configured scrape interval

### DIFF
--- a/apps/web/src/app/api/admin/config/route.ts
+++ b/apps/web/src/app/api/admin/config/route.ts
@@ -6,6 +6,7 @@ import { hashPassword } from '@/lib/password';
 import { registerForCommunity } from '@/lib/community-sync';
 import { encryptVpnCode } from '@/lib/vpn-crypto';
 import { isThemeId } from '@/lib/theme';
+import { updateCronInterval } from '@/lib/cron';
 
 function stripHashes(config: Record<string, unknown>) {
   const { adminPasswordHash, vpnActivationCode, ...rest } = config;
@@ -136,6 +137,11 @@ export async function PATCH(request: NextRequest) {
     update: data,
     create: { id: 'singleton', ...data },
   });
+
+  // Immediately reschedule cron if the scrape interval changed
+  if (typeof data.scrapeInterval === 'number') {
+    updateCronInterval(data.scrapeInterval);
+  }
 
   return apiSuccess(stripHashes(config as unknown as Record<string, unknown>));
 }

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -2,6 +2,6 @@ export async function register() {
   // Only start cron on the Node.js server, not in Edge runtime
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     const { startCron } = await import('./lib/cron');
-    startCron();
+    await startCron();
   }
 }

--- a/apps/web/src/lib/cron.test.ts
+++ b/apps/web/src/lib/cron.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const { mockFindFirst } = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+}));
+
+vi.mock('./prisma', () => ({
+  prisma: {
+    extractionConfig: {
+      findFirst: (...args: unknown[]) => mockFindFirst(...args),
+    },
+  },
+}));
+
+import { startCron, stopCron, getCronInfo, updateCronInterval } from './cron';
+
+afterEach(() => {
+  stopCron();
+  vi.useRealTimers();
+  mockFindFirst.mockReset();
+  delete process.env.CRON_INTERVAL_HOURS;
+  delete process.env.CRON_ENABLED;
+});
+
+describe('cron scheduler reads DB interval', () => {
+  it('uses database scrapeInterval on startup instead of env var default', async () => {
+    mockFindFirst.mockImplementation(() => Promise.resolve({ id: 'singleton', scrapeInterval: 1 }));
+
+    await startCron();
+    const info = getCronInfo();
+
+    expect(info.intervalHours).toBe(1);
+    expect(mockFindFirst).toHaveBeenCalledWith({ where: { id: 'singleton' } });
+  });
+
+  it('falls back to env var when DB has no config row', async () => {
+    process.env.CRON_INTERVAL_HOURS = '6';
+    mockFindFirst.mockImplementation(() => Promise.resolve(null));
+
+    await startCron();
+
+    expect(getCronInfo().intervalHours).toBe(6);
+  });
+
+  it('falls back to env var when DB query fails', async () => {
+    process.env.CRON_INTERVAL_HOURS = '4';
+    mockFindFirst.mockImplementation(() => Promise.reject(new Error('connection refused')));
+
+    await startCron();
+
+    expect(getCronInfo().intervalHours).toBe(4);
+  });
+
+  it('defaults to 3h when no DB config and no env var', async () => {
+    mockFindFirst.mockImplementation(() => Promise.resolve(null));
+
+    await startCron();
+
+    expect(getCronInfo().intervalHours).toBe(3);
+  });
+});
+
+describe('updateCronInterval', () => {
+  it('immediately reschedules with new interval', async () => {
+    vi.useFakeTimers();
+    mockFindFirst.mockImplementation(() => Promise.resolve({ id: 'singleton', scrapeInterval: 3 }));
+    await startCron();
+    expect(getCronInfo().intervalHours).toBe(3);
+
+    updateCronInterval(1);
+
+    expect(getCronInfo().intervalHours).toBe(1);
+    // Next scrape should be ~1h from now, not ~3h
+    const next = new Date(getCronInfo().nextScrape!).getTime();
+    const now = Date.now();
+    const hoursUntilNext = (next - now) / (1000 * 60 * 60);
+    expect(hoursUntilNext).toBeGreaterThan(0.9);
+    expect(hoursUntilNext).toBeLessThan(1.1);
+  });
+
+  it('clamps interval to 1-24 range', async () => {
+    vi.useFakeTimers();
+    mockFindFirst.mockImplementation(() => Promise.resolve(null));
+    await startCron();
+
+    updateCronInterval(0);
+    expect(getCronInfo().intervalHours).toBe(1);
+
+    updateCronInterval(48);
+    expect(getCronInfo().intervalHours).toBe(24);
+  });
+});
+
+describe('CRON_ENABLED', () => {
+  it('does not start when CRON_ENABLED=false', async () => {
+    process.env.CRON_ENABLED = 'false';
+    mockFindFirst.mockImplementation(() => Promise.resolve({ id: 'singleton', scrapeInterval: 1 }));
+
+    await startCron();
+
+    expect(getCronInfo().nextScrape).toBeNull();
+    expect(mockFindFirst).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/cron.ts
+++ b/apps/web/src/lib/cron.ts
@@ -1,3 +1,5 @@
+import { prisma } from './prisma';
+
 const JITTER_RANGE_SECONDS = 150; // ±2.5 min → 5 min total window
 
 let timer: ReturnType<typeof setTimeout> | null = null;
@@ -20,6 +22,16 @@ function formatDuration(ms: number): string {
   if (m > 0) parts.push(`${m}m`);
   if (s > 0 || parts.length === 0) parts.push(`${s}s`);
   return parts.join(' ');
+}
+
+async function readDbInterval(): Promise<number> {
+  try {
+    const config = await prisma.extractionConfig.findFirst({ where: { id: 'singleton' } });
+    if (config?.scrapeInterval) return config.scrapeInterval;
+  } catch {
+    // DB not ready yet (startup) or connection error -- fall through to current value
+  }
+  return cronIntervalHours;
 }
 
 function scheduleNext() {
@@ -53,6 +65,13 @@ async function runAndReschedule() {
     console.error('[cron] Scrape failed:', err instanceof Error ? err.message : err);
   }
 
+  // Re-read interval from DB before scheduling next run
+  const dbInterval = await readDbInterval();
+  if (dbInterval !== cronIntervalHours) {
+    console.log(`[cron] Interval changed: ${cronIntervalHours}h → ${dbInterval}h`);
+    cronIntervalHours = dbInterval;
+  }
+
   scheduleNext();
 }
 
@@ -74,13 +93,28 @@ export function getCronInfo(): {
   };
 }
 
-export function startCron() {
+/** Immediately reschedule cron with a new interval (called when settings change). */
+export function updateCronInterval(hours: number) {
+  cronIntervalHours = Math.max(1, Math.min(24, hours));
+  console.log(`[cron] Interval updated to ${cronIntervalHours}h, rescheduling`);
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  scheduleNext();
+}
+
+export async function startCron() {
   if (process.env.CRON_ENABLED === 'false') {
     console.log('[cron] Disabled via CRON_ENABLED=false');
     return;
   }
 
-  cronIntervalHours = Math.max(1, parseInt(process.env.CRON_INTERVAL_HOURS ?? '3', 10));
+  // DB value takes priority, env var is fallback for first boot
+  const envFallback = Math.max(1, parseInt(process.env.CRON_INTERVAL_HOURS ?? '3', 10));
+  cronIntervalHours = envFallback;
+  const dbInterval = await readDbInterval();
+  cronIntervalHours = dbInterval;
 
   console.log(`[cron] Starting with ${cronIntervalHours}h base interval (±${JITTER_RANGE_SECONDS}s jitter)`);
   scheduleNext();


### PR DESCRIPTION
## Summary

- The cron scheduler was hardcoded to read `CRON_INTERVAL_HOURS` env var once at startup, ignoring the scrape interval users configured via the Settings UI
- Now reads `ExtractionConfig.scrapeInterval` from the database at startup (env var is fallback for first boot only) and re-reads after each scrape run
- Saving a new interval in Settings immediately reschedules the cron timer via `updateCronInterval()`

Fixes #50

## Changes

| File | What Changed | Impact |
|------|-------------|--------|
| `apps/web/src/lib/cron.ts` | Added `readDbInterval()`, `updateCronInterval()` export; `startCron()` reads DB; `runAndReschedule()` re-reads DB each cycle | Cron interval stays in sync with user settings |
| `apps/web/src/app/api/admin/config/route.ts` | Calls `updateCronInterval()` after saving interval change | Immediate effect when user saves settings |
| `apps/web/src/instrumentation.ts` | `await startCron()` (now async) | Startup waits for DB read before scheduling |

## Test plan

- [x] `npm run ci` passes (lint, typecheck, 203 tests, build)
- [ ] Set interval to 1h in Settings UI, verify logs show `[cron] Interval updated to 1h, rescheduling`
- [ ] Restart app, verify startup log shows `Starting with 1h base interval` (reads DB, not env default)
- [ ] Verify scrape runs respect the configured interval