### PR TITLE
fix: clarification loop and stacked dialog history (refs #54)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,9 @@
   "devDependencies": {
     "@copilotkit/llmock": "^1.3.1",
     "@eslint/js": "^9.39.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/geoip-lite": "^1.4.4",
     "@types/node": "^22.13.10",
@@ -40,6 +43,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.22.0",
     "eslint-config-next": "^15.2.3",
+    "jsdom": "^29.0.2",
     "prisma": "^6.4.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.56.1",

--- a/apps/web/src/components/ClarificationCard.module.css
+++ b/apps/web/src/components/ClarificationCard.module.css
@@ -49,6 +49,50 @@
   margin-left: 0.25rem;
 }
 
+.history {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.turn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+
+.assistantTurn {
+  background: var(--elevated);
+  align-self: flex-start;
+  max-width: 90%;
+}
+
+.userTurn {
+  background: var(--accent-glow);
+  align-self: flex-end;
+  max-width: 90%;
+}
+
+.turnLabel {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.turnContent {
+  color: var(--text);
+  white-space: pre-wrap;
+}
+
 .questions {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/components/ClarificationCard.test.tsx
+++ b/apps/web/src/components/ClarificationCard.test.tsx
@@ -1,0 +1,108 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ClarificationCard } from './ClarificationCard';
+import type { ParseAmbiguity, ParsedFlightQuery } from '@/lib/scraper/parse-query';
+import type { ConversationMessage } from '@/lib/clarification-types';
+
+function makeAmbiguities(): ParseAmbiguity[] {
+  return [
+    {
+      field: 'date',
+      question: "That's a 9-day return window. Pick a specific return date or narrow the range.",
+    },
+  ];
+}
+
+function makePartial(): ParsedFlightQuery {
+  return {
+    origin: 'JFK',
+    originName: 'JFK',
+    destination: 'LAX',
+    destinationName: 'LAX',
+    origins: [{ code: 'JFK', name: 'JFK' }],
+    destinations: [{ code: 'LAX', name: 'LAX' }],
+    dateFrom: '2026-03-01',
+    dateTo: '2026-03-25',
+    flexibility: 0,
+    maxPrice: null,
+    maxStops: null,
+    preferredAirlines: [],
+    timePreference: 'any',
+    cabinClass: 'economy',
+    tripType: 'round_trip',
+    currency: null,
+  };
+}
+
+describe('ClarificationCard', () => {
+  it('renders the active question without history when conversation is empty', () => {
+    render(
+      <ClarificationCard
+        ambiguities={makeAmbiguities()}
+        partialParsed={makePartial()}
+        onAnswer={vi.fn().mockResolvedValue(true)}
+        onReset={vi.fn()}
+        loading={false}
+      />,
+    );
+
+    // The active question appears in the form (visible <p> + visually-hidden <label>).
+    expect(screen.getAllByText(/9-day return window/).length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText('Clarification history')).not.toBeInTheDocument();
+  });
+
+  it('renders prior turns above the active question and excludes the active turn', () => {
+    const conversation: ConversationMessage[] = [
+      { role: 'user', content: 'JFK to LAX March 1, return March 15-27' },
+      { role: 'assistant', content: 'That was a 12-day window. Narrow it down.' },
+      { role: 'user', content: 'March 15-21' },
+      // The active question, which should be excluded from history.
+      { role: 'assistant', content: "That's a 9-day return window. Pick a specific return date or narrow the range." },
+    ];
+
+    render(
+      <ClarificationCard
+        ambiguities={makeAmbiguities()}
+        partialParsed={makePartial()}
+        conversation={conversation}
+        onAnswer={vi.fn().mockResolvedValue(true)}
+        onReset={vi.fn()}
+        loading={false}
+      />,
+    );
+
+    const history = screen.getByLabelText('Clarification history');
+    expect(history).toBeInTheDocument();
+
+    // History should include the prior turns.
+    expect(screen.getByText(/12-day window/)).toBeInTheDocument();
+    expect(screen.getByText('March 15-21')).toBeInTheDocument();
+    expect(screen.getByText('JFK to LAX March 1, return March 15-27')).toBeInTheDocument();
+
+    // Active question must NOT appear inside the history block (it's only in the active form).
+    expect(history.textContent).not.toMatch(/9-day return window/);
+  });
+
+  it('submits the typed answer when the user clicks submit', async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn().mockResolvedValue(true);
+
+    render(
+      <ClarificationCard
+        ambiguities={makeAmbiguities()}
+        partialParsed={makePartial()}
+        onAnswer={onAnswer}
+        onReset={vi.fn()}
+        loading={false}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(/type your answer/i);
+    await user.type(input, 'March 17');
+    await user.click(screen.getByRole('button', { name: /submit answers/i }));
+
+    expect(onAnswer).toHaveBeenCalledWith('March 17');
+  });
+});

--- a/apps/web/src/components/ClarificationCard.tsx
+++ b/apps/web/src/components/ClarificationCard.tsx
@@ -2,17 +2,41 @@
 
 import { useId, useRef, useState } from 'react';
 import type { ParseAmbiguity, ParsedFlightQuery } from '@/lib/scraper/parse-query';
+import type { ConversationMessage } from '@/lib/clarification-types';
 import styles from './ClarificationCard.module.css';
+
+/**
+ * Strip the trailing assistant turns that correspond to the active questions —
+ * those are rendered as the live form below, not duplicated in history.
+ */
+function priorTurns(
+  conversation: ConversationMessage[],
+  activeQuestions: string[],
+): ConversationMessage[] {
+  if (!conversation.length || !activeQuestions.length) return conversation;
+  const activeSet = new Set(activeQuestions);
+  let endIdx = conversation.length;
+  while (
+    endIdx > 0 &&
+    conversation[endIdx - 1]!.role === 'assistant' &&
+    activeSet.has(conversation[endIdx - 1]!.content)
+  ) {
+    endIdx -= 1;
+  }
+  return conversation.slice(0, endIdx);
+}
 
 export function ClarificationCard({
   ambiguities,
   partialParsed,
+  conversation = [],
   onAnswer,
   onReset,
   loading,
 }: {
   ambiguities: ParseAmbiguity[];
   partialParsed: ParsedFlightQuery | null;
+  conversation?: ConversationMessage[];
   onAnswer: (answer: string) => Promise<boolean>;
   onReset: () => void;
   loading: boolean;
@@ -41,6 +65,8 @@ export function ClarificationCard({
     }
   };
 
+  const history = priorTurns(conversation, ambiguities.map((a) => a.question));
+
   return (
     <div className={styles.root}>
       {partialParsed && (
@@ -49,6 +75,22 @@ export function ClarificationCard({
           <span className={styles.arrow}>→</span>
           <span className={styles.code}>{partialParsed.destination}</span>
           <span className={styles.narrowing}>narrowing...</span>
+        </div>
+      )}
+
+      {history.length > 0 && (
+        <div className={styles.history} aria-label="Clarification history">
+          {history.map((turn, i) => (
+            <div
+              key={`${i}-${turn.role}`}
+              className={`${styles.turn} ${turn.role === 'assistant' ? styles.assistantTurn : styles.userTurn}`}
+            >
+              <span className={styles.turnLabel}>
+                {turn.role === 'assistant' ? 'Fairtrail' : 'You'}
+              </span>
+              <span className={styles.turnContent}>{turn.content}</span>
+            </div>
+          ))}
         </div>
       )}
 

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import type { ParseAmbiguity, ParsedFlightQuery } from '@/lib/scraper/parse-query';
+import type { ConversationMessage } from '@/lib/clarification-types';
 import type { PreviewRunStatusPayload } from '@/lib/preview-run';
 import type { PriceData } from '@/lib/scraper/extract-prices';
 import { detectLocaleCurrency } from '@/lib/currency';
@@ -29,11 +30,6 @@ interface SavedPreviewState {
   manualRawInput: string;
   vpnCountries: string[];
   startedAt: number;
-}
-
-interface ConversationMessage {
-  role: 'user' | 'assistant';
-  content: string;
 }
 
 function playNotificationSound() {
@@ -179,10 +175,16 @@ export function SearchBar({
         setAmbiguities(nextAmbiguities || []);
         setPartialParsed(nextParsed);
 
-        const assistantMsg =
-          nextAmbiguities?.map((ambiguity: ParseAmbiguity) => ambiguity.question).join(' ') ||
-          'Can you be more specific?';
-        setConversation((prev) => [...prev, { role: 'assistant', content: assistantMsg }]);
+        // Store one assistant turn per question so the stacked dialog renders
+        // each as its own bubble. Fall back to a single placeholder turn when
+        // the LLM gave no questions.
+        const assistantTurns: ConversationMessage[] = nextAmbiguities?.length
+          ? nextAmbiguities.map((ambiguity: ParseAmbiguity) => ({
+              role: 'assistant' as const,
+              content: ambiguity.question,
+            }))
+          : [{ role: 'assistant' as const, content: 'Can you be more specific?' }];
+        setConversation((prev) => [...prev, ...assistantTurns]);
       }
       return true;
     } catch {
@@ -282,6 +284,9 @@ export function SearchBar({
   const handleAnswer = useCallback(async (answer: string): Promise<boolean> => {
     const newConversation: ConversationMessage[] = [...conversation, { role: 'user', content: answer }];
     setConversation(newConversation);
+    // Pass the updated history (including the just-added user turn minus the
+    // raw answer string itself, since doParse re-appends it) so the LLM sees
+    // every prior turn — not the stale pre-answer slice.
     return doParse(answer, conversation);
   }, [conversation, doParse]);
 
@@ -608,6 +613,7 @@ export function SearchBar({
         <ClarificationCard
           ambiguities={ambiguities}
           partialParsed={partialParsed}
+          conversation={conversation}
           onAnswer={handleAnswer}
           onReset={handleReset}
           loading={loading}

--- a/apps/web/src/lib/clarification-types.ts
+++ b/apps/web/src/lib/clarification-types.ts
@@ -1,0 +1,4 @@
+export interface ConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}

--- a/apps/web/src/lib/scraper/parse-query.test.ts
+++ b/apps/web/src/lib/scraper/parse-query.test.ts
@@ -315,6 +315,199 @@ describe('parseFlightQuery', () => {
     await expect(parseFlightQuery('JFK to LAX')).rejects.toThrow('Unknown extraction provider');
   });
 
+  it('keeps round-trip with two pinned legs at high confidence even when trip spans 21 days', async () => {
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'JFK' }],
+          destinations: [{ code: 'LAX', name: 'LAX' }],
+          dateFrom: '2026-03-01',
+          dateTo: '2026-03-22',
+          outboundDates: ['2026-03-01'],
+          returnDates: ['2026-03-22'],
+          flexibility: 0,
+          maxPrice: null,
+          maxStops: null,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    const { response } = await parseFlightQuery('JFK to LAX March 1, return March 22');
+    expect(response.confidence).toBe('high');
+    expect(response.dateSpanDays).toBe(21);
+    expect(response.ambiguities).toEqual([]);
+  });
+
+  it('downgrades round-trip with wide outbound window and names the outbound leg', async () => {
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'JFK' }],
+          destinations: [{ code: 'LAX', name: 'LAX' }],
+          dateFrom: '2026-03-01',
+          dateTo: '2026-03-25',
+          outboundDates: ['2026-03-01', '2026-03-11'],
+          returnDates: ['2026-03-25'],
+          flexibility: 0,
+          maxPrice: null,
+          maxStops: null,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    const { response } = await parseFlightQuery('JFK to LAX March 1-11 out, March 25 return');
+    expect(response.confidence).toBe('medium');
+    const outboundAmbiguity = response.ambiguities.find((a) => /outbound/i.test(a.question));
+    expect(outboundAmbiguity).toBeDefined();
+    expect(response.ambiguities.find((a) => /return/i.test(a.question))).toBeUndefined();
+  });
+
+  it('downgrades round-trip with wide return window and names the return leg', async () => {
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'JFK' }],
+          destinations: [{ code: 'LAX', name: 'LAX' }],
+          dateFrom: '2026-03-01',
+          dateTo: '2026-03-25',
+          outboundDates: ['2026-03-01'],
+          returnDates: ['2026-03-15', '2026-03-27'],
+          flexibility: 0,
+          maxPrice: null,
+          maxStops: null,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    const { response } = await parseFlightQuery('JFK to LAX March 1, return March 15-27');
+    expect(response.confidence).toBe('medium');
+    const returnAmbiguity = response.ambiguities.find((a) => /return/i.test(a.question));
+    expect(returnAmbiguity).toBeDefined();
+    expect(response.ambiguities.find((a) => /outbound/i.test(a.question))).toBeUndefined();
+  });
+
+  it('caps each leg at 4 dates when both legs are ranges', async () => {
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'JFK' }],
+          destinations: [{ code: 'LAX', name: 'LAX' }],
+          dateFrom: '2026-03-01',
+          dateTo: '2026-03-25',
+          outboundDates: ['2026-03-01', '2026-03-02', '2026-03-03', '2026-03-04', '2026-03-05', '2026-03-06'],
+          returnDates: ['2026-03-20', '2026-03-21', '2026-03-22', '2026-03-23', '2026-03-24', '2026-03-25'],
+          flexibility: 0,
+          maxPrice: null,
+          maxStops: null,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    const { response } = await parseFlightQuery('JFK to LAX March 1-6 out, March 20-25 return');
+    expect(response.parsed?.outboundDates).toHaveLength(4);
+    expect(response.parsed?.returnDates).toHaveLength(4);
+  });
+
+  it('keeps 6-date cap when only one leg is a range', async () => {
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'JFK' }],
+          destinations: [{ code: 'LAX', name: 'LAX' }],
+          dateFrom: '2026-03-01',
+          dateTo: '2026-03-25',
+          outboundDates: ['2026-03-01', '2026-03-02', '2026-03-03', '2026-03-04', '2026-03-05', '2026-03-06', '2026-03-07'],
+          returnDates: ['2026-03-25'],
+          flexibility: 0,
+          maxPrice: null,
+          maxStops: null,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    const { response } = await parseFlightQuery('JFK to LAX any of first week, return March 25');
+    expect(response.parsed?.outboundDates).toHaveLength(6);
+    expect(response.parsed?.returnDates).toHaveLength(1);
+  });
+
+  it('caps conversation history sent to the LLM at the most recent 6 turns', async () => {
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'JFK' }],
+          destinations: [{ code: 'LAX', name: 'LAX' }],
+          dateFrom: '2026-06-15',
+          dateTo: '2026-06-22',
+          flexibility: 0,
+          maxPrice: null,
+          maxStops: null,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    const longHistory = Array.from({ length: 12 }, (_, i) => ({
+      role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+      content: `turn-${i}`,
+    }));
+
+    await parseFlightQuery('latest answer', longHistory);
+
+    const promptArg = mockExtract.mock.calls[0]?.[3] as string;
+    expect(promptArg).toContain('turn-11');
+    expect(promptArg).toContain('turn-6');
+    expect(promptArg).not.toContain('turn-5');
+    expect(promptArg).not.toContain('turn-0');
+    expect(promptArg.endsWith('User: latest answer')).toBe(true);
+  });
+
   it('throws when api key is missing', async () => {
     const { prisma } = await import('@/lib/prisma');
     vi.mocked(prisma.extractionConfig.findFirst).mockResolvedValueOnce({

--- a/apps/web/src/lib/scraper/parse-query.ts
+++ b/apps/web/src/lib/scraper/parse-query.ts
@@ -95,9 +95,9 @@ Multi-airport rules (same city, different airports):
 - Put the most common/major airport first in the array (it becomes the default)
 
 Confidence rules:
-- "high": clear origin, destination, and specific date(s) within 14 days span
-- "medium": mostly clear but one ambiguity (e.g., city has multiple airports, or 2-3 possible dates mentioned)
-- "low": too vague (no dates, unclear cities, date range > 14 days, or missing origin/destination)
+- "high": clear origin, destination, and specific date(s) within 14 days span. For round trips with both legs pinned (one or a few dates per leg, each leg's window ≤ 7 days), the trip itself can be any length — only the per-leg flexibility matters.
+- "medium": mostly clear but one ambiguity (e.g., city has multiple airports, 2-3 possible dates mentioned, or one leg of a round trip has a window > 7 days while the other is pinned)
+- "low": too vague (no dates, unclear cities, date range > 14 days for one-way, both legs of a round trip wide open, or missing origin/destination)
 
 When confidence is "medium" or "low":
 - Still fill in "parsed" with your best guess for ALL fields you can determine
@@ -106,6 +106,9 @@ When confidence is "medium" or "low":
   - { "field": "date", "question": "Did you mean Friday Mar 14 or Saturday Mar 15?", "options": ["Friday Mar 14", "Saturday Mar 15", "Both days"] }
   - { "field": "origin", "question": "Which New York airport?", "options": ["JFK", "EWR", "LGA"] }
   - { "field": "date", "question": "That's a 30-day window. Can you narrow it to specific dates?", "options": ["First week", "Second week", "Last week"] }
+  - { "field": "date", "question": "That's a 12-day outbound window. Pick a specific outbound date or narrow the range." }
+  - { "field": "date", "question": "That's a 9-day return window. Pick a specific return date or narrow the range." }
+  - When the issue is one specific leg of a round trip, name the leg ("outbound" or "return") in the question so the user knows which window to narrow
 
 When confidence is "high":
 - Set "ambiguities" to an empty array []
@@ -115,6 +118,7 @@ Multi-date rules:
 - "returnDates": when the user mentions SPECIFIC individual return dates (e.g., "return March 22 or March 25"), populate with each date. For one-way trips, set to null.
 - When only a single date or a continuous range is mentioned (e.g., "June 15-20", "around June 15"), leave outboundDates and returnDates as null — use dateFrom/dateTo as before.
 - For round trips: if the user says "fly March 15, return March 20", set outboundDates to ["YYYY-MM-15"] and returnDates to ["YYYY-MM-20"]. If they say "fly March 15 or 16, return March 20 or 21", set outboundDates to both departure dates and returnDates to both return dates.
+- For round trips with a RANGE on each leg (e.g. "March 1-3 out, March 22-24 return", "depart sometime D1 to D2, return sometime E1 to E2"): expand each range into the individual dates and populate outboundDates with the outbound dates and returnDates with the return dates. dateFrom is the earliest outbound date (D1), dateTo is the latest return date (E2). Confidence stays "high" as long as each leg's window is at most 7 days wide. NEVER ask the user to "narrow the window from D1 to E2" — that's the trip duration, not a flexibility ambiguity.
 - Maximum 6 dates per array. If the user mentions more, pick the 6 most likely.
 
 Parsing rules:
@@ -137,6 +141,19 @@ Parsing rules:
 - Return ONLY the JSON object, no markdown, no explanation`;
 }
 
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const LEG_WINDOW_LIMIT_DAYS = 7;
+const SINGLE_RANGE_LIMIT_DAYS = 14;
+const CONVERSATION_HISTORY_LIMIT = 6;
+
+/** Span in days between the earliest and latest date in a sorted ISO date array. */
+function legSpanDays(dates: string[] | undefined): number {
+  if (!dates || dates.length < 2) return 0;
+  const first = new Date(dates[0]!).getTime();
+  const last = new Date(dates[dates.length - 1]!).getTime();
+  return Math.ceil((last - first) / MS_PER_DAY);
+}
+
 /** Normalize LLM response to always have origins/destinations arrays + derived single fields */
 function normalizeAirports(parsed: Record<string, unknown>): ParsedFlightQuery {
   const p = parsed as Record<string, unknown>;
@@ -157,13 +174,19 @@ function normalizeAirports(parsed: Record<string, unknown>): ParsedFlightQuery {
     destinations = [{ code: p.destination as string, name: (p.destinationName as string) || p.destination as string }];
   }
 
-  // Normalize outboundDates / returnDates — validate ISO date strings, cap at 6
-  const outboundDates = Array.isArray(p.outboundDates)
-    ? (p.outboundDates as string[]).filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d)).slice(0, 6).sort()
+  // Normalize outboundDates / returnDates — validate ISO date strings, sort, then cap.
+  // When both legs are ranges (>1 date each), cap at 4 per leg to stay under the
+  // scrape combo budget (preview/route.ts: combos × dates ≤ 24). Otherwise cap at 6.
+  const rawOutbound = Array.isArray(p.outboundDates)
+    ? (p.outboundDates as string[]).filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d)).sort()
     : undefined;
-  const returnDates = Array.isArray(p.returnDates)
-    ? (p.returnDates as string[]).filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d)).slice(0, 6).sort()
+  const rawReturn = Array.isArray(p.returnDates)
+    ? (p.returnDates as string[]).filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d)).sort()
     : undefined;
+  const bothLegsRanged = (rawOutbound?.length ?? 0) > 1 && (rawReturn?.length ?? 0) > 1;
+  const perLegCap = bothLegsRanged ? 4 : 6;
+  const outboundDates = rawOutbound?.slice(0, perLegCap);
+  const returnDates = rawReturn?.slice(0, perLegCap);
 
   // Derive dateFrom/dateTo from individual dates when present
   const allDates = [...(outboundDates ?? []), ...(returnDates ?? [])];
@@ -217,10 +240,12 @@ export async function parseFlightQuery(
     throw new Error(`Missing API key: ${providerConfig.envKey}`);
   }
 
-  // Build prompt with conversation history
+  // Build prompt with conversation history. Cap to the most recent turns to
+  // prevent token bloat across long clarification loops.
   let fullPrompt = rawInput;
   if (conversationHistory?.length) {
-    fullPrompt = conversationHistory
+    const recentHistory = conversationHistory.slice(-CONVERSATION_HISTORY_LIMIT);
+    fullPrompt = recentHistory
       .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`)
       .join('\n') + '\nUser: ' + rawInput;
   }
@@ -275,10 +300,36 @@ export async function parseFlightQuery(
   let dateSpanDays = 0;
   if (parsed) {
     dateSpanDays = Math.ceil(
-      (new Date(parsed.dateTo).getTime() - new Date(parsed.dateFrom).getTime()) / (1000 * 60 * 60 * 24)
+      (new Date(parsed.dateTo).getTime() - new Date(parsed.dateFrom).getTime()) / MS_PER_DAY
     );
 
-    if (dateSpanDays > 14 && confidence === 'high') {
+    // For round trips with specific dates on either leg, validate each leg's
+    // window separately. The trip duration (gap between outbound and return)
+    // is not a flexibility ambiguity, so we don't flag it.
+    const hasLegArrays =
+      (parsed.outboundDates?.length ?? 0) > 0 || (parsed.returnDates?.length ?? 0) > 0;
+    const isRoundTripWithLegs = parsed.tripType === 'round_trip' && hasLegArrays;
+
+    if (isRoundTripWithLegs) {
+      if (confidence === 'high') {
+        const outboundSpan = legSpanDays(parsed.outboundDates);
+        const returnSpan = legSpanDays(parsed.returnDates);
+        if (outboundSpan > LEG_WINDOW_LIMIT_DAYS) {
+          confidence = 'medium';
+          ambiguities.push({
+            field: 'date',
+            question: `That's a ${outboundSpan}-day outbound window. Pick a specific outbound date or narrow the range.`,
+          });
+        }
+        if (returnSpan > LEG_WINDOW_LIMIT_DAYS) {
+          confidence = 'medium';
+          ambiguities.push({
+            field: 'date',
+            question: `That's a ${returnSpan}-day return window. Pick a specific return date or narrow the range.`,
+          });
+        }
+      }
+    } else if (dateSpanDays > SINGLE_RANGE_LIMIT_DAYS && confidence === 'high') {
       confidence = 'medium';
       ambiguities.push({
         field: 'date',

--- a/apps/web/src/test/setup-dom.ts
+++ b/apps/web/src/test/setup-dom.ts
@@ -1,0 +1,12 @@
+// Only register DOM-related setup when a document exists (jsdom env).
+// Tests with `environment: 'node'` skip this file's effects entirely.
+export {};
+
+if (typeof document !== 'undefined') {
+  await import('@testing-library/jest-dom/vitest');
+  const { afterEach } = await import('vitest');
+  const { cleanup } = await import('@testing-library/react');
+  afterEach(() => {
+    cleanup();
+  });
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,10 +4,12 @@ import path from 'path';
 export default defineConfig({
   test: {
     globals: true,
+    // Default to node. .test.tsx files opt into jsdom via the
+    // `/** @vitest-environment jsdom */` directive at the top of each file.
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     globalSetup: ['src/test/llmock-setup.ts'],
-    setupFiles: ['src/test/setup.ts'],
+    setupFiles: ['src/test/setup.ts', 'src/test/setup-dom.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/lib/**/*.ts', 'src/app/api/**/*.ts'],
@@ -18,5 +20,10 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src'),
     },
+  },
+  // tsconfig uses jsx: 'preserve' for Next.js. Vitest's esbuild needs the
+  // automatic transform so React doesn't have to be imported explicitly.
+  esbuild: {
+    jsx: 'automatic',
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,9 @@
       "devDependencies": {
         "@copilotkit/llmock": "^1.3.1",
         "@eslint/js": "^9.39.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/geoip-lite": "^1.4.4",
         "@types/node": "^22.13.10",
@@ -49,11 +52,19 @@
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^9.22.0",
         "eslint-config-next": "^15.2.3",
+        "jsdom": "^29.0.2",
         "prisma": "^6.4.1",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.56.1",
         "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alcalzone/ansi-tokenize": {
       "version": "0.2.5",
@@ -98,6 +109,73 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -169,6 +247,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@choojs/findup": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
@@ -190,6 +281,146 @@
       "license": "MIT",
       "bin": {
         "llmock": "dist/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -809,6 +1040,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fairtrail/cli": {
@@ -2310,6 +2559,107 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@turf/area": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.4.tgz",
@@ -2397,6 +2747,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -3778,6 +4136,16 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-search-bounds": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
@@ -4436,6 +4804,27 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
@@ -4664,6 +5053,20 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4734,6 +5137,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -4844,6 +5254,17 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -4899,6 +5320,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -5028,6 +5457,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -6934,6 +7376,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7621,6 +8076,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7927,6 +8389,47 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -8149,6 +8652,27 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8350,6 +8874,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -8393,6 +8924,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -9046,6 +9587,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
@@ -9416,6 +9970,55 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prisma": {
       "version": "6.19.2",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
@@ -9747,6 +10350,30 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -9930,6 +10557,16 @@
         "pick-by-alias": "^1.2.0",
         "raf": "^3.4.1",
         "regl-scatter2d": "^3.2.3"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -10200,6 +10837,19 @@
       "peer": true,
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -10822,6 +11472,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -10989,6 +11652,13 @@
         "parse-svg-path": "^0.1.2",
         "svg-path-bounds": "^1.0.1"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
@@ -11196,6 +11866,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-float32": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
@@ -11251,6 +11941,32 @@
         "topo2geo": "bin/topo2geo",
         "topomerge": "bin/topomerge",
         "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -11599,6 +12315,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -12011,6 +12737,19 @@
         "pbf": "^3.2.1"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/weak-map": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
@@ -12026,6 +12765,41 @@
       "peer": true,
       "dependencies": {
         "get-canvas-context": "^1.0.1"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -12263,6 +13037,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",


### PR DESCRIPTION
## Summary

Fixes the clarification loop and dialog overwrite reported in #54 by Fenisu.

Three things were broken when a user typed a round-trip query with a date range on each leg ("D1-D2 out, E1-E2 return"):

1. The server validator computed a single span across both legs (`max(all dates) - min(all dates)`), so a 3-week vacation with both ends pinned tripped "window > 14 days" forever.
2. The clarifying question never named which leg was wide ("outbound" vs "return"), and offered "First week / Second week / Last week" options that didn't apply to a 7-day leg window.
3. Each new clarification turn replaced the previous one in the UI, so the user lost the audit trail of what was already asked and answered.

## What changed

### Server (`apps/web/src/lib/scraper/parse-query.ts`)

- New `legSpanDays()` helper. Round-trip queries with `outboundDates` and/or `returnDates` populated now validate **each leg** against a 7-day window instead of the trip duration.
- Ambiguity questions name the leg explicitly ("That's a 9-day return window. Pick a specific return date or narrow the range.").
- When both legs are date ranges (`length > 1` each), each leg is capped at 4 dates instead of 6 to stay under the existing `combos × dates ≤ 24` scrape budget in `preview/route.ts`.
- Conversation history sent to the LLM is capped at the last 6 turns to control token cost on long clarification loops (the reporter said they burned 50% of a Claude session on one query).
- System prompt: explicit Multi-date rule for "D1-D2 out, E1-E2 return" round trips, leg-specific ambiguity examples, updated confidence rules so per-leg windows are reasoned about independently.

One-way and round-trip-without-leg-arrays paths keep the prior `dateSpanDays > 14` behavior untouched.

### UI (`SearchBar.tsx`, `ClarificationCard.tsx`, CSS)

- New shared `ConversationMessage` type at `lib/clarification-types.ts` (was inline in SearchBar).
- SearchBar passes `conversation` into ClarificationCard and stores **one assistant turn per question** instead of joining them with a space, so each renders cleanly as its own bubble.
- ClarificationCard renders prior turns above the active question(s) as a stacked dialog, alternating "Fairtrail" and "You" labels. Trailing assistant turns matching the active questions are filtered out so the live form isn't duplicated in history.
- New CSS classes use existing Altitude tokens (no new variables introduced).

### Test infra

- Added `jsdom`, `@testing-library/react`, `@testing-library/jest-dom`, `@testing-library/user-event` as dev deps in `apps/web/`.
- `vitest.config.ts`: includes `.tsx`, default env still `node`, `esbuild.jsx = 'automatic'` so tests don't need a React import. Per-file tests opt into jsdom with `/** @vitest-environment jsdom */` (vitest 4 dropped `environmentMatchGlobs`).
- New `src/test/setup-dom.ts` conditionally wires up jest-dom matchers and afterEach cleanup only when `document` is defined, so node-only tests aren't affected.

## Test plan

- [x] `npm run ci` passes (lint + typecheck + 219 tests across 23 files)
- [x] New unit tests for per-leg validation in `parse-query.test.ts` (6 cases)
- [x] New component tests in `ClarificationCard.test.tsx` (3 cases)
- [ ] **Manual UI walkthrough** before merge: type "Round trip JFK to LAX, March 1-3 out, March 22-24 return" against a real LLM and verify (a) no clarification loop, (b) prior Q&A renders as a stacked dialog if any clarification turns happen.

Refs #54.
