### PR TITLE
fix(best-price): exclude sold-out snapshots from Best price found

### DIFF
--- a/apps/web/src/components/BestPrice.test.tsx
+++ b/apps/web/src/components/BestPrice.test.tsx
@@ -1,0 +1,92 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BestPrice } from './BestPrice';
+
+interface Snap {
+  price: number;
+  currency: string;
+  airline: string;
+  bookingUrl: string | null;
+  stops: number;
+  departureTime: string | null;
+  arrivalTime: string | null;
+  duration: string | null;
+  vpnCountry: string | null;
+  scrapedAt: string;
+  status?: string;
+}
+
+function snap(overrides: Partial<Snap>): Snap {
+  return {
+    price: 200,
+    currency: 'USD',
+    airline: 'Delta',
+    bookingUrl: null,
+    stops: 0,
+    departureTime: null,
+    arrivalTime: null,
+    duration: null,
+    vpnCountry: null,
+    scrapedAt: '2026-05-01T00:00:00.000Z',
+    status: 'available',
+    ...overrides,
+  };
+}
+
+describe('BestPrice — sold-out exclusion (issue #64)', () => {
+  it('ignores sold-out snapshots when picking the best price', () => {
+    // A sold-out snapshot at a lower price should not win — its listing is
+    // gone and the user can't actually book at that price anymore.
+    render(
+      <BestPrice
+        snapshots={[
+          snap({ price: 96, status: 'sold_out', airline: 'Turkish' }),
+          snap({ price: 175, status: 'available', airline: 'Pegasus' }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText(/Best price found/)).toBeTruthy();
+    expect(screen.getByText(/175/)).toBeTruthy();
+    expect(screen.queryByText(/96$/)).toBeNull();
+  });
+
+  it('renders nothing when every snapshot is sold out', () => {
+    const { container } = render(
+      <BestPrice
+        snapshots={[
+          snap({ price: 96, status: 'sold_out' }),
+          snap({ price: 110, status: 'sold_out' }),
+        ]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('still picks the cheapest available snapshot when none are sold out', () => {
+    render(
+      <BestPrice
+        snapshots={[
+          snap({ price: 320, airline: 'Lufthansa' }),
+          snap({ price: 220, airline: 'United' }),
+          snap({ price: 410, airline: 'Air France' }),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/220/)).toBeTruthy();
+  });
+
+  it('falls back gracefully when snapshots have no status field', () => {
+    // Defensive: callers passing legacy data without `status` should still work.
+    render(
+      <BestPrice
+        snapshots={[
+          { ...snap({ price: 150 }), status: undefined },
+          { ...snap({ price: 90 }), status: undefined },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/90/)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/BestPrice.tsx
+++ b/apps/web/src/components/BestPrice.tsx
@@ -12,12 +12,18 @@ interface Snapshot {
   duration: string | null;
   vpnCountry: string | null;
   scrapedAt: string;
+  status?: string;
 }
 
 export function BestPrice({ snapshots }: { snapshots: Snapshot[] }) {
-  if (snapshots.length === 0) return null;
+  // Sold-out snapshots carry the last seen price (run-scrape.ts marks the row
+  // sold_out but copies the prior price). The listing is no longer bookable,
+  // so excluding them keeps a vanished cheap fare from outranking real ones
+  // and avoids a Book button that points at a dead URL.
+  const bookable = snapshots.filter((s) => s.status !== 'sold_out');
+  if (bookable.length === 0) return null;
 
-  const best = snapshots.reduce((min, s) => (s.price < min.price ? s : min), snapshots[0]!);
+  const best = bookable.reduce((min, s) => (s.price < min.price ? s : min), bookable[0]!);
 
   return (
     <div className={styles.root}>


### PR DESCRIPTION
## Summary

Stop showing sold-out flights as the "Best price found".

`run-scrape.ts` writes a fresh snapshot with `status='sold_out'` each time a previously seen flight disappears, copying the prior price so the chart can render a vertical "sold out" marker. `PriceChart` and `PriceHistory` already filter `status !== 'sold_out'`; `BestPrice` did not, so a vanished cheap fare could keep ranking as the best price found and the Book button could 404.

This PR matches the other two components — filter sold-out before reducing, and bail out when no bookable snapshots remain.

## Notes on issue #64

This addresses **one** path that would produce a too-high "best price found": stale sold-out snapshots polluting the minimum. There is a second possible path — the LLM extraction missing a cheap listing on the live page — that needs run-time data to diagnose. Asking the reporter for their actual displayed value and a `/admin/runs` snapshot in the issue thread.

## Test plan

- [x] `BestPrice.test.tsx`: ignores sold-out snapshots when picking best
- [x] `BestPrice.test.tsx`: renders nothing when every snapshot is sold out
- [x] `BestPrice.test.tsx`: still picks cheapest available when none are sold out
- [x] `BestPrice.test.tsx`: legacy snapshots without `status` still work
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean

Refs #64 (best-price sub-issue).
