### PR TITLE
fix(web): preserve origin airport on edit (refs #60)

### DIFF
--- a/apps/web/src/components/ManualEntryForm.test.tsx
+++ b/apps/web/src/components/ManualEntryForm.test.tsx
@@ -1,0 +1,54 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ManualEntryForm, type ManualFormValues } from './ManualEntryForm';
+
+function makeInitialValues(): ManualFormValues {
+  return {
+    origin: { code: 'MAN', name: 'Manchester (Manchester Airport)' },
+    destination: { code: 'HRG', name: 'Hurghada (Hurghada International Airport)' },
+    dateFrom: '2026-05-07',
+    dateTo: '2026-05-21',
+    tripType: 'round_trip',
+    flexibility: 0,
+    maxPrice: '',
+    maxStops: '',
+    maxDuration: '',
+    airlines: '',
+    timePreference: 'any',
+    cabinClass: 'economy',
+    currency: '',
+  };
+}
+
+describe('ManualEntryForm — edit flow (issue #60)', () => {
+  beforeEach(() => {
+    // jsdom does not implement fetch; AirportCombobox calls /api/airports.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, data: [] }),
+    }));
+  });
+
+  it('keeps both origin and destination resolved when re-mounting with initialValues', () => {
+    render(
+      <ManualEntryForm
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        adminCurrency={null}
+        initialValues={makeInitialValues()}
+      />,
+    );
+
+    const origin = screen.getByRole('combobox', { name: /origin/i }) as HTMLInputElement;
+    const destination = screen.getByRole('combobox', { name: /destination/i }) as HTMLInputElement;
+
+    // Both fields should display the resolved IATA-prefixed value.
+    expect(destination.value).toBe('HRG - Hurghada (Hurghada International Airport)');
+    expect(origin.value).toBe('MAN - Manchester (Manchester Airport)');
+
+    // Neither should be flagged invalid on mount.
+    expect(origin.getAttribute('aria-invalid')).not.toBe('true');
+    expect(destination.getAttribute('aria-invalid')).not.toBe('true');
+  });
+});

--- a/apps/web/src/components/ManualEntryForm.tsx
+++ b/apps/web/src/components/ManualEntryForm.tsx
@@ -205,7 +205,7 @@ export function ManualEntryForm({
         onChange={(v) => { setOrigin(v); clearError('origin'); }}
         error={fieldErrors.origin}
         excludeCode={destination?.code}
-        autoFocus
+        autoFocus={!iv}
       />
 
       <AirportCombobox


### PR DESCRIPTION
## Summary

* Manual flight form lost the origin airport whenever the user clicked Edit on a previously parsed query. Manchester rendered as a plain string with a red `Select an origin airport` error while the destination stayed resolved (see screenshots in #60).
* Root cause: `ManualEntryForm` sets `autoFocus` on the Origin `AirportCombobox`. React fires the focus event synchronously after mount, the combobox's focus handler runs, sees a seeded `value`, and calls `onChange(null)` to put the field into "search again" mode. That clears the just rehydrated selection. Destination is never focused, so it survives.
* Fix: `autoFocus={!iv}` on the origin combobox. Fresh mounts still autofocus; edit roundtrips do not, so both fields rehydrate identically.

## What changed

| File | Change |
|------|--------|
| `apps/web/src/components/ManualEntryForm.tsx` | One line: gate autoFocus on `!iv` so it only fires on fresh mounts |
| `apps/web/src/components/ManualEntryForm.test.tsx` | New test mounts the form with the exact Manchester to Hurghada `initialValues` from the issue and asserts both inputs render their resolved `IATA City (Airport)` string and are not flagged invalid |

Refs #60.

## Test plan

* [x] Vitest: `ManualEntryForm.test.tsx` fails on `main` with `Received: "Manchester"`, passes after the one line fix.
* [x] `npm run ci` green (lint, typecheck, build, 236/236 tests).
* [ ] Manual smoke in dev: open landing page, switch to manual entry, fill Manchester to Hurghada, submit, hit Edit, confirm both fields show their full `IATA City (Airport)` text and there is no red error border.
* [ ] Reporter verification on issue #60.
