### PR TITLE
fix: fully-qualify image refs for podman compatibility (refs #55)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS deps
+FROM docker.io/library/node:22-alpine AS deps
 RUN apk add --no-cache libc6-compat openssl python3 make g++
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -8,7 +8,7 @@ RUN npm ci --loglevel=error
 RUN npx prisma generate --schema=apps/web/prisma/schema.prisma
 
 # Production-only deps (no devDependencies)
-FROM node:22-alpine AS proddeps
+FROM docker.io/library/node:22-alpine AS proddeps
 RUN apk add --no-cache libc6-compat openssl python3 make g++
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -17,7 +17,7 @@ COPY apps/web/prisma ./apps/web/prisma/
 RUN npm ci --omit=dev --loglevel=error
 RUN npx prisma generate --schema=apps/web/prisma/schema.prisma
 
-FROM node:22-alpine AS builder
+FROM docker.io/library/node:22-alpine AS builder
 RUN apk add --no-cache libc6-compat openssl python3 make g++
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
@@ -28,7 +28,7 @@ ENV NODE_ENV=production
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
 RUN npm run build --workspace=@fairtrail/web
 
-FROM node:22-alpine AS runner
+FROM docker.io/library/node:22-alpine AS runner
 RUN apk add --no-cache libc6-compat openssl chromium
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -245,7 +245,7 @@ fi
 cat > "$FAIRTRAIL_DIR/docker-compose.yml" << COMPOSE
 services:
   db:
-    image: postgres:16-alpine
+    image: docker.io/library/postgres:16-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: fairtrail
@@ -262,7 +262,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: docker.io/library/redis:7-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data
@@ -552,7 +552,7 @@ if [ "$SETUP_VPN" = "y" ] || [ "$SETUP_VPN" = "Y" ]; then
     cat > "$FAIRTRAIL_DIR/docker-compose.vpn.yml" << 'VPNYAML'
 services:
   expressvpn:
-    image: misioslav/expressvpn:latest
+    image: docker.io/misioslav/expressvpn:latest
     container_name: fairtrail-expressvpn
     restart: unless-stopped
     cap_add:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16-alpine
+    image: docker.io/library/postgres:16-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: fairtrail
@@ -12,7 +12,7 @@ services:
       - "127.0.0.1:5433:5432"
 
   redis:
-    image: redis:7-alpine
+    image: docker.io/library/redis:7-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/docker-compose.test-vpn.yml
+++ b/docker-compose.test-vpn.yml
@@ -13,7 +13,7 @@
 
 services:
   db:
-    image: postgres:16-alpine
+    image: docker.io/library/postgres:16-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: fairtrail
@@ -28,7 +28,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: docker.io/library/redis:7-alpine
     restart: unless-stopped
     volumes:
       - vpntest-redisdata:/data

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,7 +15,7 @@ services:
       - "127.0.0.1:6399:6379"
 
   llmock:
-    image: node:22-alpine
+    image: docker.io/library/node:22-alpine
     restart: "no"
     volumes:
       - ./scripts/llmock-server.mjs:/app/llmock-server.mjs:ro

--- a/docker-compose.vpn.yml
+++ b/docker-compose.vpn.yml
@@ -16,7 +16,7 @@
 
 services:
   expressvpn:
-    image: misioslav/expressvpn:latest
+    image: docker.io/misioslav/expressvpn:latest
     container_name: fairtrail-expressvpn
     restart: unless-stopped
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 
 services:
   db:
-    image: postgres:16-alpine
+    image: docker.io/library/postgres:16-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: fairtrail
@@ -24,7 +24,7 @@ services:
   # Redis is optional — improves performance with response caching.
   # Comment out this service and unset REDIS_URL in .env to run without it.
   redis:
-    image: redis:7-alpine
+    image: docker.io/library/redis:7-alpine
     restart: unless-stopped
     volumes:
       - redisdata:/data

--- a/scripts/docker-compose.integration.yml
+++ b/scripts/docker-compose.integration.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16-alpine
+    image: docker.io/library/postgres:16-alpine
     environment:
       POSTGRES_DB: fairtrail
       POSTGRES_USER: postgres
@@ -12,7 +12,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:7-alpine
+    image: docker.io/library/redis:7-alpine
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 3s


### PR DESCRIPTION
## Summary

- Replace short-form image references (`postgres:16-alpine`, `redis:7-alpine`, `node:22-alpine`, `misioslav/expressvpn:latest`) with fully-qualified ones (`docker.io/library/...`, `docker.io/misioslav/...`) across all compose files, the install.sh inlined compose, and Dockerfile `FROM` lines.
- Local-built tags (`fairtrail:vpn-test`, `fairtrail-test:latest`) and `ghcr.io/affromero/fairtrail` were already fine and were left untouched.

## Why

Podman with `short-name-mode=enforcing` (Fedora's default in `/etc/containers/registries.conf`) cannot resolve unqualified image names without a TTY prompt. In non-interactive `up -d` runs (and the install.sh flow), this fails with:

```
Error: short-name resolution enforced but cannot prompt without a TTY
Error: "fairtrail_db_1" is not a valid container, cannot be used as a dependency
```

Reported in #55. The reporter worked around it by switching their podman config to `permissive`, but that requires `sudo` and edits a system file. Fully-qualifying the refs lets podman skip short-name resolution entirely, so installs work out of the box.

Docker users are unaffected (it has always assumed `docker.io/library/` for unqualified names).

## Test plan

- [ ] `npm run ci` (lint + typecheck + build) — passed locally
- [ ] Verify on Fedora + podman that `~/.fairtrail/install.sh` completes without `short-name resolution enforced` errors
- [ ] Verify on Docker that `docker compose -f docker-compose.prod.yml up -d` still pulls and runs the same images

Refs #55.
