### PR TITLE
Search and CLI feedback fixes (refs #57)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+**/node_modules
+.next
+**/.next
+dist
+**/dist
+.git
+.github
+.claude
+.venv
+**/__pycache__
+.DS_Store
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
 RUN npm run build --workspace=@fairtrail/web
+RUN npm run build --workspace=@fairtrail/cli
 
 FROM docker.io/library/node:22-alpine AS runner
 RUN apk add --no-cache libc6-compat openssl chromium
@@ -81,10 +82,18 @@ COPY --from=proddeps --chown=node:node /app/node_modules/ts-algebra ./node_modul
 COPY --from=proddeps --chown=node:node /app/node_modules/openai ./node_modules/openai
 COPY --from=proddeps --chown=node:node /app/node_modules/@google ./node_modules/@google
 
+# Ink terminal UI (fairtrail-tui). Bundle is self contained except for @prisma/client,
+# playwright, ioredis (resolved from /app/node_modules via Node's parent walk).
+COPY --from=builder --chown=node:node /app/packages/cli/dist /app/packages/cli/dist
+RUN printf '#!/bin/sh\nexec node /app/packages/cli/dist/index.js "$@"\n' > /home/node/.npm-global/bin/fairtrail-tui \
+    && chmod +x /home/node/.npm-global/bin/fairtrail-tui \
+    && chown node:node /home/node/.npm-global/bin/fairtrail-tui
+
 RUN mkdir -p /app/data && chown node:node /app/data
 
 COPY --chown=node:node docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh
 USER node
+RUN fairtrail-tui --help >/dev/null
 EXPOSE 3003
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN apk add --no-cache libc6-compat openssl python3 make g++
 WORKDIR /app
 COPY package.json package-lock.json ./
 COPY apps/web/package.json apps/web/
+COPY packages/cli/package.json packages/cli/
 COPY apps/web/prisma ./apps/web/prisma/
 RUN npm ci --loglevel=error
 RUN npx prisma generate --schema=apps/web/prisma/schema.prisma
@@ -13,6 +14,7 @@ RUN apk add --no-cache libc6-compat openssl python3 make g++
 WORKDIR /app
 COPY package.json package-lock.json ./
 COPY apps/web/package.json apps/web/
+COPY packages/cli/package.json packages/cli/
 COPY apps/web/prisma ./apps/web/prisma/
 RUN npm ci --omit=dev --loglevel=error
 RUN npx prisma generate --schema=apps/web/prisma/schema.prisma

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ FROM docker.io/library/node:22-alpine AS builder
 RUN apk add --no-cache libc6-compat openssl python3 make g++
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
+# npm hoists most deps to root, but tsup lands in packages/cli/node_modules
+# (workspace local). Without this, the CLI build fails with `tsup: not found`.
+COPY --from=deps /app/packages/cli/node_modules ./packages/cli/node_modules
 COPY . .
 ARG COMMIT_SHA=unknown
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -41,7 +44,7 @@ ENV CHROME_PATH=/usr/bin/chromium-browser
 
 # CLI provider support: writable npm global prefix for node user
 # *-host dirs are read-only mount points; entrypoint copies into writable dirs
-RUN mkdir -p /home/node/.npm-global \
+RUN mkdir -p /home/node/.npm-global/bin \
              /home/node/.claude /home/node/.claude-host \
              /home/node/.codex /home/node/.codex-host && \
     chown -R node:node /home/node/.npm-global \
@@ -84,9 +87,17 @@ COPY --from=proddeps --chown=node:node /app/node_modules/ts-algebra ./node_modul
 COPY --from=proddeps --chown=node:node /app/node_modules/openai ./node_modules/openai
 COPY --from=proddeps --chown=node:node /app/node_modules/@google ./node_modules/@google
 
-# Ink terminal UI (fairtrail-tui). Bundle is self contained except for @prisma/client,
-# playwright, ioredis (resolved from /app/node_modules via Node's parent walk).
+# Ink terminal UI (fairtrail-tui). The CLI's runtime deps (ink, react,
+# chalk, commander, ink-*, plus their transitives) are not in the lean
+# Next standalone trace, so we ship the full proddeps node_modules under
+# /app/packages/cli/node_modules. Two layers:
+#   1. Root proddeps node_modules — supplies ink, react, etc. (hoisted).
+#   2. Workspace local proddeps node_modules — overrides commander v13 and
+#      chalk v5 that npm could not hoist due to version conflicts at root.
+# Without layer 2 the wrapper picks up commander v2.20.3 which is ESM hostile.
 COPY --from=builder --chown=node:node /app/packages/cli/dist /app/packages/cli/dist
+COPY --from=proddeps --chown=node:node /app/node_modules /app/packages/cli/node_modules
+COPY --from=proddeps --chown=node:node /app/packages/cli/node_modules /app/packages/cli/node_modules
 RUN printf '#!/bin/sh\nexec node /app/packages/cli/dist/index.js "$@"\n' > /home/node/.npm-global/bin/fairtrail-tui \
     && chmod +x /home/node/.npm-global/bin/fairtrail-tui \
     && chown node:node /home/node/.npm-global/bin/fairtrail-tui

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -55,7 +55,8 @@ model PriceSnapshot {
   bookingUrl        String?
   stops             Int      @default(0)
   duration          String?
-  flightId          String?  // stable identity: airline-HHMM-origin-dest-date
+  flightId          String?  // stable identity: airline-(flightNumber|HHMM)-origin-dest-date
+  flightNumber      String?  // human-readable flight identifier (e.g. "DL 345")
   departureTime     String?
   arrivalTime       String?
   seatsLeft         Int?

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -33,7 +33,7 @@ model Query {
   expiresAt       DateTime
   firstViewedAt   DateTime?
   vpnCountries    String[] @default([]) // ISO 3166-1 codes for VPN comparison
-  scrapeInterval  Int      @default(3) // hours
+  scrapeInterval  Int?     // hours, null = follow extractionConfig.scrapeInterval (global)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Query {
   flexibility     Int      @default(0)
   maxPrice        Float?
   maxStops        Int?
+  maxDurationHours Int?     // optional cap on total trip duration in hours
   preferredAirlines String[] @default([])
   timePreference  String   @default("any")
   cabinClass      String   @default("economy")

--- a/apps/web/public/fairtrail-cli
+++ b/apps/web/public/fairtrail-cli
@@ -445,7 +445,7 @@ cmd_help() {
   echo "    (none)       Start Fairtrail (Ctrl+C to stop)"
   echo "    search \"..\"  Search and track a flight from the terminal"
   echo "    start        Start in background"
-  echo "    stop         Stop — pauses all price tracking until you start again"
+  echo "    stop         Stop. Pauses all price tracking until you start again."
   echo "    logs         View live logs"
   echo "    status       Check if running"
   echo "    update       Pull latest version and restart"
@@ -453,9 +453,40 @@ cmd_help() {
   echo "    uninstall    Remove Fairtrail and all data"
   echo "    help         Show this help"
   echo ""
+  echo "  Terminal UI flags (forwarded to fairtrail-tui inside the container):"
+  echo "    --headless              Render the Ink terminal UI"
+  echo "    --list                  List tracked queries (with --headless)"
+  echo "    --view <id>             View a tracker (with --headless)"
+  echo "    --backend <provider>    AI backend override (claude-code, codex, anthropic, openai, google)"
+  echo "    --model <model>         Model override"
+  echo ""
+}
+
+# Dispatch terminal UI flags to fairtrail-tui inside the running container.
+cmd_tui() {
+  local health
+  health=$(fetch_health)
+  if [ -z "$health" ]; then
+    printf "${RED}${BOLD}✗${RESET} Fairtrail is not running. Start with: fairtrail\n"
+    exit 1
+  fi
+
+  local exec_flags
+  if [ -t 0 ] && [ -t 1 ]; then
+    exec_flags="-it"
+  else
+    exec_flags="-i"
+  fi
+
+  exec dc exec $exec_flags web fairtrail-tui "$@"
 }
 
 case "${1:-}" in
+  --headless|--list|--view|--backend|--model)
+    cmd_tui "$@" ;;
+  --tmux)
+    printf "${YELLOW}${BOLD}!${RESET} --tmux is not supported in the production install. Use the dev mode CLI: npm run cli -- --tmux ...\n"
+    exit 1 ;;
   search)    shift; cmd_search "$@" ;;
   start)     cmd_start_background ;;
   stop)      cmd_stop ;;

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -34,6 +34,15 @@ FAIRTRAIL_API_KEY="${FAIRTRAIL_API_KEY:-}"
 FAIRTRAIL_API_PROVIDER="${FAIRTRAIL_API_PROVIDER:-}"
 FAIRTRAIL_EXTRA_ENV="${FAIRTRAIL_EXTRA_ENV:-}"
 
+# Parse install-time flags. --no-browser suppresses the auto-open at the end
+# (use for SSH, CI, or server installs that have no display).
+FAIRTRAIL_OPEN_BROWSER="${FAIRTRAIL_OPEN_BROWSER:-1}"
+for arg in "$@"; do
+  case "$arg" in
+    --no-browser) FAIRTRAIL_OPEN_BROWSER=0 ;;
+  esac
+done
+
 echo ""
 printf "${BOLD}  Fairtrail — Flight Price Tracker${RESET}\n"
 printf "  ${DIM}The price trail airlines don't show you${RESET}\n"
@@ -740,9 +749,11 @@ printf "  Next time, just run: ${BOLD}fairtrail${RESET}\n"
 printf "  ${DIM}Ctrl+C to stop  |  fairtrail stop  |  fairtrail help${RESET}\n"
 echo ""
 
-# Open browser automatically (skip on headless systems)
-if [ "$(uname)" = "Darwin" ] && command -v open &>/dev/null; then
-  open "http://localhost:${HOST_PORT}"
-elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
-  xdg-open "http://localhost:${HOST_PORT}" >/dev/null 2>&1 &
+# Open browser automatically (skip on headless systems or with --no-browser)
+if [ "$FAIRTRAIL_OPEN_BROWSER" = "1" ]; then
+  if [ "$(uname)" = "Darwin" ] && command -v open &>/dev/null; then
+    open "http://localhost:${HOST_PORT}"
+  elif [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v xdg-open &>/dev/null; then
+    xdg-open "http://localhost:${HOST_PORT}" >/dev/null 2>&1 &
+  fi
 fi

--- a/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
+++ b/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
@@ -13,7 +13,7 @@ interface QueryData {
   dateTo: string;
   active: boolean;
   expiresAt: string;
-  scrapeInterval: number;
+  scrapeInterval: number | null;
   snapshotCount: number;
   runCount: number;
 }
@@ -42,10 +42,11 @@ export function QueryRow({ query }: { query: QueryData }) {
   };
 
   const handleIntervalChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value === '' ? null : Number(e.target.value);
     await fetch(`/api/admin/queries/${query.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ scrapeInterval: Number(e.target.value) }),
+      body: JSON.stringify({ scrapeInterval: value }),
     });
     router.refresh();
   };
@@ -67,9 +68,10 @@ export function QueryRow({ query }: { query: QueryData }) {
       <div className={styles.rowActions}>
         <select
           className={styles.intervalSelect}
-          value={query.scrapeInterval}
+          value={query.scrapeInterval ?? ''}
           onChange={handleIntervalChange}
         >
+          <option value="">Follow global</option>
           <option value={1}>Every 1h</option>
           <option value={3}>Every 3h</option>
           <option value={6}>Every 6h</option>

--- a/apps/web/src/app/admin/(dashboard)/seed-routes/SeedRouteRow.tsx
+++ b/apps/web/src/app/admin/(dashboard)/seed-routes/SeedRouteRow.tsx
@@ -11,7 +11,7 @@ interface SeedData {
   destinationName: string;
   active: boolean;
   lookAheadDays: number;
-  scrapeInterval: number;
+  scrapeInterval: number | null;
   cabinClass: string;
   preferredAirlines: string[];
   snapshotCount: number;
@@ -49,10 +49,11 @@ export function SeedRouteRow({ seed }: { seed: SeedData }) {
   };
 
   const handleIntervalChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value === '' ? null : Number(e.target.value);
     await fetch(`/api/admin/seed-routes/${seed.id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ scrapeInterval: Number(e.target.value) }),
+      body: JSON.stringify({ scrapeInterval: value }),
     });
     router.refresh();
   };
@@ -103,7 +104,8 @@ export function SeedRouteRow({ seed }: { seed: SeedData }) {
         </div>
       )}
       <div className={styles.rowActions}>
-        <select className={styles.intervalSelect} value={seed.scrapeInterval} onChange={handleIntervalChange}>
+        <select className={styles.intervalSelect} value={seed.scrapeInterval ?? ''} onChange={handleIntervalChange}>
+          <option value="">Follow global</option>
           <option value={1}>Every 1h</option>
           <option value={3}>Every 3h</option>
           <option value={6}>Every 6h</option>

--- a/apps/web/src/app/api/admin/queries/[id]/route.ts
+++ b/apps/web/src/app/api/admin/queries/[id]/route.ts
@@ -19,6 +19,11 @@ export async function PATCH(
   if (typeof body.scrapeInterval === 'number' && [1, 3, 6, 12, 24].includes(body.scrapeInterval)) {
     data.scrapeInterval = body.scrapeInterval;
   }
+  if (body.maxDurationHours === null) {
+    data.maxDurationHours = null;
+  } else if (typeof body.maxDurationHours === 'number' && Number.isInteger(body.maxDurationHours) && body.maxDurationHours >= 1 && body.maxDurationHours <= 48) {
+    data.maxDurationHours = body.maxDurationHours;
+  }
 
   const updated = await prisma.query.update({ where: { id }, data });
   return apiSuccess(updated);

--- a/apps/web/src/app/api/admin/queries/[id]/route.ts
+++ b/apps/web/src/app/api/admin/queries/[id]/route.ts
@@ -16,7 +16,9 @@ export async function PATCH(
   const data: Record<string, unknown> = {};
 
   if (typeof body.active === 'boolean') data.active = body.active;
-  if (typeof body.scrapeInterval === 'number' && [1, 3, 6, 12, 24].includes(body.scrapeInterval)) {
+  if (body.scrapeInterval === null) {
+    data.scrapeInterval = null;
+  } else if (typeof body.scrapeInterval === 'number' && [1, 3, 6, 12, 24].includes(body.scrapeInterval)) {
     data.scrapeInterval = body.scrapeInterval;
   }
   if (body.maxDurationHours === null) {

--- a/apps/web/src/app/api/admin/seed-routes/[id]/route.ts
+++ b/apps/web/src/app/api/admin/seed-routes/[id]/route.ts
@@ -16,7 +16,9 @@ export async function PATCH(
   const data: Record<string, unknown> = {};
 
   if (typeof body.active === 'boolean') data.active = body.active;
-  if (typeof body.scrapeInterval === 'number' && [1, 3, 6, 12, 24].includes(body.scrapeInterval)) {
+  if (body.scrapeInterval === null) {
+    data.scrapeInterval = null;
+  } else if (typeof body.scrapeInterval === 'number' && [1, 3, 6, 12, 24].includes(body.scrapeInterval)) {
     data.scrapeInterval = body.scrapeInterval;
   }
   if (typeof body.lookAheadDays === 'number' && [7, 14, 21, 30].includes(body.lookAheadDays)) {

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -56,6 +56,7 @@ interface ScrapeRouteParams {
   tripType: string;
   maxPrice: number | null;
   maxStops: number | null;
+  maxDurationHours: number | null;
   preferredAirlines: string[];
   timePreference: string;
   currency: string | null;
@@ -102,6 +103,7 @@ function toPreviewRequestPayload(body: Record<string, unknown>): PreviewRequestP
     dateTo: String(body.dateTo || ''),
     maxPrice: body.maxPrice === undefined || body.maxPrice === null ? null : Number(body.maxPrice),
     maxStops: body.maxStops === undefined || body.maxStops === null ? null : Number(body.maxStops),
+    maxDurationHours: body.maxDurationHours === undefined || body.maxDurationHours === null ? null : Number(body.maxDurationHours),
     preferredAirlines: Array.isArray(body.preferredAirlines) ? body.preferredAirlines.map(String) : [],
     timePreference: typeof body.timePreference === 'string' ? body.timePreference : 'any',
     cabinClass: typeof body.cabinClass === 'string' ? body.cabinClass : 'economy',
@@ -190,6 +192,7 @@ async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
   const filters = {
     maxPrice: params.maxPrice,
     maxStops: params.maxStops,
+    maxDurationHours: params.maxDurationHours,
     preferredAirlines: airlines,
     timePreference: params.timePreference,
     cabinClass,
@@ -304,7 +307,7 @@ async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
 
 async function runPreview(payload: PreviewRequestPayload): Promise<PreviewResultPayload> {
   const { origins, destinations, isOneWay } = validatePreviewPayload(payload);
-  const { dateFrom, dateTo, maxPrice, maxStops, preferredAirlines, timePreference, cabinClass, tripType, currency: bodyCurrency } = payload;
+  const { dateFrom, dateTo, maxPrice, maxStops, maxDurationHours, preferredAirlines, timePreference, cabinClass, tripType, currency: bodyCurrency } = payload;
   const config = await prisma.extractionConfig.findFirst({ where: { id: 'singleton' } });
   const currency: string | null = config?.defaultCurrency ?? bodyCurrency;
   const outboundDates = payload.outboundDates;
@@ -360,6 +363,7 @@ async function runPreview(payload: PreviewRequestPayload): Promise<PreviewResult
           tripType: tripType || 'round_trip',
           maxPrice: maxPrice ? Number(maxPrice) : null,
           maxStops: maxStops !== undefined && maxStops !== null ? Number(maxStops) : null,
+          maxDurationHours,
           preferredAirlines,
           timePreference: timePreference || 'any',
           currency,

--- a/apps/web/src/app/api/queries/[id]/prices/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/prices/route.test.ts
@@ -4,12 +4,14 @@ import { NextRequest } from 'next/server';
 const mockQueryFindUnique = vi.fn();
 const mockSnapshotFindMany = vi.fn();
 const mockFetchRunFindFirst = vi.fn();
+const mockExtractionConfigFindFirst = vi.fn().mockResolvedValue({ scrapeInterval: 3 });
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
     query: { findUnique: (...args: unknown[]) => mockQueryFindUnique(...args) },
     priceSnapshot: { findMany: (...args: unknown[]) => mockSnapshotFindMany(...args) },
     fetchRun: { findFirst: (...args: unknown[]) => mockFetchRunFindFirst(...args) },
+    extractionConfig: { findFirst: (...args: unknown[]) => mockExtractionConfigFindFirst(...args) },
   },
 }));
 

--- a/apps/web/src/app/api/queries/[id]/prices/route.ts
+++ b/apps/web/src/app/api/queries/[id]/prices/route.ts
@@ -30,7 +30,13 @@ export async function GET(
       expiresAt: true,
       createdAt: true,
       active: true,
+      scrapeInterval: true,
     },
+  });
+
+  const globalConfig = await prisma.extractionConfig.findFirst({
+    where: { id: 'singleton' },
+    select: { scrapeInterval: true },
   });
 
   if (!query) {
@@ -76,11 +82,14 @@ export async function GET(
     select: { startedAt: true, status: true },
   });
 
+  const effectiveInterval = query.scrapeInterval ?? globalConfig?.scrapeInterval ?? 3;
+
   return apiSuccess({
     query,
     snapshots,
     lastChecked: lastRun?.startedAt ?? null,
     lastStatus: lastRun?.status ?? null,
     snapshotCount: snapshots.length,
+    effectiveInterval,
   });
 }

--- a/apps/web/src/app/api/queries/[id]/prices/route.ts
+++ b/apps/web/src/app/api/queries/[id]/prices/route.ts
@@ -57,6 +57,7 @@ export async function GET(
           stops: true,
           duration: true,
           flightId: true,
+          flightNumber: true,
           departureTime: true,
           arrivalTime: true,
           seatsLeft: true,

--- a/apps/web/src/app/api/queries/[id]/route.ts
+++ b/apps/web/src/app/api/queries/[id]/route.ts
@@ -30,9 +30,15 @@ export async function PATCH(
     }
   }
 
-  const interval = Number(body.scrapeInterval);
-  if (!ALLOWED_INTERVALS.includes(interval)) {
-    return apiError(`scrapeInterval must be one of: ${ALLOWED_INTERVALS.join(', ')}`, 400);
+  // Accept null (means "follow global") or one of the allowed numeric intervals.
+  let interval: number | null;
+  if (body.scrapeInterval === null) {
+    interval = null;
+  } else {
+    interval = Number(body.scrapeInterval);
+    if (!ALLOWED_INTERVALS.includes(interval)) {
+      return apiError(`scrapeInterval must be null or one of: ${ALLOWED_INTERVALS.join(', ')}`, 400);
+    }
   }
 
   // Update this query and all siblings in the group

--- a/apps/web/src/app/api/queries/route.ts
+++ b/apps/web/src/app/api/queries/route.ts
@@ -34,6 +34,7 @@ export async function POST(request: NextRequest) {
     flexibility,
     maxPrice,
     maxStops,
+    maxDurationHours,
     preferredAirlines,
     timePreference,
     cabinClass,
@@ -42,6 +43,16 @@ export async function POST(request: NextRequest) {
     vpnCountries: bodyVpnCountries,
   } = body;
   const currency: string | null = typeof bodyCurrency === 'string' && bodyCurrency ? bodyCurrency : null;
+
+  // Validate maxDurationHours: integer between 1 and 48 hours, or null.
+  let maxDurationHoursValidated: number | null = null;
+  if (maxDurationHours !== undefined && maxDurationHours !== null) {
+    const n = Number(maxDurationHours);
+    if (!Number.isInteger(n) || n < 1 || n > 48) {
+      return apiError('maxDurationHours must be an integer between 1 and 48', 400);
+    }
+    maxDurationHoursValidated = n;
+  }
   const vpnCountries: string[] = Array.isArray(bodyVpnCountries)
     ? bodyVpnCountries.filter((c: unknown) => typeof c === 'string' && /^[A-Z]{2}$/.test(c))
     : [];
@@ -135,6 +146,7 @@ export async function POST(request: NextRequest) {
         flexibility: routeFlex,
         maxPrice: maxPrice ? Number(maxPrice) : null,
         maxStops: maxStops !== undefined && maxStops !== null ? Number(maxStops) : null,
+        maxDurationHours: maxDurationHoursValidated,
         preferredAirlines: routeAirlines,
         timePreference: timePreference || 'any',
         cabinClass: cabinClass || 'economy',

--- a/apps/web/src/app/api/queries/route.ts
+++ b/apps/web/src/app/api/queries/route.ts
@@ -18,6 +18,7 @@ interface RouteInput {
     bookingUrl: string | null;
     stops?: number;
     duration?: string | null;
+    flightNumber?: string | null;
   }>;
 }
 
@@ -158,6 +159,7 @@ export async function POST(request: NextRequest) {
           bookingUrl: f.bookingUrl || '',
           stops: f.stops ?? 0,
           duration: f.duration ?? null,
+          flightNumber: f.flightNumber ?? null,
         })),
       });
     }

--- a/apps/web/src/app/api/test/scrape/route.ts
+++ b/apps/web/src/app/api/test/scrape/route.ts
@@ -83,7 +83,7 @@ export async function GET(request: NextRequest) {
         fixtureHtml,
         'https://www.google.com/travel/flights?q=flights+from+JFK+to+LAX',
         '2026-06-15',
-        { maxPrice: null, maxStops: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
+        { maxPrice: null, maxStops: null, maxDurationHours: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
         10,
         true,
         'google_flights',

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -61,7 +61,7 @@ interface QueryWithSnapshots {
     firstViewedAt: Date | null;
     groupId: string | null;
     currency: string | null;
-    scrapeInterval: number;
+    scrapeInterval: number | null;
     vpnCountries: string[];
   };
   snapshots: Array<{
@@ -84,6 +84,7 @@ interface QueryWithSnapshots {
     scrapedAt: string;
   }>;
   lastRun: { startedAt: Date } | null;
+  globalScrapeInterval: number;
 }
 
 async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | null> {
@@ -120,6 +121,11 @@ async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | 
     select: { startedAt: true },
   });
 
+  const globalConfig = await prisma.extractionConfig.findFirst({
+    where: { id: 'singleton' },
+    select: { scrapeInterval: true },
+  });
+
   return {
     query,
     snapshots: snapshots.map((s) => ({
@@ -128,6 +134,7 @@ async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | 
       scrapedAt: s.scrapedAt.toISOString(),
     })),
     lastRun,
+    globalScrapeInterval: globalConfig?.scrapeInterval ?? 3,
   };
 }
 
@@ -310,7 +317,8 @@ export default async function ChartPage({ params }: Props) {
           <p className={styles.footerText}>
             Tracked since {formatDate(primary.query.createdAt)}
             {allQueries[0]?.lastRun && ` · Last checked ${timeAgo(allQueries[0].lastRun.startedAt)}`}
-            {allQueries[0]?.lastRun && !expired && ` · Next check in ~${primary.query.scrapeInterval}h`}
+            {allQueries[0]?.lastRun && !expired && ` · Next check in ~${primary.query.scrapeInterval ?? primary.globalScrapeInterval}h`}
+            {primary.query.scrapeInterval === null && !expired && ' (follows global)'}
           </p>
           {!expired && (
             <>

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -74,6 +74,7 @@ interface QueryWithSnapshots {
     stops: number;
     duration: string | null;
     flightId: string | null;
+    flightNumber: string | null;
     departureTime: string | null;
     arrivalTime: string | null;
     seatsLeft: number | null;
@@ -102,6 +103,7 @@ async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | 
       stops: true,
       duration: true,
       flightId: true,
+      flightNumber: true,
       departureTime: true,
       arrivalTime: true,
       seatsLeft: true,

--- a/apps/web/src/components/ClarificationCard.test.tsx
+++ b/apps/web/src/components/ClarificationCard.test.tsx
@@ -28,6 +28,7 @@ function makePartial(): ParsedFlightQuery {
     flexibility: 0,
     maxPrice: null,
     maxStops: null,
+    maxDurationHours: null,
     preferredAirlines: [],
     timePreference: 'any',
     cabinClass: 'economy',

--- a/apps/web/src/components/ConfirmationCard.tsx
+++ b/apps/web/src/components/ConfirmationCard.tsx
@@ -19,6 +19,7 @@ export interface ParsedQuery {
   flexibility: number;
   maxPrice: number | null;
   maxStops: number | null;
+  maxDurationHours: number | null;
   preferredAirlines: string[];
   timePreference: string;
   cabinClass: string;
@@ -38,6 +39,7 @@ function hasFilters(p: ParsedQuery): boolean {
   return !!(
     p.maxPrice ||
     p.maxStops !== null ||
+    (p.maxDurationHours !== null && p.maxDurationHours > 0) ||
     p.preferredAirlines.length > 0 ||
     p.timePreference !== 'any' ||
     p.cabinClass !== 'economy'
@@ -218,6 +220,9 @@ export function ConfirmationCard({
             <span className={styles.tag}>
               {parsed.maxStops === 0 ? 'Nonstop only' : `Max ${parsed.maxStops} stop${parsed.maxStops > 1 ? 's' : ''}`}
             </span>
+          )}
+          {parsed.maxDurationHours !== null && parsed.maxDurationHours > 0 && (
+            <span className={styles.tag}>Under {parsed.maxDurationHours}h</span>
           )}
           {parsed.preferredAirlines.length > 0 && (
             <span className={styles.tag}>{parsed.preferredAirlines.join(', ')}</span>

--- a/apps/web/src/components/ManualEntryForm.tsx
+++ b/apps/web/src/components/ManualEntryForm.tsx
@@ -15,6 +15,7 @@ export interface ManualFormValues {
   flexibility: number;
   maxPrice: string;
   maxStops: string;
+  maxDuration: string;
   airlines: string;
   timePreference: 'any' | 'morning' | 'afternoon' | 'evening' | 'redeye';
   cabinClass: 'economy' | 'premium_economy' | 'business' | 'first';
@@ -73,6 +74,7 @@ export function ManualEntryForm({
     iv.flexibility > 0 ||
     iv.maxPrice ||
     iv.maxStops ||
+    iv.maxDuration ||
     iv.airlines ||
     iv.timePreference !== 'any' ||
     iv.cabinClass !== 'economy'
@@ -81,6 +83,7 @@ export function ManualEntryForm({
   const [flexibility, setFlexibility] = useState(iv?.flexibility ?? 0);
   const [maxPrice, setMaxPrice] = useState(iv?.maxPrice ?? '');
   const [maxStops, setMaxStops] = useState(iv?.maxStops ?? '');
+  const [maxDuration, setMaxDuration] = useState(iv?.maxDuration ?? '');
   const [airlines, setAirlines] = useState(iv?.airlines ?? '');
   const [timePreference, setTimePreference] = useState<'any' | 'morning' | 'afternoon' | 'evening' | 'redeye'>(
     iv?.timePreference ?? 'any',
@@ -120,6 +123,12 @@ export function ManualEntryForm({
         errors.dateTo = 'Return must be after departure';
       }
     }
+    if (maxDuration) {
+      const n = parseInt(maxDuration, 10);
+      if (!Number.isInteger(n) || n < 1 || n > 48) {
+        errors.maxDuration = 'Enter a value between 1 and 48 hours';
+      }
+    }
 
     return Object.keys(errors).length > 0 ? errors : null;
   };
@@ -147,7 +156,7 @@ export function ManualEntryForm({
       flexibility,
       maxPrice: maxPrice ? parseInt(maxPrice, 10) : null,
       maxStops: maxStops === '' ? null : parseInt(maxStops, 10),
-      maxDurationHours: null,
+      maxDurationHours: maxDuration ? parseInt(maxDuration, 10) : null,
       preferredAirlines: airlines ? airlines.split(',').map((s) => s.trim()).filter(Boolean) : [],
       timePreference,
       cabinClass,
@@ -174,6 +183,7 @@ export function ManualEntryForm({
       flexibility,
       maxPrice,
       maxStops,
+      maxDuration,
       airlines,
       timePreference,
       cabinClass,
@@ -306,17 +316,18 @@ export function ManualEntryForm({
 
           <div className={styles.fieldRow}>
             <div className={styles.field}>
-              <label className={styles.label} htmlFor="me-max-stops">Max stops</label>
+              <label className={styles.label} htmlFor="me-time">Time preference</label>
               <select
-                id="me-max-stops"
+                id="me-time"
                 className={styles.input}
-                value={maxStops}
-                onChange={(e) => setMaxStops(e.target.value)}
+                value={timePreference}
+                onChange={(e) => setTimePreference(e.target.value as typeof timePreference)}
               >
-                <option value="">Any</option>
-                <option value="0">Nonstop only</option>
-                <option value="1">Max 1 stop</option>
-                <option value="2">Max 2 stops</option>
+                <option value="any">Any</option>
+                <option value="morning">Morning</option>
+                <option value="afternoon">Afternoon</option>
+                <option value="evening">Evening</option>
+                <option value="redeye">Red-eye</option>
               </select>
             </div>
             <div className={styles.field}>
@@ -337,20 +348,37 @@ export function ManualEntryForm({
 
           <div className={styles.fieldRow}>
             <div className={styles.field}>
-              <label className={styles.label} htmlFor="me-time">Time preference</label>
+              <label className={styles.label} htmlFor="me-max-stops">Max stops</label>
               <select
-                id="me-time"
+                id="me-max-stops"
                 className={styles.input}
-                value={timePreference}
-                onChange={(e) => setTimePreference(e.target.value as typeof timePreference)}
+                value={maxStops}
+                onChange={(e) => setMaxStops(e.target.value)}
               >
-                <option value="any">Any</option>
-                <option value="morning">Morning</option>
-                <option value="afternoon">Afternoon</option>
-                <option value="evening">Evening</option>
-                <option value="redeye">Red-eye</option>
+                <option value="">Any</option>
+                <option value="0">Nonstop only</option>
+                <option value="1">Max 1 stop</option>
+                <option value="2">Max 2 stops</option>
               </select>
             </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="me-max-duration">Max trip duration (hours)</label>
+              <input
+                id="me-max-duration"
+                className={`${styles.input} ${fieldErrors.maxDuration ? styles.inputError : ''}`}
+                type="number"
+                min={1}
+                max={48}
+                placeholder="No limit"
+                value={maxDuration}
+                onChange={(e) => { setMaxDuration(e.target.value); clearError('maxDuration'); }}
+                aria-invalid={!!fieldErrors.maxDuration}
+              />
+              {fieldErrors.maxDuration && <span className={styles.errorText}>{fieldErrors.maxDuration}</span>}
+            </div>
+          </div>
+
+          <div className={styles.fieldRow}>
             <div className={styles.field}>
               <label className={styles.label} htmlFor="me-currency">Currency</label>
               <input
@@ -363,6 +391,7 @@ export function ManualEntryForm({
                 onChange={(e) => setCurrency(e.target.value.toUpperCase())}
               />
             </div>
+            <div className={styles.field} aria-hidden="true" />
           </div>
 
           <div className={styles.field}>

--- a/apps/web/src/components/ManualEntryForm.tsx
+++ b/apps/web/src/components/ManualEntryForm.tsx
@@ -147,6 +147,7 @@ export function ManualEntryForm({
       flexibility,
       maxPrice: maxPrice ? parseInt(maxPrice, 10) : null,
       maxStops: maxStops === '' ? null : parseInt(maxStops, 10),
+      maxDurationHours: null,
       preferredAirlines: airlines ? airlines.split(',').map((s) => s.trim()).filter(Boolean) : [],
       timePreference,
       cabinClass,

--- a/apps/web/src/components/PriceHistory.tsx
+++ b/apps/web/src/components/PriceHistory.tsx
@@ -10,6 +10,7 @@ interface Snapshot {
   stops: number;
   duration: string | null;
   flightId: string | null;
+  flightNumber: string | null;
   departureTime: string | null;
   arrivalTime: string | null;
   seatsLeft: number | null;
@@ -86,7 +87,7 @@ export function PriceHistory({ snapshots }: { snapshots: Snapshot[] }) {
     return (
       <tr key={s.id}>
         <td className={styles.date}>{formatDateTime(s.scrapedAt)}</td>
-        <td>{s.airline}</td>
+        <td>{s.airline}{s.flightNumber ? ` ${s.flightNumber}` : ''}</td>
         <td className={styles.times}>
           {s.departureTime || s.arrivalTime
             ? `${s.departureTime ?? '?'} - ${s.arrivalTime ?? '?'}`

--- a/apps/web/src/components/ScrapeInterval.tsx
+++ b/apps/web/src/components/ScrapeInterval.tsx
@@ -14,18 +14,18 @@ const INTERVALS = [
 
 interface Props {
   queryId: string;
-  currentInterval: number;
+  currentInterval: number | null;
 }
 
 export function ScrapeInterval({ queryId, currentInterval }: Props) {
-  const [interval, setInterval] = useState(currentInterval);
+  const [interval, setInterval] = useState<number | null>(currentInterval);
   const [saving, setSaving] = useState(false);
 
   const token = typeof window !== 'undefined' ? getDeleteToken(queryId) : null;
 
   if (!token) return null;
 
-  const handleChange = async (value: number) => {
+  const handleChange = async (value: number | null) => {
     if (value === interval) return;
 
     setSaving(true);
@@ -51,6 +51,13 @@ export function ScrapeInterval({ queryId, currentInterval }: Props) {
     <div className={styles.root}>
       <span className={styles.label}>Check every</span>
       <div className={styles.options}>
+        <button
+          className={`${styles.option} ${interval === null ? styles.active : ''}`}
+          onClick={() => handleChange(null)}
+          disabled={saving}
+        >
+          Auto
+        </button>
         {INTERVALS.map((opt) => (
           <button
             key={opt.value}

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -352,6 +352,7 @@ export function SearchBar({
           flexibility: parsed.flexibility,
           maxPrice: parsed.maxPrice,
           maxStops: parsed.maxStops,
+          maxDurationHours: parsed.maxDurationHours ?? null,
           preferredAirlines: parsed.preferredAirlines,
           timePreference: parsed.timePreference,
           currency: parsed.currency,

--- a/apps/web/src/lib/preview-run.ts
+++ b/apps/web/src/lib/preview-run.ts
@@ -5,6 +5,7 @@ export interface PreviewRequestPayload {
   dateTo: string;
   maxPrice: number | null;
   maxStops: number | null;
+  maxDurationHours: number | null;
   preferredAirlines: string[];
   timePreference: string;
   cabinClass: string;

--- a/apps/web/src/lib/scraper/duration.test.ts
+++ b/apps/web/src/lib/scraper/duration.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { parseDurationToMinutes } from './duration';
+
+describe('parseDurationToMinutes', () => {
+  it('parses hours and minutes', () => {
+    expect(parseDurationToMinutes('11h 20m')).toBe(11 * 60 + 20);
+  });
+
+  it('parses hours only', () => {
+    expect(parseDurationToMinutes('2h')).toBe(120);
+  });
+
+  it('parses minutes only', () => {
+    expect(parseDurationToMinutes('45m')).toBe(45);
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseDurationToMinutes('')).toBeNull();
+  });
+
+  it('returns null for null', () => {
+    expect(parseDurationToMinutes(null)).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(parseDurationToMinutes(undefined)).toBeNull();
+  });
+
+  it('returns null when no h or m markers are present', () => {
+    expect(parseDurationToMinutes('abc')).toBeNull();
+    expect(parseDurationToMinutes('11')).toBeNull();
+  });
+
+  it('also parses ISO 8601 PT12H30M as a side effect of the loose regex', () => {
+    // This is incidental: the regex matches the H and M markers.
+    expect(parseDurationToMinutes('PT12H30M')).toBe(12 * 60 + 30);
+  });
+
+  it('handles uppercase H and M', () => {
+    expect(parseDurationToMinutes('5H 10M')).toBe(310);
+  });
+});

--- a/apps/web/src/lib/scraper/duration.ts
+++ b/apps/web/src/lib/scraper/duration.ts
@@ -1,0 +1,15 @@
+/**
+ * Parse a human duration string like "11h 20m" or "2h" into total minutes.
+ * Returns null when the string contains neither hours nor minutes (e.g. empty,
+ * null, or unrecognized formats like "PT12H30M"). Callers treat null as
+ * "unparseable, do not filter on it".
+ */
+export function parseDurationToMinutes(s: string | null | undefined): number | null {
+  if (!s) return null;
+  const h = s.match(/(\d+)\s*h/i);
+  const m = s.match(/(\d+)\s*m/i);
+  if (!h && !m) return null;
+  const hours = h ? parseInt(h[1]!, 10) : 0;
+  const mins = m ? parseInt(m[1]!, 10) : 0;
+  return hours * 60 + mins;
+}

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -42,7 +42,7 @@ describe('extractPrices', () => {
       '<html>loading...</html>',
       'https://flights.google.com',
       '2026-06-15',
-      { maxPrice: null, maxStops: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
+      { maxPrice: null, maxStops: null, maxDurationHours: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
       10,
       false,
     );
@@ -170,7 +170,7 @@ describe('extractPrices', () => {
     });
 
     await extractPrices('page content', 'https://flights.google.com', '2026-06-15',
-      { maxPrice: null, maxStops: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
+      { maxPrice: null, maxStops: null, maxDurationHours: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
       10, true, 'google_flights', null
     );
 
@@ -187,7 +187,7 @@ describe('extractPrices', () => {
     });
 
     await extractPrices('page content', 'https://flights.google.com', '2026-06-15',
-      { maxPrice: null, maxStops: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
+      { maxPrice: null, maxStops: null, maxDurationHours: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
       10, true, 'google_flights', 'EUR'
     );
 
@@ -206,6 +206,56 @@ describe('extractPrices', () => {
     await expect(
       extractPrices('content', 'https://example.com', '2026-06-15')
     ).rejects.toThrow('Unknown extraction provider');
+  });
+
+  it('filters out flights exceeding maxDurationHours', async () => {
+    mockExtract.mockResolvedValue({
+      content: JSON.stringify([
+        { travelDate: '2026-06-15', price: 500, currency: 'USD', airline: 'Delta', bookingUrl: '', stops: 0, duration: '11h 20m', departureTime: '10:00 AM', arrivalTime: '9:20 PM', seatsLeft: null, flightNumber: 'DL 1' },
+        { travelDate: '2026-06-15', price: 600, currency: 'USD', airline: 'United', bookingUrl: '', stops: 1, duration: '21h 30m', departureTime: '8:00 AM', arrivalTime: '5:30 AM', seatsLeft: null, flightNumber: 'UA 2' },
+        { travelDate: '2026-06-15', price: 450, currency: 'USD', airline: 'Alaska', bookingUrl: '', stops: 0, duration: '8h', departureTime: '6:00 AM', arrivalTime: '2:00 PM', seatsLeft: null, flightNumber: 'AS 3' },
+      ]),
+      usage: { inputTokens: 500, outputTokens: 100 },
+    });
+
+    const result = await extractPrices(
+      'page', 'https://flights.google.com', '2026-06-15',
+      { maxPrice: null, maxStops: null, maxDurationHours: 12, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
+    );
+    expect(result.prices).toHaveLength(2);
+    expect(result.prices.map((p) => p.flightNumber).sort()).toEqual(['AS 3', 'DL 1']);
+  });
+
+  it('returns all_filtered_out when duration filter empties an otherwise valid result', async () => {
+    mockExtract.mockResolvedValue({
+      content: JSON.stringify([
+        { travelDate: '2026-06-15', price: 500, currency: 'USD', airline: 'Delta', bookingUrl: '', stops: 0, duration: '15h', departureTime: null, arrivalTime: null, seatsLeft: null, flightNumber: 'DL 1' },
+        { travelDate: '2026-06-15', price: 600, currency: 'USD', airline: 'United', bookingUrl: '', stops: 1, duration: '20h', departureTime: null, arrivalTime: null, seatsLeft: null, flightNumber: 'UA 2' },
+      ]),
+      usage: { inputTokens: 500, outputTokens: 100 },
+    });
+
+    const result = await extractPrices(
+      'page', 'https://flights.google.com', '2026-06-15',
+      { maxPrice: null, maxStops: null, maxDurationHours: 10, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
+    );
+    expect(result.prices).toEqual([]);
+    expect(result.failureReason).toBe('all_filtered_out');
+  });
+
+  it('keeps flights with unparseable duration when maxDurationHours is set', async () => {
+    mockExtract.mockResolvedValue({
+      content: JSON.stringify([
+        { travelDate: '2026-06-15', price: 500, currency: 'USD', airline: 'Delta', bookingUrl: '', stops: 0, duration: null, departureTime: null, arrivalTime: null, seatsLeft: null, flightNumber: 'DL 1' },
+      ]),
+      usage: { inputTokens: 500, outputTokens: 100 },
+    });
+
+    const result = await extractPrices(
+      'page', 'https://flights.google.com', '2026-06-15',
+      { maxPrice: null, maxStops: null, maxDurationHours: 10, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
+    );
+    expect(result.prices).toHaveLength(1);
   });
 
   it('propagates flightNumber from llm output', async () => {

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -208,6 +208,25 @@ describe('extractPrices', () => {
     ).rejects.toThrow('Unknown extraction provider');
   });
 
+  it('propagates flightNumber from llm output', async () => {
+    mockExtract.mockResolvedValue({
+      content: JSON.stringify([
+        { travelDate: '2026-06-15', price: 623, currency: 'USD', airline: 'Delta', bookingUrl: 'https://delta.com', stops: 0, duration: '5h 30m', departureTime: '10:25 AM', arrivalTime: '3:55 PM', seatsLeft: 3, flightNumber: 'DL 345' },
+        { travelDate: '2026-06-15', price: 450, currency: 'USD', airline: 'Delta', bookingUrl: 'https://delta.com', stops: 0, duration: '5h 30m', departureTime: '10:25 AM', arrivalTime: '3:55 PM', seatsLeft: 5, flightNumber: 'DL 901' },
+      ]),
+      usage: { inputTokens: 500, outputTokens: 100 },
+    });
+
+    const result = await extractPrices(
+      'Flights: Delta DL 345 $623, Delta DL 901 $450',
+      'https://flights.google.com',
+      '2026-06-15',
+    );
+    expect(result.prices).toHaveLength(2);
+    expect(result.prices[0]!.flightNumber).toBe('DL 345');
+    expect(result.prices[1]!.flightNumber).toBe('DL 901');
+  });
+
   it('throws when api key is missing', async () => {
     const origKey = process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -13,6 +13,7 @@ export interface PriceData {
   departureTime: string | null; // e.g. "10:25 AM"
   arrivalTime: string | null; // e.g. "4:45 PM"
   seatsLeft: number | null; // e.g. 3 when "3 seats left" shown
+  flightNumber: string | null; // e.g. "DL 345"
 }
 
 export interface QueryFilters {
@@ -81,7 +82,8 @@ Return ONLY valid JSON — an array of UP TO ${maxResults} objects with this exa
     "duration": "11h 20m",
     "departureTime": "10:25 AM",
     "arrivalTime": "4:45 PM",
-    "seatsLeft": 3
+    "seatsLeft": 3,
+    "flightNumber": "DL 345"
   }
 ]
 ${filterSection}
@@ -96,6 +98,7 @@ ${bookingUrlRule}
 - departureTime: the departure time as shown (e.g. "10:25 AM", "7:50 PM"). Use null if not visible
 - arrivalTime: the arrival time as shown (e.g. "4:45 PM", "11:30 AM"). Use null if not visible
 - seatsLeft: if the page shows "N seats left" or "N seats left at this price", extract the number. Use null if not shown
+- flightNumber: extract the carrier code plus number when shown (e.g. "DL 345", "AA 1102", "TK 32"). Use null if only the airline name is visible without a number
 - If the travel date is not clearly visible per result, use the search date provided
 - Prefer variety: if multiple airlines are available, include at least one from each (up to the ${maxResults} limit)
 - Return ONLY the JSON array, no markdown, no explanation

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -1,5 +1,6 @@
 import { EXTRACTION_PROVIDERS, CLI_PROVIDERS, LOCAL_PROVIDERS, type ExtractionUsage } from './ai-registry';
 import { prisma } from '@/lib/prisma';
+import { parseDurationToMinutes } from './duration';
 import type { NavigationSource } from './navigate';
 
 export interface PriceData {
@@ -19,6 +20,7 @@ export interface PriceData {
 export interface QueryFilters {
   maxPrice: number | null;
   maxStops: number | null;
+  maxDurationHours: number | null;
   preferredAirlines: string[];
   timePreference: string;
   cabinClass: string;
@@ -121,7 +123,7 @@ export async function extractPrices(
   html: string,
   searchUrl: string,
   travelDateFallback: string,
-  filters: QueryFilters = { maxPrice: null, maxStops: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
+  filters: QueryFilters = { maxPrice: null, maxStops: null, maxDurationHours: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' },
   maxResults: number = DEFAULT_MAX_RESULTS,
   resultsFound: boolean = true,
   source: NavigationSource = 'google_flights',
@@ -186,15 +188,30 @@ ${html}`;
   }
 
   // Filter out obviously invalid entries
-  const prices = raw.filter(
+  const validPrices = raw.filter(
     (p) => p.price > 0 && p.airline && p.airline.length > 0
   );
 
-  if (prices.length === 0) {
+  if (validPrices.length === 0) {
     console.log(`[extract] FAIL all_filtered_out — ${raw.length} raw results all invalid`);
     return { prices: [], usage: result.usage, failureReason: 'all_filtered_out' };
   }
 
-  console.log(`[extract] OK — ${prices.length} flights extracted (cheapest: $${prices[0]?.price})`);
-  return { prices, usage: result.usage };
+  // Apply server side duration filter. The LLM extracts the duration string
+  // (e.g. "11h 20m") and we parse it deterministically here so the filter is
+  // testable without the LLM and consistent across providers.
+  const durationFiltered = filters.maxDurationHours
+    ? validPrices.filter((p) => {
+        const minutes = parseDurationToMinutes(p.duration);
+        return minutes === null || minutes <= filters.maxDurationHours! * 60;
+      })
+    : validPrices;
+
+  if (durationFiltered.length === 0) {
+    console.log(`[extract] FAIL all_filtered_out — duration filter (max ${filters.maxDurationHours}h) removed all ${validPrices.length} flights`);
+    return { prices: [], usage: result.usage, failureReason: 'all_filtered_out' };
+  }
+
+  console.log(`[extract] OK — ${durationFiltered.length} flights extracted (cheapest: $${durationFiltered[0]?.price})`);
+  return { prices: durationFiltered, usage: result.usage };
 }

--- a/apps/web/src/lib/scraper/parse-query.test.ts
+++ b/apps/web/src/lib/scraper/parse-query.test.ts
@@ -296,6 +296,62 @@ describe('parseFlightQuery', () => {
     expect(response.parsed?.currency).toBeNull();
   });
 
+  it('extracts maxDurationHours when phrased as "duration under N hours"', async () => {
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'LAX', name: 'Los Angeles' }],
+          destinations: [{ code: 'IST', name: 'Istanbul' }],
+          dateFrom: '2026-05-20',
+          dateTo: '2026-05-30',
+          flexibility: 0,
+          maxPrice: 1000,
+          maxStops: null,
+          maxDurationHours: 20,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 120, outputTokens: 60 },
+    });
+
+    const { response } = await parseFlightQuery('LAX to IST 5/20 to 5/30 with duration under 20 hours and price under $1000');
+    expect(response.parsed?.maxDurationHours).toBe(20);
+    expect(response.parsed?.maxPrice).toBe(1000);
+  });
+
+  it('returns null maxDurationHours when not mentioned', async () => {
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'New York JFK' }],
+          destinations: [{ code: 'LAX', name: 'Los Angeles' }],
+          dateFrom: '2026-06-15',
+          dateTo: '2026-06-22',
+          flexibility: 0,
+          maxPrice: null,
+          maxStops: null,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: null,
+        },
+      }),
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    const { response } = await parseFlightQuery('JFK to LAX June 15-22');
+    expect(response.parsed?.maxDurationHours).toBeNull();
+  });
+
   it('throws when llm returns no JSON', async () => {
     mockExtract.mockResolvedValue({
       content: 'Sorry, I cannot parse that query.',

--- a/apps/web/src/lib/scraper/parse-query.ts
+++ b/apps/web/src/lib/scraper/parse-query.ts
@@ -20,6 +20,7 @@ export interface ParsedFlightQuery {
   flexibility: number; // days
   maxPrice: number | null;
   maxStops: number | null; // 0 = nonstop only, 1 = max 1 stop, null = any
+  maxDurationHours: number | null; // total trip duration cap (hours), null = no cap
   preferredAirlines: string[]; // empty = no preference
   timePreference: 'any' | 'morning' | 'afternoon' | 'evening' | 'redeye';
   cabinClass: 'economy' | 'premium_economy' | 'business' | 'first';
@@ -60,6 +61,7 @@ Return ONLY valid JSON with this exact shape:
     "flexibility": number of days of flexibility (0 if exact dates),
     "maxPrice": number or null,
     "maxStops": number or null (0 if "nonstop"/"direct", 1 if "max 1 stop", null if no preference),
+    "maxDurationHours": number or null (e.g. 20 for "duration under 20 hours"),
     "preferredAirlines": ["Delta", "United"] or [] if no preference,
     "timePreference": "any" | "morning" | "afternoon" | "evening" | "redeye",
     "cabinClass": "economy" | "premium_economy" | "business" | "first",
@@ -129,6 +131,7 @@ Parsing rules:
 - tripType: "one_way" if no return date is mentioned or user says "one way"; "round_trip" if a return date is given or user says "round trip" or "return". Default to "one_way" when ambiguous (no return info)
 - Extract airline preferences if mentioned
 - Extract price caps if mentioned (e.g. "under $800")
+- Extract trip duration caps when phrased as "under N hours", "less than Nh", "max N hours", "duration < Nh", "shorter than N hours", "no more than Nh", or "flights shorter than N hours". Round fractional values up to whole hours. Set maxDurationHours to null if not mentioned.
 - If no stop preference stated, maxStops is null
 - Extract currency if mentioned (e.g. "in euros" → "EUR", "prices in pounds" → "GBP", "in CAD" → "CAD", "¥" → "JPY"). Set to null if not mentioned by the user. Use ISO 4217 codes.
 - Ignore trailing fragments or incomplete words at the end of the input — parse what you can
@@ -184,6 +187,7 @@ function normalizeAirports(parsed: Record<string, unknown>): ParsedFlightQuery {
     destination: destinations[0]?.code ?? '',
     destinationName: destinations[0]?.name ?? '',
     currency: typeof p.currency === 'string' && p.currency ? p.currency : null,
+    maxDurationHours: typeof p.maxDurationHours === 'number' && p.maxDurationHours > 0 ? p.maxDurationHours : null,
     dateFrom,
     dateTo,
     outboundDates: outboundDates?.length ? outboundDates : undefined,

--- a/apps/web/src/lib/scraper/run-scrape.test.ts
+++ b/apps/web/src/lib/scraper/run-scrape.test.ts
@@ -220,6 +220,62 @@ describe('runScrapeForQuery', () => {
     });
   });
 
+  it('does not mark legacy-id snapshot as sold_out when same flight comes back with a flight number', async () => {
+    // Existing row was persisted before the flightNumber rollout, so its
+    // flightId is the legacy time-only form.
+    mockPrisma.priceSnapshot.findMany.mockResolvedValue([{
+      flightId: 'Delta-1025-JFK-LAX-2026-06-15',
+      flightNumber: null,
+      price: 350,
+      airline: 'Delta',
+      travelDate: new Date('2026-06-15'),
+      currency: 'USD',
+      bookingUrl: 'https://example.com',
+      stops: 0,
+      duration: '5h',
+      departureTime: '10:25 AM',
+      arrivalTime: '3:25 PM',
+      status: 'available',
+    }]);
+
+    // The new extraction returns the same physical flight (same airline, same
+    // departure time) but now carries the real flight number, so the new
+    // synthesis tail is DL345 instead of 1025.
+    mockExtractPrices.mockResolvedValue({
+      prices: [{
+        travelDate: '2026-06-15',
+        price: 360,
+        currency: 'USD',
+        airline: 'Delta',
+        bookingUrl: 'https://delta.com',
+        stops: 0,
+        duration: '5h',
+        departureTime: '10:25 AM',
+        arrivalTime: '3:25 PM',
+        seatsLeft: 4,
+        flightNumber: 'DL 345',
+      }],
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('success');
+    // createMany must be called once (the new available row) and NOT a second
+    // time for sold-out — otherwise every existing flight at deploy would be
+    // flagged as sold-out.
+    expect(mockPrisma.priceSnapshot.createMany).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.priceSnapshot.createMany).toHaveBeenCalledWith({
+      data: expect.arrayContaining([
+        expect.objectContaining({
+          airline: 'Delta',
+          flightNumber: 'DL 345',
+          flightId: 'Delta-DL345-JFK-LAX-2026-06-15',
+        }),
+      ]),
+    });
+  });
+
   it('accepts null bookingUrl without error (schema is String?)', async () => {
     mockExtractPrices.mockResolvedValue({
       prices: [{

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -35,7 +35,7 @@ interface ScrapeResult {
 /** Scrape a single query for a single country pass (local or VPN). */
 async function scrapeQueryForCountry(
   queryId: string,
-  query: { origin: string; destination: string; preferredAirlines: string[]; maxPrice: number | null; maxStops: number | null; timePreference: string; cabinClass: string },
+  query: { origin: string; destination: string; preferredAirlines: string[]; maxPrice: number | null; maxStops: number | null; maxDurationHours: number | null; timePreference: string; cabinClass: string },
   searchParams: import('./navigate').FlightSearchParams,
   config: { provider?: string; model?: string } | null,
   vpnCountry: string | null,
@@ -52,6 +52,7 @@ async function scrapeQueryForCountry(
   const filters = {
     maxPrice: query.maxPrice,
     maxStops: query.maxStops,
+    maxDurationHours: query.maxDurationHours,
     preferredAirlines: query.preferredAirlines,
     timePreference: query.timePreference,
     cabinClass: query.cabinClass,

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -145,12 +145,19 @@ async function scrapeQueryForCountry(
     },
   });
 
-  // Build stable flightId for each price
+  // Build stable flightId for each price. When the LLM extracted a real flight
+  // number, prefer that over the departure time so codeshares at the same
+  // minute do not collide. flightIdLegacy carries the time-only form for
+  // matching against rows persisted before this rollout (kept in memory only,
+  // never written to the DB).
   const withFlightIds = allPrices.map((p) => {
     const timePart = (p.departureTime ?? '').replace(/[^0-9]/g, '') || '0000';
     const airlinePart = p.airline.replace(/[^a-zA-Z0-9]/g, '').substring(0, 20);
-    const flightId = `${airlinePart}-${timePart}-${query.origin}-${query.destination}-${p.travelDate}`;
-    return { ...p, flightId };
+    const flightNumberPart = (p.flightNumber ?? '').replace(/\s+/g, '').toUpperCase();
+    const idTail = flightNumberPart || timePart;
+    const flightId = `${airlinePart}-${idTail}-${query.origin}-${query.destination}-${p.travelDate}`;
+    const flightIdLegacy = `${airlinePart}-${timePart}-${query.origin}-${query.destination}-${p.travelDate}`;
+    return { ...p, flightId, flightIdLegacy };
   });
 
   // Sold-out detection: scope by BOTH queryId AND vpnCountry to avoid cross-country false positives
@@ -162,12 +169,19 @@ async function scrapeQueryForCountry(
     },
     orderBy: { scrapedAt: 'desc' },
     distinct: ['flightId'],
-    select: { flightId: true, price: true, airline: true, travelDate: true, currency: true, bookingUrl: true, stops: true, duration: true, departureTime: true, arrivalTime: true, status: true },
+    select: { flightId: true, price: true, airline: true, travelDate: true, currency: true, bookingUrl: true, stops: true, duration: true, departureTime: true, arrivalTime: true, flightNumber: true, status: true },
   });
 
+  // Match prior rows against BOTH the new and the legacy id forms so the
+  // rollout does not flag every existing flight as sold out when scraping
+  // resumes.
   const currentFlightIds = new Set(withFlightIds.map((p) => p.flightId));
+  const currentLegacyIds = new Set(withFlightIds.map((p) => p.flightIdLegacy));
   const soldOutSnapshots = previousSnapshots
-    .filter((prev) => prev.flightId && !currentFlightIds.has(prev.flightId) && prev.status === 'available')
+    .filter((prev) => {
+      if (!prev.flightId || prev.status !== 'available') return false;
+      return !currentFlightIds.has(prev.flightId) && !currentLegacyIds.has(prev.flightId);
+    })
     .map((prev) => ({
       queryId,
       travelDate: prev.travelDate,
@@ -180,6 +194,7 @@ async function scrapeQueryForCountry(
       departureTime: prev.departureTime,
       arrivalTime: prev.arrivalTime,
       flightId: prev.flightId,
+      flightNumber: prev.flightNumber,
       status: 'sold_out' as const,
       vpnCountry,
       fetchRunId,
@@ -187,7 +202,9 @@ async function scrapeQueryForCountry(
 
   if (withFlightIds.length > 0) {
     await prisma.priceSnapshot.createMany({
-      data: withFlightIds.map((p) => ({
+      // Drop flightIdLegacy before insert; it is only used for in-memory
+      // sold-out matching above.
+      data: withFlightIds.map(({ flightIdLegacy: _legacy, ...p }) => ({
         queryId,
         travelDate: new Date(p.travelDate),
         price: p.price,
@@ -199,6 +216,7 @@ async function scrapeQueryForCountry(
         departureTime: p.departureTime ?? null,
         arrivalTime: p.arrivalTime ?? null,
         flightId: p.flightId,
+        flightNumber: p.flightNumber ?? null,
         seatsLeft: p.seatsLeft ?? null,
         vpnCountry,
         fetchRunId,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run test --workspace=@fairtrail/web",
     "cli": "doppler run -- node --import tsx/esm --import ./packages/cli/register.mjs packages/cli/src/index.tsx --headless",
     "cli:dev": "npm run dev --workspace=@fairtrail/cli",
-    "ci": "npm run lint && npm run typecheck && npm run test && npm run build",
+    "ci": "npm run lint && npm run typecheck && npm run test && npm run build && npm run build --workspace=@fairtrail/cli",
     "db:push": "npx prisma db push --schema=apps/web/prisma/schema.prisma",
     "db:generate": "npx prisma generate --schema=apps/web/prisma/schema.prisma",
     "db:migrate": "npx prisma migrate deploy --schema=apps/web/prisma/schema.prisma"

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { program } = require('commander');
+// commander 13 ships an ESM entry (esm.mjs) that re-exports `program` as a
+// named binding from the CJS index. There is no default export, so use the
+// named import. Node 22 in production resolves commander v13 from the
+// workspace local node_modules (see Dockerfile), not the root v2 hoist.
+import { program } from 'commander';
 import { render } from 'ink';
 import React from 'react';
 import { App } from './app.js';

--- a/packages/cli/src/lib/preview.ts
+++ b/packages/cli/src/lib/preview.ts
@@ -33,6 +33,7 @@ interface ScrapeRouteParams {
   tripType: string;
   maxPrice: number | null;
   maxStops: number | null;
+  maxDurationHours: number | null;
   preferredAirlines: string[];
   timePreference: string;
   currency: string | null;
@@ -47,6 +48,7 @@ async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
   const filters = {
     maxPrice: params.maxPrice,
     maxStops: params.maxStops,
+    maxDurationHours: params.maxDurationHours,
     preferredAirlines: airlines,
     timePreference: params.timePreference,
     cabinClass,
@@ -205,6 +207,7 @@ export async function previewFlights({ parsed, onProgress }: PreviewParams): Pro
         tripType: parsed.tripType || 'round_trip',
         maxPrice: parsed.maxPrice,
         maxStops: parsed.maxStops,
+        maxDurationHours: parsed.maxDurationHours,
         preferredAirlines: parsed.preferredAirlines,
         timePreference: parsed.timePreference || 'any',
         currency: parsed.currency,

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -14,9 +14,23 @@ export default defineConfig({
     };
     options.jsx = 'automatic';
   },
+  // Externalize every npm package. Bundling React together with ink's own
+  // react-reconciler creates two React copies and breaks hooks ("Cannot read
+  // properties of null reading useState"). Production runtime resolves all of
+  // these from /app/packages/cli/node_modules (see Dockerfile).
   external: [
     '@prisma/client',
     'playwright',
     'ioredis',
+    'react',
+    'react-reconciler',
+    'react-devtools-core',
+    'scheduler',
+    'ink',
+    'ink-select-input',
+    'ink-spinner',
+    'ink-text-input',
+    'chalk',
+    'commander',
   ],
 });

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -138,6 +138,54 @@ test_ansi_variables_defined() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: fairtrail-cli dispatches Ink TUI flags to docker exec
+# ---------------------------------------------------------------------------
+test_cli_dispatches_tui_flags() {
+  local cli="apps/web/public/fairtrail-cli"
+  if grep -q '\-\-headless|\-\-list|\-\-view|\-\-backend|\-\-model' "$cli"; then
+    pass "fairtrail-cli dispatches Ink TUI flags"
+  else
+    fail "fairtrail-cli should dispatch --headless/--list/--view/--backend/--model"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test: fairtrail-cli defines cmd_tui with TTY detection
+# ---------------------------------------------------------------------------
+test_cli_has_cmd_tui() {
+  local cli="apps/web/public/fairtrail-cli"
+  if grep -q 'cmd_tui()' "$cli" && grep -q 'fairtrail-tui' "$cli"; then
+    pass "fairtrail-cli defines cmd_tui that invokes fairtrail-tui"
+  else
+    fail "fairtrail-cli should define cmd_tui invoking fairtrail-tui"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test: install.sh supports --no-browser flag
+# ---------------------------------------------------------------------------
+test_install_supports_no_browser() {
+  local installer="apps/web/public/install.sh"
+  if grep -q '\-\-no-browser' "$installer" && grep -q 'FAIRTRAIL_OPEN_BROWSER' "$installer"; then
+    pass "install.sh supports --no-browser flag"
+  else
+    fail "install.sh should support --no-browser flag"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test: Dockerfile ships fairtrail-tui binary
+# ---------------------------------------------------------------------------
+test_dockerfile_ships_cli() {
+  local dockerfile="Dockerfile"
+  if grep -q 'workspace=@fairtrail/cli' "$dockerfile" && grep -q 'fairtrail-tui --help' "$dockerfile"; then
+    pass "Dockerfile builds @fairtrail/cli and smoke tests fairtrail-tui"
+  else
+    fail "Dockerfile should build @fairtrail/cli and run fairtrail-tui --help smoke check"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 echo ""
@@ -152,6 +200,10 @@ test_env_host_port
 test_entrypoint_port_warning
 test_install_overrides
 test_ansi_variables_defined
+test_cli_dispatches_tui_flags
+test_cli_has_cmd_tui
+test_install_supports_no_browser
+test_dockerfile_ships_cli
 
 echo ""
 printf "${BOLD}Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}\n" "$PASS" "$FAIL"


### PR DESCRIPTION
Refs #57.

## Summary

Five-phase fix for the user feedback collected on issue #57 (originally followup to #55). Each phase is one commit; each phase passes `npm run ci` and the install-flow regression test.

| # | Subject | Commit |
|---|---------|--------|
| 4 | Ship Ink TUI in Docker, route TUI flags from bash wrapper | c552278 |
| 2 | Capture flight numbers with sold-out rollout transition | 6680815 |
| 1 | Server-side max trip duration filter | 9e40248 |
| 3 | Manual form max trip duration input | 3c48d2c |
| 5 | Scrape interval follows global default for new trackers | 343e620 |

## What changes for users

### `fairtrail --headless` works after curl install (Phase 4)
Previously `fairtrail --headless` printed "Unknown command". The Dockerfile now builds and ships `packages/cli/dist`, exposing `fairtrail-tui` on PATH inside the runner image. The bash wrapper at `apps/web/public/fairtrail-cli` intercepts `--headless`, `--list`, `--view`, `--backend`, `--model` and forwards them via `dc exec` with TTY auto detection. `--tmux` is rejected with a clear message because the existing `tmux-view.ts` calls `process.cwd()` which is meaningless across the Docker boundary; that needs a separate refactor. `install.sh` gains a `--no-browser` flag for SSH and CI installs.

### Flight numbers in price history (Phase 2)
Snapshots persist real flight numbers extracted by the LLM (e.g. `DL 345`). The `PriceHistory` airline column now reads `Delta DL 345`. Sold-out detection still works against rows persisted before this change because we generate the legacy time-only id form in memory and match against both formats.

### Duration filters (Phases 1 and 3)
The reporter's example `LAX to IST 5/20 to 5/30 with duration under 20 hours and price under 1000 dollars` now honors the duration cap. The LLM extracts the duration string per result; we parse `11h 20m` to minutes deterministically in `apps/web/src/lib/scraper/duration.ts` and filter in TypeScript inside `extractPrices`. The manual entry form gains a "Max trip duration (hours)" input under Advanced options.

### Scrape interval consistency (Phase 5)
`Query.scrapeInterval` is now nullable. `null` means "follow global default". New trackers default to null; existing rows keep their pinned numeric value. The chart page renders the effective interval and appends `(follows global)` when applicable. The chart `ScrapeInterval` button group gains an "Auto" affordance, and the admin row selects gain a "Follow global" option.

## Test plan

* [x] `npm run ci` passes (lint, typecheck, web tests, web build, CLI build) — 226 tests, 23 files
* [x] `bash scripts/install-flow-test.sh` passes — 12 grep-based assertions
* [ ] Manual smoke: in dev (`npm run dev`), search `"LAX to IST 5/20 to 5/30 with duration under 20 hours and price under 1000 dollars"`, confirm the chip "Under 20h" appears and tracker creation succeeds
* [ ] Manual smoke: open a tracker page, click `Auto` on the ScrapeInterval, confirm `(follows global)` appears
* [ ] Manual smoke: run `fairtrail --headless --list` against a running container, confirm Ink TUI renders
* [ ] Production deploy verifies that one cycle of legacy-id snapshots are not flagged as sold-out (covered by the new run-scrape unit test)

## Schema migrations

Three nullable column changes, all applied via `npx prisma db push --schema=apps/web/prisma/schema.prisma`:

* `PriceSnapshot.flightNumber String?` (Phase 2)
* `Query.maxDurationHours Int?` (Phase 1)
* `Query.scrapeInterval Int?` (Phase 5; was `Int @default(3)`)

No backfill needed. Existing rows keep their values.

## Notes

* `community-sync.ts` is unaffected: `CommunityPayload` and `CommunitySnapshot` schema both omit `flightNumber`.
* Public Redis cache `ft:prices:${id}` (120s TTL) catches up automatically with the new field after deploy.
* Prompt cost growth from the new `flightNumber` extraction rule is roughly 30 input tokens; negligible at current volume.
