### PR TITLE
fix(cli): use $_DC instead of exec dc for headless TUI dispatch

### DIFF
--- a/apps/web/public/fairtrail-cli
+++ b/apps/web/public/fairtrail-cli
@@ -478,7 +478,8 @@ cmd_tui() {
     exec_flags="-i"
   fi
 
-  exec dc exec $exec_flags web fairtrail-tui "$@"
+  # `exec` cannot run shell functions, so call $_DC directly instead of dc().
+  exec $_DC $COMPOSE_FILES exec $exec_flags web fairtrail-tui "$@"
 }
 
 case "${1:-}" in

--- a/apps/web/src/lib/scraper/install-scripts.test.ts
+++ b/apps/web/src/lib/scraper/install-scripts.test.ts
@@ -249,4 +249,17 @@ describe('fairtrail-cli', () => {
       );
     }
   });
+
+  it('never `exec`s the dc() shell function (regression: GH #64)', () => {
+    // `exec` only runs external commands; `exec dc ...` invokes /usr/bin/dc
+    // (the desk calculator), producing errors like `dc: invalid option -- 't'`.
+    // To replace the process with docker compose, expand $_DC inline instead.
+    const offending = CLI_SH.split('\n').filter(
+      (l) => /^\s*exec\s+dc(\s|$)/.test(l) && !l.trimStart().startsWith('#')
+    );
+    expect(
+      offending,
+      `'exec dc ...' must use $_DC directly:\n${offending.join('\n')}`
+    ).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Fix the CLI `dc: invalid option -- 't'` error when running `fairtrail --headless`.

`cmd_tui` did `exec dc exec ...` to dispatch the headless TUI, where `dc` was a shell function wrapping `docker compose`. Bash's `exec` builtin can only run external commands — never shell functions — so it found `/usr/bin/dc` (the GNU desk calculator) and passed it `-it web fairtrail-tui --headless`. On Linux GNU dc that surfaces as `dc: invalid option -- 't'`; on macOS BSD dc as a fatal-error stub.

The fix expands `$_DC` and `$COMPOSE_FILES` inline so the running shell is replaced by `docker compose` as intended, preserving all existing word-splitting behavior of the original `dc()` helper.

## Test plan

- [x] Unit test: regression assertion that `^\s*exec\s+dc(\s|$)` never reappears in `apps/web/public/fairtrail-cli`
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/lib/scraper/install-scripts.test.ts` (25/25 passing)
- [ ] Manual: `fairtrail --headless` resolves to the in-container TUI (verify on a deployed instance)

Fixes #64 (CLI sub-issue).
