### PR TITLE
fix(install): support Arch/Manjaro via pacman

### DIFF
--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -94,20 +94,43 @@ case "$(uname -s)" in
     ;;
 esac
 
+# Detect Linux distro family. get.docker.com supports Debian/Ubuntu/Fedora/RHEL
+# but rejects Arch and derivatives, which ship Docker via pacman instead.
+DISTRO_FAMILY=""
+if [ "$OS" = "linux" ] || [ "$OS" = "wsl" ]; then
+  if [ -r /etc/os-release ]; then
+    . /etc/os-release
+    case "${ID:-}" in
+      arch|manjaro|endeavouros|garuda|artix|cachyos)
+        DISTRO_FAMILY="arch" ;;
+      *)
+        case " ${ID_LIKE:-} " in
+          *" arch "*) DISTRO_FAMILY="arch" ;;
+        esac ;;
+    esac
+  fi
+fi
+
 install_docker_linux() {
   info "Installing Docker Engine..."
   if ! command -v sudo &>/dev/null; then
     fail "sudo is required to install Docker. Install sudo first, then re-run."
   fi
   printf "  ${DIM}This requires sudo — you may be prompted for your password.${RESET}\n"
-  curl -fsSL https://get.docker.com | sudo sh
+  if [ "$DISTRO_FAMILY" = "arch" ]; then
+    # Arch family: get.docker.com refuses to run, so install via pacman.
+    sudo pacman -Sy --needed --noconfirm docker docker-compose
+    sudo systemctl enable --now docker.service
+  else
+    curl -fsSL https://get.docker.com | sudo sh
+  fi
   sudo usermod -aG docker "$USER"
   warn "You were added to the docker group. Log out and back in, then re-run this installer."
   exit 0
 }
 
 if ! command -v git &>/dev/null; then
-  fail "git is required to install Fairtrail.\n\n  Install: ${BOLD}sudo apt install git${RESET} (Debian/Ubuntu) or ${BOLD}sudo dnf install git${RESET} (Fedora)"
+  fail "git is required to install Fairtrail.\n\n  Install: ${BOLD}sudo apt install git${RESET} (Debian/Ubuntu), ${BOLD}sudo dnf install git${RESET} (Fedora), or ${BOLD}sudo pacman -S git${RESET} (Arch/Manjaro)"
 fi
 
 if command -v docker &>/dev/null; then

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -186,6 +186,24 @@ test_dockerfile_ships_cli() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: install.sh installs Docker via pacman on Arch-family distros
+# Regression test for issue #62: get.docker.com rejects Manjaro/Arch,
+# so the installer must detect the Arch family and use pacman instead.
+# ---------------------------------------------------------------------------
+test_install_supports_arch_family() {
+  local installer="apps/web/public/install.sh"
+  local has_detection has_pacman_branch has_git_hint
+  has_detection=$(grep -c 'DISTRO_FAMILY="arch"' "$installer" || true)
+  has_pacman_branch=$(grep -c 'pacman .* docker' "$installer" || true)
+  has_git_hint=$(grep -c 'pacman -S git' "$installer" || true)
+  if [ "$has_detection" -ge 1 ] && [ "$has_pacman_branch" -ge 1 ] && [ "$has_git_hint" -ge 1 ]; then
+    pass "install.sh detects Arch family and installs Docker + git via pacman"
+  else
+    fail "install.sh should detect Arch family (DISTRO_FAMILY=arch), install Docker via pacman, and hint pacman -S git"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 echo ""
@@ -204,6 +222,7 @@ test_cli_dispatches_tui_flags
 test_cli_has_cmd_tui
 test_install_supports_no_browser
 test_dockerfile_ships_cli
+test_install_supports_arch_family
 
 echo ""
 printf "${BOLD}Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}\n" "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

- Installer now detects Arch-family distros (arch, manjaro, endeavouros, garuda, artix, cachyos, plus anything with `ID_LIKE` containing `arch`) from `/etc/os-release` and installs Docker via `pacman -Sy --needed --noconfirm docker docker-compose` followed by `systemctl enable --now docker.service`.
- Other distros keep the existing `curl get.docker.com | sudo sh` path.
- The git-missing fail message now also hints `sudo pacman -S git` for Arch users.
- Added `test_install_supports_arch_family` regression test in `scripts/install-flow-test.sh`.

## Why

`get.docker.com` is Docker's official convenience script and refuses to run on Arch-family distros, printing `ERROR: Unsupported distribution`. Docker upstream excludes Arch on purpose because the official Arch repos already ship Docker. The Fairtrail installer was unconditionally piping that script, which dead-ended Manjaro users at the Docker install step.

Refs #62

## Test plan

- [x] `bash -n apps/web/public/install.sh` passes
- [x] `bash scripts/install-flow-test.sh` passes (13/13, including the new Arch regression test)
- [ ] Manual smoke test on Manjaro/Arch (would appreciate confirmation from issue reporter)
