### PR TITLE
Admin search page + multi-question clarification fix

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/DashboardNav.tsx
+++ b/apps/web/src/app/admin/(dashboard)/DashboardNav.tsx
@@ -7,6 +7,7 @@ import styles from './layout.module.css';
 
 const ALL_NAV_ITEMS = [
   { href: '/admin', label: 'Dashboard', selfHosted: true },
+  { href: '/admin/search', label: 'Search', selfHosted: true },
   { href: '/admin/queries', label: 'Queries', selfHosted: true },
   { href: '/admin/seed-routes', label: 'Seed Routes', selfHosted: false },
   { href: '/admin/insights', label: 'Insights', selfHosted: true },

--- a/apps/web/src/app/admin/(dashboard)/search/page.module.css
+++ b/apps/web/src/app/admin/(dashboard)/search/page.module.css
@@ -1,0 +1,39 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.subtitle {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  max-width: 60ch;
+  line-height: 1.5;
+}
+
+.code {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  padding: 0.1rem 0.35rem;
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+}
+
+.searchWrapper {
+  width: 100%;
+}

--- a/apps/web/src/app/admin/(dashboard)/search/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/search/page.tsx
@@ -1,0 +1,23 @@
+import { SearchBar } from '@/components/SearchBar';
+import styles from './page.module.css';
+
+export const dynamic = 'force-dynamic';
+
+export default function AdminSearchPage() {
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>Search</h1>
+        <p className={styles.subtitle}>
+          Describe a flight in plain English (or enter details manually). This runs the same
+          flow as <code className={styles.code}>fairtrail</code> on the command line: parse,
+          preview Google Flights results, pick flights, start tracking.
+        </p>
+      </div>
+
+      <div className={styles.searchWrapper}>
+        <SearchBar />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/search/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/search/page.tsx
@@ -16,7 +16,7 @@ export default function AdminSearchPage() {
       </div>
 
       <div className={styles.searchWrapper}>
-        <SearchBar />
+        <SearchBar surface="admin" />
       </div>
     </div>
   );

--- a/apps/web/src/components/ClarificationCard.module.css
+++ b/apps/web/src/components/ClarificationCard.module.css
@@ -99,8 +99,46 @@
   cursor: not-allowed;
 }
 
+.optionSelected,
+.optionSelected:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+
 .freeInput {
   width: 100%;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.submit {
+  align-self: stretch;
+  padding: 0.75rem 1rem;
+  font-family: var(--font-display);
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--bg);
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.submit:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .input {

--- a/apps/web/src/components/ClarificationCard.module.css
+++ b/apps/web/src/components/ClarificationCard.module.css
@@ -110,6 +110,18 @@
   width: 100%;
 }
 
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .actions {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/components/ClarificationCard.tsx
+++ b/apps/web/src/components/ClarificationCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import type { ParseAmbiguity, ParsedFlightQuery } from '@/lib/scraper/parse-query';
 import styles from './ClarificationCard.module.css';
 
@@ -13,11 +13,13 @@ export function ClarificationCard({
 }: {
   ambiguities: ParseAmbiguity[];
   partialParsed: ParsedFlightQuery | null;
-  onAnswer: (answer: string) => void;
+  onAnswer: (answer: string) => Promise<boolean>;
   onReset: () => void;
   loading: boolean;
 }) {
   const [answers, setAnswers] = useState<Record<number, string>>({});
+  const submittingRef = useRef(false);
+  const baseId = useId();
 
   const setAnswer = (index: number, value: string) => {
     setAnswers((prev) => ({ ...prev, [index]: value }));
@@ -25,13 +27,18 @@ export function ClarificationCard({
 
   const allAnswered = ambiguities.every((_, i) => (answers[i] ?? '').trim() !== '');
 
-  const handleSubmit = () => {
-    if (!allAnswered || loading) return;
-    const combined = ambiguities
-      .map((amb, i) => `${amb.question} ${answers[i]!.trim()}`)
-      .join('\n');
-    setAnswers({});
-    onAnswer(combined);
+  const handleSubmit = async () => {
+    if (submittingRef.current || !allAnswered || loading) return;
+    submittingRef.current = true;
+    try {
+      const combined = ambiguities
+        .map((_, i) => answers[i]!.trim())
+        .join('\n');
+      const ok = await onAnswer(combined);
+      if (ok) setAnswers({});
+    } finally {
+      submittingRef.current = false;
+    }
   };
 
   return (
@@ -51,12 +58,18 @@ export function ClarificationCard({
           const hasOptions = !!(amb.options && amb.options.length > 0);
           const matchesOption = hasOptions && amb.options!.includes(current);
           const textValue = matchesOption ? '' : current;
+          const questionId = `${baseId}-q${i}`;
+          const inputId = `${baseId}-input${i}`;
 
           return (
             <div key={i} className={styles.question}>
-              <p className={styles.questionText}>{amb.question}</p>
+              <p id={questionId} className={styles.questionText}>{amb.question}</p>
               {hasOptions && (
-                <div className={styles.options}>
+                <div
+                  className={styles.options}
+                  role="group"
+                  aria-labelledby={questionId}
+                >
                   {amb.options!.map((opt) => {
                     const selected = current === opt;
                     return (
@@ -66,6 +79,7 @@ export function ClarificationCard({
                         className={`${styles.option} ${selected ? styles.optionSelected : ''}`}
                         onClick={() => setAnswer(i, opt)}
                         disabled={loading}
+                        aria-pressed={selected}
                       >
                         {opt}
                       </button>
@@ -73,7 +87,11 @@ export function ClarificationCard({
                   })}
                 </div>
               )}
+              <label htmlFor={inputId} className={styles.visuallyHidden}>
+                {amb.question}
+              </label>
               <input
+                id={inputId}
                 type="text"
                 className={styles.input}
                 placeholder={hasOptions ? 'Or type your answer...' : 'Type your answer...'}
@@ -81,10 +99,11 @@ export function ClarificationCard({
                 onChange={(e) => setAnswer(i, e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && allAnswered && !loading) {
-                    handleSubmit();
+                    void handleSubmit();
                   }
                 }}
                 disabled={loading}
+                aria-labelledby={questionId}
               />
             </div>
           );

--- a/apps/web/src/components/ClarificationCard.tsx
+++ b/apps/web/src/components/ClarificationCard.tsx
@@ -17,13 +17,21 @@ export function ClarificationCard({
   onReset: () => void;
   loading: boolean;
 }) {
-  const [freeText, setFreeText] = useState('');
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+
+  const setAnswer = (index: number, value: string) => {
+    setAnswers((prev) => ({ ...prev, [index]: value }));
+  };
+
+  const allAnswered = ambiguities.every((_, i) => (answers[i] ?? '').trim() !== '');
 
   const handleSubmit = () => {
-    const trimmed = freeText.trim();
-    if (!trimmed) return;
-    setFreeText('');
-    onAnswer(trimmed);
+    if (!allAnswered || loading) return;
+    const combined = ambiguities
+      .map((amb, i) => `${amb.question} ${answers[i]!.trim()}`)
+      .join('\n');
+    setAnswers({});
+    onAnswer(combined);
   };
 
   return (
@@ -38,42 +46,69 @@ export function ClarificationCard({
       )}
 
       <div className={styles.questions}>
-        {ambiguities.map((amb, i) => (
-          <div key={i} className={styles.question}>
-            <p className={styles.questionText}>{amb.question}</p>
-            {amb.options && amb.options.length > 0 && (
-              <div className={styles.options}>
-                {amb.options.map((opt) => (
-                  <button
-                    key={opt}
-                    className={styles.option}
-                    onClick={() => onAnswer(opt)}
-                    disabled={loading}
-                  >
-                    {opt}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        ))}
+        {ambiguities.map((amb, i) => {
+          const current = answers[i] ?? '';
+          const hasOptions = !!(amb.options && amb.options.length > 0);
+          const matchesOption = hasOptions && amb.options!.includes(current);
+          const textValue = matchesOption ? '' : current;
+
+          return (
+            <div key={i} className={styles.question}>
+              <p className={styles.questionText}>{amb.question}</p>
+              {hasOptions && (
+                <div className={styles.options}>
+                  {amb.options!.map((opt) => {
+                    const selected = current === opt;
+                    return (
+                      <button
+                        key={opt}
+                        type="button"
+                        className={`${styles.option} ${selected ? styles.optionSelected : ''}`}
+                        onClick={() => setAnswer(i, opt)}
+                        disabled={loading}
+                      >
+                        {opt}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+              <input
+                type="text"
+                className={styles.input}
+                placeholder={hasOptions ? 'Or type your answer...' : 'Type your answer...'}
+                value={textValue}
+                onChange={(e) => setAnswer(i, e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && allAnswered && !loading) {
+                    handleSubmit();
+                  }
+                }}
+                disabled={loading}
+              />
+            </div>
+          );
+        })}
       </div>
 
-      <div className={styles.freeInput}>
-        <input
-          type="text"
-          className={styles.input}
-          placeholder="Or type your answer..."
-          value={freeText}
-          onChange={(e) => setFreeText(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && !loading && handleSubmit()}
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={styles.submit}
+          onClick={handleSubmit}
+          disabled={loading || !allAnswered}
+        >
+          {loading ? 'Submitting...' : 'Submit answers'}
+        </button>
+        <button
+          type="button"
+          className={styles.resetLink}
+          onClick={onReset}
           disabled={loading}
-        />
+        >
+          Start over
+        </button>
       </div>
-
-      <button className={styles.resetLink} onClick={onReset} disabled={loading}>
-        Start over
-      </button>
     </div>
   );
 }

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -13,8 +13,14 @@ import { FlightPicker, type RouteFlights } from './FlightPicker';
 import { LinkBanner, type CreatedTracker } from './LinkBanner';
 import { ManualEntryForm, type ManualFormValues } from './ManualEntryForm';
 
-const PREVIEW_STORAGE_KEY = 'ft-preview-run';
+const PREVIEW_STORAGE_KEY_BASE = 'ft-preview-run';
 const PREVIEW_POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+function previewStorageKey(surface: SearchSurface): string {
+  return surface === 'admin' ? `${PREVIEW_STORAGE_KEY_BASE}-admin` : PREVIEW_STORAGE_KEY_BASE;
+}
+
+export type SearchSurface = 'public' | 'admin';
 
 interface SavedPreviewState {
   previewRunId: string;
@@ -48,11 +54,11 @@ function playNotificationSound() {
   }
 }
 
-function readSavedPreview(): SavedPreviewState | null {
+function readSavedPreview(key: string): SavedPreviewState | null {
   if (typeof window === 'undefined') return null;
 
   try {
-    const raw = window.sessionStorage.getItem(PREVIEW_STORAGE_KEY);
+    const raw = window.sessionStorage.getItem(key);
     if (!raw) return null;
     return JSON.parse(raw) as SavedPreviewState;
   } catch {
@@ -60,27 +66,34 @@ function readSavedPreview(): SavedPreviewState | null {
   }
 }
 
-function writeSavedPreview(state: SavedPreviewState) {
+function writeSavedPreview(key: string, state: SavedPreviewState) {
   if (typeof window === 'undefined') return;
 
   try {
-    window.sessionStorage.setItem(PREVIEW_STORAGE_KEY, JSON.stringify(state));
+    window.sessionStorage.setItem(key, JSON.stringify(state));
   } catch {
     // Ignore storage errors
   }
 }
 
-function clearSavedPreview() {
+function clearSavedPreview(key: string) {
   if (typeof window === 'undefined') return;
 
   try {
-    window.sessionStorage.removeItem(PREVIEW_STORAGE_KEY);
+    window.sessionStorage.removeItem(key);
   } catch {
     // Ignore storage errors
   }
 }
 
-export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
+export function SearchBar({
+  initialQuery,
+  surface = 'public',
+}: {
+  initialQuery?: string;
+  surface?: SearchSurface;
+} = {}) {
+  const storageKey = previewStorageKey(surface);
   const [query, setQuery] = useState(initialQuery ?? '');
   const [parsed, setParsed] = useState<ParsedQuery | null>(null);
   const [loading, setLoading] = useState(false);
@@ -119,7 +132,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
   }, []);
 
   useEffect(() => {
-    const saved = readSavedPreview();
+    const saved = readSavedPreview(storageKey);
     if (!saved) return;
 
     setParsed(saved.parsed);
@@ -128,9 +141,9 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setVpnCountries(saved.vpnCountries);
     setPreviewRunId(saved.previewRunId);
     setPreviewLoading(true);
-  }, []);
+  }, [storageKey]);
 
-  const doParse = useCallback(async (input: string, history: ConversationMessage[]) => {
+  const doParse = useCallback(async (input: string, history: ConversationMessage[]): Promise<boolean> => {
     setLoading(true);
     setError(null);
 
@@ -148,7 +161,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
 
       if (!data.ok) {
         setError(data.error || 'Failed to parse query');
-        return;
+        return false;
       }
 
       const { parsed: nextParsed, confidence, ambiguities: nextAmbiguities } = data.data;
@@ -171,8 +184,10 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
           'Can you be more specific?';
         setConversation((prev) => [...prev, { role: 'assistant', content: assistantMsg }]);
       }
+      return true;
     } catch {
       setError('Network error - please try again');
+      return false;
     } finally {
       setLoading(false);
     }
@@ -195,18 +210,18 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
           setError(data.error || 'Failed to search flights');
           setPreviewLoading(false);
           setPreviewRunId(null);
-          clearSavedPreview();
+          clearSavedPreview(storageKey);
           return;
         }
 
         const preview = data.data as PreviewRunStatusPayload;
-        const saved = readSavedPreview();
+        const saved = readSavedPreview(storageKey);
 
         if (saved && Date.now() - saved.startedAt > PREVIEW_POLL_TIMEOUT_MS) {
           setError('Flight search took too long. Please try again.');
           setPreviewLoading(false);
           setPreviewRunId(null);
-          clearSavedPreview();
+          clearSavedPreview(storageKey);
           return;
         }
 
@@ -215,7 +230,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
           setPreviewRoutes(preview.result.routes);
           setPreviewLoading(false);
           setPreviewRunId(null);
-          clearSavedPreview();
+          clearSavedPreview(storageKey);
           return;
         }
 
@@ -223,7 +238,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
           setError(preview.error || 'Failed to search flights');
           setPreviewLoading(false);
           setPreviewRunId(null);
-          clearSavedPreview();
+          clearSavedPreview(storageKey);
           return;
         }
 
@@ -243,7 +258,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
         window.clearTimeout(timer);
       }
     };
-  }, [previewRunId, parsed]);
+  }, [previewRunId, parsed, storageKey]);
 
   const handleParse = useCallback(async () => {
     const trimmed = query.trim();
@@ -259,15 +274,15 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setCreatedTrackers(null);
     setManualRawInput('');
     setManualFormValues(null);
-    clearSavedPreview();
+    clearSavedPreview(storageKey);
 
     await doParse(trimmed, []);
-  }, [query, doParse]);
+  }, [query, doParse, storageKey]);
 
-  const handleAnswer = useCallback(async (answer: string) => {
+  const handleAnswer = useCallback(async (answer: string): Promise<boolean> => {
     const newConversation: ConversationMessage[] = [...conversation, { role: 'user', content: answer }];
     setConversation(newConversation);
-    await doParse(answer, conversation);
+    return doParse(answer, conversation);
   }, [conversation, doParse]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -306,7 +321,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
       }
 
       setPreviewRunId(nextPreviewRunId);
-      writeSavedPreview({
+      writeSavedPreview(storageKey, {
         previewRunId: nextPreviewRunId,
         parsed,
         query,
@@ -397,7 +412,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
       })));
 
       setPreviewRunId(null);
-      clearSavedPreview();
+      clearSavedPreview(storageKey);
     } catch {
       setError('Network error - please try again');
     } finally {
@@ -408,7 +423,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
   const handleBackFromPicker = () => {
     setPreviewRoutes(null);
     setPreviewRunId(null);
-    clearSavedPreview();
+    clearSavedPreview(storageKey);
   };
 
   const [editingValues, setEditingValues] = useState<ManualFormValues | null>(null);
@@ -428,7 +443,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setManualFormValues(null);
     setVpnCountries([]);
     setEditingValues(null);
-    clearSavedPreview();
+    clearSavedPreview(storageKey);
     inputRef.current?.focus();
   };
 
@@ -443,7 +458,7 @@ export function SearchBar({ initialQuery }: { initialQuery?: string } = {}) {
     setPreviewLoading(false);
     setPreviewRunId(null);
     setCreatedTrackers(null);
-    clearSavedPreview();
+    clearSavedPreview(storageKey);
 
     if (wasManual) {
       setEditingValues(manualFormValues);


### PR DESCRIPTION
## Summary

- Adds an **/admin/search** page that runs the same flow as `fairtrail` on the CLI (parse natural-language query → clarify → preview Google Flights → pick flights → track) by reusing the existing `SearchBar` component. A Search entry is added to `DashboardNav` (visible in both self-hosted and hosted modes).
- Fixes `ClarificationCard` so multiple clarifying questions from the parser can all be answered before submitting. Previously, clicking an option button for the first question called `onAnswer` immediately, submitting only that one answer and skipping the remaining questions. Now answers are collected per-question (option pill or per-question free-text) and combined into one reply on Submit, so the LLM sees an answer to every question it asked.

## Test plan

- [ ] Log into `/admin`, click the new "Search" nav item, run a full search → confirm → preview → pick flights → track flow, and verify the query shows up in `/admin/queries`.
- [ ] Enter a deliberately ambiguous query (e.g. `NYC to Paris sometime soon`) so the parser returns multiple questions; verify clicking an option highlights it without submitting, the text input works as a fallback per question, and "Submit answers" only enables once every question is answered.
- [ ] Run `npm run lint` — passes.