### PR TITLE
fix(scraper): rotate URL formats so smaller EU airports resolve

### DIFF
--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -341,6 +341,23 @@ describe('pageHasRequestedRoute (strict directional defense)', () => {
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK', '$$$')).toBe(false);
   });
 
+  it('documents the currency/IATA overlap residual risk', () => {
+    // Several allowlisted currency codes are ALSO real (small) IATA airport
+    // codes: HKD = Hakodate, BRL = Borba, CAD = Cadillac, CHF = Chefornak.
+    // A chained-route phrase using one of those as a layover technically
+    // passes the route validator. We accept this because:
+    //
+    // (a) Real Google Flights pages do not render "BDS to HKD via JFK" as
+    //     a header for a JFK booking — Hakodate is not a layover hop on
+    //     EU-to-NA routes.
+    // (b) Removing overlapping currencies would resurface the cycle-5/6
+    //     false-negative bugs for users actually transacting in HKD/BRL/etc.
+    //
+    // This test exists to make the trade-off explicit so a future change
+    // that wants stricter behavior knows what it is overriding.
+    expect(pageHasRequestedRoute('BDS to HKD via JFK', 'BDS', 'JFK')).toBe(true);
+  });
+
   it('still rejects unknown 3-letter uppercase codes (real airport layovers)', () => {
     // Allowlist must NOT swallow real airport codes that are layovers.
     expect(pageHasRequestedRoute('BDS to LHR via JFK', 'BDS', 'JFK')).toBe(false);

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -375,18 +375,43 @@ describe('pageHasRequestedRoute (strict directional defense)', () => {
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 
-  it('does NOT block "stop" / "stops" / "stopping" (intentional, real flight cards use them)', () => {
-    // Google flight cards display "1 stop", "Nonstop", etc. in metadata
-    // adjacent to airport codes. Blocking these would reject every page
-    // with a layover description in the gap, including legitimate ones.
-    // Chained routes that route through a real airport code are still
-    // caught by the IATA-allowlist guard (LHR/FCO/NYC etc. block the gap).
-    // Currency-airport overlaps with these phrasings are out of scope.
-    // The phrasing "BDS to HKD stopping at JFK" is unusual on real pages.
+  it('still accepts bare "stop" / "Nonstop" metadata on flight cards', () => {
+    // The chain-phrase blockers target chained-route phrases like "stops at"
+    // or "with a stop". Bare "stop" / "1 stop" / "Nonstop" remains unblocked
+    // because that text appears in legitimate flight-card metadata adjacent
+    // to airport codes.
     expect(pageHasRequestedRoute('BDS Brindisi to JFK 1 stop', 'BDS', 'JFK')).toBe(true);
-    // The currency-airport overlap with "stopping" remains theoretically
-    // open. Real Google headers do not phrase headers this way.
-    expect(pageHasRequestedRoute('BDS to HKD stopping at JFK', 'BDS', 'JFK')).toBe(true);
+    expect(pageHasRequestedRoute('Flights from BDS to JFK Nonstop', 'BDS', 'JFK')).toBe(true);
+  });
+
+  it.each([
+    ['stops at', 'BDS to HKD stops at JFK'],
+    ['stops in', 'BDS to HKD stops in JFK'],
+    ['stop at', 'BDS to HKD stop at JFK'],
+    ['stop in', 'BDS to HKD stop in JFK'],
+    ['stopping at', 'BDS to HKD stopping at JFK'],
+    ['stopping in', 'BDS to HKD stopping in JFK'],
+    ['with stop', 'BDS to HKD with stop JFK'],
+    ['with a stop', 'BDS to HKD with a stop JFK'],
+    ['with stopover', 'BDS to HKD with stopover JFK'],
+    ['with a stopover', 'BDS to HKD with a stopover JFK'],
+    ['stop over (two words)', 'BDS to HKD stop over JFK'],
+    ['stop-over (hyphen)', 'BDS to HKD stop-over JFK'],
+    ['connection', 'BDS to HKD connection JFK'],
+    ['connection at', 'BDS to HKD connection at JFK'],
+    ['connection in', 'BDS to HKD connection in JFK'],
+    ['connection through', 'BDS to HKD connection through JFK'],
+  ])('rejects chained-route phrase "%s" even with currency-airport overlap', (_label, text) => {
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
+  it.each([
+    ['Stops At', 'BDS to HKD Stops At JFK'],
+    ['STOPPING IN', 'BDS to HKD STOPPING IN JFK'],
+    ['With A Stop', 'BDS to HKD With A Stop JFK'],
+    ['Connection Through', 'BDS to HKD Connection Through JFK'],
+  ])('chain-phrase blockers are case-insensitive (%s)', (_label, text) => {
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 
   it('still rejects unknown 3-letter uppercase codes (real airport layovers)', () => {

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildGoogleFlightsUrl, buildGoogleFlightsUrlCandidates } from './navigate';
+import {
+  buildGoogleFlightsUrl,
+  buildGoogleFlightsUrlCandidates,
+  pageHasRequestedRoute,
+} from './navigate';
 
 describe('buildGoogleFlightsUrl', () => {
   const base = {
@@ -82,9 +86,20 @@ describe('buildGoogleFlightsUrlCandidates (regression: #65)', () => {
     const candidates = buildGoogleFlightsUrlCandidates(oneWay);
     expect(candidates).toHaveLength(3);
     expect(candidates[0]).toContain('one+way+flights+from+BDS+to+JFK');
-    expect(candidates[1]).toMatch(/\?q=BDS\+to\+JFK\+2026-11-09/);
+    expect(candidates[1]).toContain('one+way+BDS+to+JFK+2026-11-09');
     expect(candidates[1]).not.toContain('flights+from');
-    expect(candidates[2]).toContain('flights+to+JFK+from+BDS+departing+2026-11-09');
+    expect(candidates[2]).toContain('one+way+flights+to+JFK+from+BDS+departing+2026-11-09');
+  });
+
+  it('every one-way candidate carries the "one way" token (regression: silent trip-type drift)', () => {
+    // Without an explicit "one way" marker Google may infer round trip from
+    // a single date and return prices that include an unrequested return leg.
+    // Every one-way candidate must carry the marker so trip type is never
+    // ambiguous to Google's parser.
+    const candidates = buildGoogleFlightsUrlCandidates(oneWay);
+    for (const url of candidates) {
+      expect(url).toContain('one+way');
+    }
   });
 
   it('every candidate carries the requested date — never a date-less URL', () => {
@@ -123,6 +138,79 @@ describe('buildGoogleFlightsUrlCandidates (regression: #65)', () => {
     expect(candidates[0]).toContain('on+2026-11-09+to+2026-11-15');
     expect(candidates[1]).toContain('BDS+to+JFK+2026-11-09+to+2026-11-15');
     expect(candidates[2]).toContain('departing+2026-11-09+returning+2026-11-15');
-    expect(candidates[2]).not.toContain('one+way');
+    // No candidate should announce one-way intent on a round trip.
+    for (const url of candidates) {
+      expect(url).not.toContain('one+way');
+    }
+  });
+});
+
+describe('IATA validation (regression: query-param injection via raw interpolation)', () => {
+  // URLSearchParams encodes specials safely, but a malformed code (lowercase,
+  // contains an ampersand, contains a space) means the upstream parser wrote
+  // garbage; building a URL on top of garbage masks the real bug. Reject
+  // explicitly at the boundary.
+  const ok = {
+    origin: 'BDS',
+    destination: 'JFK',
+    dateFrom: new Date('2026-11-09T00:00:00Z'),
+    dateTo: new Date('2026-11-09T00:00:00Z'),
+    tripType: 'one_way',
+  };
+
+  it.each([
+    ['lowercase code', { origin: 'bds' }],
+    ['contains ampersand', { origin: 'BDS&curr=USD' }],
+    ['contains hash', { destination: 'JFK#x' }],
+    ['contains space', { origin: 'BD S' }],
+    ['too short', { origin: 'BD' }],
+    ['too long', { origin: 'BDSX' }],
+    ['empty', { origin: '' }],
+  ])('rejects %s', (_label, override) => {
+    expect(() => buildGoogleFlightsUrl({ ...ok, ...override })).toThrow(/Invalid IATA/);
+    expect(() => buildGoogleFlightsUrlCandidates({ ...ok, ...override })).toThrow(/Invalid IATA/);
+  });
+
+  it('accepts standard 3-letter uppercase codes', () => {
+    expect(() => buildGoogleFlightsUrlCandidates(ok)).not.toThrow();
+  });
+});
+
+describe('pageHasRequestedRoute (post-navigation defense)', () => {
+  // After the URL fix and rotation, this is the last line of defense against
+  // silent route corruption: even if a candidate URL "succeeds", verify the
+  // rendered page is showing the requested route before extracting prices.
+
+  it('returns true when both airport codes appear in the page text', () => {
+    const text = 'Flights from BDS to JFK\n€96\nTurkish Airlines\nDeparts Wed Nov 9';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  });
+
+  it('returns false when origin code is missing (homepage fallback case)', () => {
+    // Bare /travel/flights homepage shows recommended destinations from your
+    // location — JFK might appear in suggestions, BDS will not.
+    const text = 'Top destinations from Rome (FCO): JFK New York, LHR London';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
+  it('returns false when destination code is missing (route-substitution case)', () => {
+    // If Google silently swaps the destination (BDS to FCO instead of JFK),
+    // we must NOT write snapshots tagged JFK with FCO prices.
+    const text = 'Cheapest flights from BDS to FCO: €45';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
+  it('uses word boundaries so codes inside other tokens do not false-match', () => {
+    // "PAYTON" must not satisfy a search for "AYT" — both are 3 chars but the
+    // user is tracking AYT (Antalya), not a name.
+    const text = 'Booking under PAYTON, John\nDeparts ISTANBUL';
+    expect(pageHasRequestedRoute(text, 'IST', 'AYT')).toBe(false);
+  });
+
+  it('matches case-sensitively (IATA codes are uppercase)', () => {
+    // IATA codes are always uppercase. A page containing only lowercase "bds"
+    // is suspicious and should not satisfy the check.
+    const text = 'flights from bds to jfk are available';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 });

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -3,6 +3,7 @@ import {
   buildGoogleFlightsUrl,
   buildGoogleFlightsUrlCandidates,
   pageHasRequestedRoute,
+  pageRedirectedToHomepage,
 } from './navigate';
 
 describe('buildGoogleFlightsUrl', () => {
@@ -177,40 +178,90 @@ describe('IATA validation (regression: query-param injection via raw interpolati
 });
 
 describe('pageHasRequestedRoute (post-navigation defense)', () => {
-  // After the URL fix and rotation, this is the last line of defense against
-  // silent route corruption: even if a candidate URL "succeeds", verify the
-  // rendered page is showing the requested route before extracting prices.
+  // After URL rotation, this is the last line of defense against silent route
+  // corruption: verify the rendered page shows the requested route in the
+  // requested direction before extracting prices.
 
-  it('returns true when both airport codes appear in the page text', () => {
+  it('returns true when codes appear in directional order with a connector', () => {
     const text = 'Flights from BDS to JFK\n€96\nTurkish Airlines\nDeparts Wed Nov 9';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
   });
 
+  it('accepts arrow connectors used in flight cards', () => {
+    const text = 'BDS → JFK · 14h 20m · 1 stop';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  });
+
+  it('accepts long flight-card context between codes (~120 chars)', () => {
+    // Real flight cards put airline, duration, stops, time between codes.
+    const text = 'BDS 6:35 PM Turkish Airlines TK 1882 14h 20m 1 stop in IST JFK 9:55 PM';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  });
+
   it('returns false when origin code is missing (homepage fallback case)', () => {
-    // Bare /travel/flights homepage shows recommended destinations from your
-    // location — JFK might appear in suggestions, BDS will not.
     const text = 'Top destinations from Rome (FCO): JFK New York, LHR London';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 
-  it('returns false when destination code is missing (route-substitution case)', () => {
-    // If Google silently swaps the destination (BDS to FCO instead of JFK),
-    // we must NOT write snapshots tagged JFK with FCO prices.
+  it('returns false when destination code is missing (route substitution)', () => {
     const text = 'Cheapest flights from BDS to FCO: €45';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 
+  it('returns false when codes appear but in WRONG direction (swap regression)', () => {
+    // Critical: a page for JFK→BDS contains both codes. The directional
+    // regex must reject it because the user requested BDS→JFK, and writing
+    // JFK→BDS prices under a BDS→JFK tracker is silent corruption.
+    const text = 'Flights from JFK to BDS\n€350\nDelta';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
+  it('returns false when codes appear in unrelated suggestion lists with no directional context', () => {
+    // Both codes exist on the homepage in disjointed contexts — there is no
+    // connector linking them in the requested direction.
+    const text = `Recent searches:
+      LHR to JFK
+      MAD to FCO
+      Popular from your area:
+        BDS · Brindisi
+        FCO · Rome
+        NAP · Naples`;
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
   it('uses word boundaries so codes inside other tokens do not false-match', () => {
-    // "PAYTON" must not satisfy a search for "AYT" — both are 3 chars but the
-    // user is tracking AYT (Antalya), not a name.
     const text = 'Booking under PAYTON, John\nDeparts ISTANBUL';
     expect(pageHasRequestedRoute(text, 'IST', 'AYT')).toBe(false);
   });
 
   it('matches case-sensitively (IATA codes are uppercase)', () => {
-    // IATA codes are always uppercase. A page containing only lowercase "bds"
-    // is suspicious and should not satisfy the check.
     const text = 'flights from bds to jfk are available';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+});
+
+describe('pageRedirectedToHomepage (the #65 headline failure mode)', () => {
+  it('detects when Google strips the q= parameter on redirect', () => {
+    const input = 'https://www.google.com/travel/flights?q=one+way+BDS+to+JFK&hl=en';
+    const final = 'https://www.google.com/travel/flights?hl=en';
+    expect(pageRedirectedToHomepage(input, final)).toBe(true);
+  });
+
+  it('returns false when q= survives the redirect', () => {
+    const input = 'https://www.google.com/travel/flights?q=one+way+BDS+to+JFK&hl=en';
+    const final = 'https://www.google.com/travel/flights?q=one+way+BDS+to+JFK&hl=en';
+    expect(pageRedirectedToHomepage(input, final)).toBe(false);
+  });
+
+  it('returns false when input never had a q= (cannot be a fallback)', () => {
+    // We are not currently producing such URLs (every candidate has q=),
+    // but defending against the symmetric case keeps the helper honest.
+    const input = 'https://www.google.com/travel/flights/search?tfs=ABC';
+    const final = 'https://www.google.com/travel/flights?hl=en';
+    expect(pageRedirectedToHomepage(input, final)).toBe(false);
+  });
+
+  it('returns false on malformed URL inputs (defensive)', () => {
+    expect(pageRedirectedToHomepage('not a url', 'also not a url')).toBe(false);
   });
 });

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildGoogleFlightsUrl } from './navigate';
+import { buildGoogleFlightsUrl, buildGoogleFlightsUrlCandidates } from './navigate';
 
 describe('buildGoogleFlightsUrl', () => {
   const base = {
@@ -40,5 +40,77 @@ describe('buildGoogleFlightsUrl', () => {
     expect(url).not.toContain('&curr=');
     expect(url).not.toContain('&gl=');
     expect(url).toContain('&hl=en');
+  });
+
+  describe('one-way URL formatting (regression: #65)', () => {
+    const baseOneWay = {
+      origin: 'BDS',
+      destination: 'JFK',
+      dateFrom: new Date('2026-11-09T00:00:00Z'),
+      dateTo: new Date('2026-11-09T00:00:00Z'),
+      tripType: 'one_way',
+    };
+
+    it('omits the redundant "+to+${dateTo}" segment for one-way', () => {
+      // Google's NLU misparses "on YYYY-MM-DD to YYYY-MM-DD" for less common
+      // airport codes and falls back to the homepage. One-way searches must
+      // only emit a single date.
+      const url = buildGoogleFlightsUrl(baseOneWay);
+      expect(url).toContain('one+way+flights+from+BDS+to+JFK+on+2026-11-09');
+      expect(url).not.toMatch(/on\+2026-11-09\+to\+2026-11-09/);
+    });
+
+    it('keeps "+to+${dateTo}" for round-trip searches with same dates', () => {
+      const url = buildGoogleFlightsUrl({ ...baseOneWay, tripType: 'round_trip' });
+      expect(url).toContain('flights+from+BDS+to+JFK+on+2026-11-09+to+2026-11-09');
+      expect(url).not.toContain('one+way');
+    });
+  });
+});
+
+describe('buildGoogleFlightsUrlCandidates (regression: #65)', () => {
+  const oneWay = {
+    origin: 'BDS',
+    destination: 'JFK',
+    dateFrom: new Date('2026-11-09T00:00:00Z'),
+    dateTo: new Date('2026-11-09T00:00:00Z'),
+    tripType: 'one_way',
+    currency: 'EUR',
+  };
+
+  it('returns three structurally distinct URL formats', () => {
+    const candidates = buildGoogleFlightsUrlCandidates(oneWay);
+    expect(candidates).toHaveLength(3);
+    expect(candidates[0]).toContain('one+way+flights+from+BDS+to+JFK');
+    expect(candidates[1]).toMatch(/\?q=BDS\+to\+JFK\+2026-11-09/);
+    expect(candidates[1]).not.toContain('flights+from');
+    expect(candidates[2]).toContain('/flights-from-BDS-to-JFK.html');
+  });
+
+  it('propagates currency and locale to every candidate', () => {
+    const candidates = buildGoogleFlightsUrlCandidates({ ...oneWay, country: 'IT' });
+    for (const url of candidates) {
+      expect(url).toContain('hl=en');
+      expect(url).toContain('curr=EUR');
+      expect(url).toContain('gl=IT');
+    }
+  });
+
+  it('all candidates differ — retrying must hit a new URL each time', () => {
+    const candidates = buildGoogleFlightsUrlCandidates(oneWay);
+    expect(new Set(candidates).size).toBe(candidates.length);
+  });
+
+  it('handles round-trip dates correctly across candidates', () => {
+    const rt = {
+      ...oneWay,
+      tripType: 'round_trip',
+      dateTo: new Date('2026-11-15T00:00:00Z'),
+    };
+    const candidates = buildGoogleFlightsUrlCandidates(rt);
+    expect(candidates[0]).toContain('on+2026-11-09+to+2026-11-15');
+    expect(candidates[1]).toContain('BDS+to+JFK+2026-11-09+to+2026-11-15');
+    // Path landing has no date; the form is filled after navigation.
+    expect(candidates[2]).not.toContain('2026-11-09');
   });
 });

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -281,6 +281,35 @@ describe('pageHasRequestedRoute (strict directional defense)', () => {
     const text = 'BDS 6:35 - 9:55 JFK';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
+
+  // ---- Allowlist exceptions: origin/destination aliases and currency codes ----
+
+  it('accepts repeated origin code as parenthetical alias ("BDS Brindisi (BDS) to JFK")', () => {
+    // Google Flights commonly renders headers with the code, the airport name,
+    // and the code again in parentheses. The repeated origin must not block
+    // the gap.
+    const text = 'BDS Brindisi (BDS) to JFK';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  });
+
+  it('accepts repeated destination code in parens ("from BDS to JFK (JFK)")', () => {
+    const text = 'Flights from BDS to JFK (JFK) New York';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  });
+
+  it('accepts currency codes in the gap ("BDS to USD airport JFK")', () => {
+    // USD/EUR/GBP/JPY/CHF/CAD/AUD are 3-letter uppercase but not airport
+    // codes. Google may render currency labels in flight pages.
+    const text = 'BDS Brindisi to USD area JFK';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  });
+
+  it('still rejects unknown 3-letter uppercase codes (real airport layovers)', () => {
+    // Allowlist must NOT swallow real airport codes that are layovers.
+    expect(pageHasRequestedRoute('BDS to LHR via JFK', 'BDS', 'JFK')).toBe(false);
+    expect(pageHasRequestedRoute('BDS via NYC to JFK', 'BDS', 'JFK')).toBe(false);
+    expect(pageHasRequestedRoute('BDS Brindisi to FCO via JFK', 'BDS', 'JFK')).toBe(false);
+  });
 });
 
 describe('pageRedirectedToHomepage (the #65 headline failure mode)', () => {

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -298,10 +298,18 @@ describe('pageHasRequestedRoute (strict directional defense)', () => {
   });
 
   it('accepts currency codes in the gap ("BDS to USD airport JFK")', () => {
-    // USD/EUR/GBP/JPY/CHF/CAD/AUD are 3-letter uppercase but not airport
+    // USD/EUR/GBP/JPY/CHF/CAD/AUD/TRY are 3-letter uppercase but not airport
     // codes. Google may render currency labels in flight pages.
     const text = 'BDS Brindisi to USD area JFK';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  });
+
+  it('accepts TRY in the gap (Turkish Lira, regression for #64 IST/AYT scenario)', () => {
+    // The IST/AYT example in issue #64 is in the Turkish market where TRY
+    // labels commonly appear in Google Flights headers. Without TRY in the
+    // allowlist the route validator would always reject those pages.
+    const text = 'IST Istanbul to TRY area AYT';
+    expect(pageHasRequestedRoute(text, 'IST', 'AYT')).toBe(true);
   });
 
   it('still rejects unknown 3-letter uppercase codes (real airport layovers)', () => {

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -355,10 +355,38 @@ describe('pageHasRequestedRoute (strict directional defense)', () => {
     expect(pageHasRequestedRoute('BDS to CAD via JFK', 'BDS', 'JFK')).toBe(false);
   });
 
-  it('rejects chained routes phrased with "layover", "through", "connecting"', () => {
+  it('rejects chained routes phrased with "layover", "through", "connecting", "stopover"', () => {
     expect(pageHasRequestedRoute('BDS to HKD layover JFK', 'BDS', 'JFK')).toBe(false);
     expect(pageHasRequestedRoute('BDS to FCO through JFK', 'BDS', 'JFK')).toBe(false);
     expect(pageHasRequestedRoute('BDS to LHR connecting JFK', 'BDS', 'JFK')).toBe(false);
+    expect(pageHasRequestedRoute('BDS to HKD stopover JFK', 'BDS', 'JFK')).toBe(false);
+  });
+
+  it.each([
+    ['Via', 'BDS to HKD Via JFK'],
+    ['VIA', 'BDS to HKD VIA JFK'],
+    ['Layover', 'BDS to HKD Layover JFK'],
+    ['LAYOVER', 'BDS to HKD LAYOVER JFK'],
+    ['Connecting', 'BDS to HKD Connecting JFK'],
+    ['CONNECTING', 'BDS to HKD CONNECTING JFK'],
+    ['Through', 'BDS to HKD Through JFK'],
+    ['Stopover', 'BDS to HKD Stopover JFK'],
+  ])('rejects %s case variant of chaining keyword', (_label, text) => {
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
+  it('does NOT block "stop" / "stops" / "stopping" (intentional, real flight cards use them)', () => {
+    // Google flight cards display "1 stop", "Nonstop", etc. in metadata
+    // adjacent to airport codes. Blocking these would reject every page
+    // with a layover description in the gap, including legitimate ones.
+    // Chained routes that route through a real airport code are still
+    // caught by the IATA-allowlist guard (LHR/FCO/NYC etc. block the gap).
+    // Currency-airport overlaps with these phrasings are out of scope.
+    // The phrasing "BDS to HKD stopping at JFK" is unusual on real pages.
+    expect(pageHasRequestedRoute('BDS Brindisi to JFK 1 stop', 'BDS', 'JFK')).toBe(true);
+    // The currency-airport overlap with "stopping" remains theoretically
+    // open. Real Google headers do not phrase headers this way.
+    expect(pageHasRequestedRoute('BDS to HKD stopping at JFK', 'BDS', 'JFK')).toBe(true);
   });
 
   it('still rejects unknown 3-letter uppercase codes (real airport layovers)', () => {

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -84,7 +84,19 @@ describe('buildGoogleFlightsUrlCandidates (regression: #65)', () => {
     expect(candidates[0]).toContain('one+way+flights+from+BDS+to+JFK');
     expect(candidates[1]).toMatch(/\?q=BDS\+to\+JFK\+2026-11-09/);
     expect(candidates[1]).not.toContain('flights+from');
-    expect(candidates[2]).toContain('/flights-from-BDS-to-JFK.html');
+    expect(candidates[2]).toContain('flights+to+JFK+from+BDS+departing+2026-11-09');
+  });
+
+  it('every candidate carries the requested date — never a date-less URL', () => {
+    // The SEO landing /flights-from-X-to-Y.html was rejected for #65 because
+    // Google fills missing dates with defaults, which would silently write
+    // snapshots tagged with the user's travelDate but priced for the wrong
+    // departure. Every candidate must carry the requested date.
+    const candidates = buildGoogleFlightsUrlCandidates(oneWay);
+    for (const url of candidates) {
+      expect(url).toContain('2026-11-09');
+    }
+    expect(candidates.some((u) => u.includes('flights-from-BDS-to-JFK.html'))).toBe(false);
   });
 
   it('propagates currency and locale to every candidate', () => {
@@ -110,7 +122,7 @@ describe('buildGoogleFlightsUrlCandidates (regression: #65)', () => {
     const candidates = buildGoogleFlightsUrlCandidates(rt);
     expect(candidates[0]).toContain('on+2026-11-09+to+2026-11-15');
     expect(candidates[1]).toContain('BDS+to+JFK+2026-11-09+to+2026-11-15');
-    // Path landing has no date; the form is filled after navigation.
-    expect(candidates[2]).not.toContain('2026-11-09');
+    expect(candidates[2]).toContain('departing+2026-11-09+returning+2026-11-15');
+    expect(candidates[2]).not.toContain('one+way');
   });
 });

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -177,48 +177,78 @@ describe('IATA validation (regression: query-param injection via raw interpolati
   });
 });
 
-describe('pageHasRequestedRoute (post-navigation defense)', () => {
-  // After URL rotation, this is the last line of defense against silent route
-  // corruption: verify the rendered page shows the requested route in the
-  // requested direction before extracting prices.
+describe('pageHasRequestedRoute (strict directional defense)', () => {
+  // Strict patterns: each pattern requires the airport codes adjacent to a
+  // route connector with no other IATA-shaped token between them.
 
-  it('returns true when codes appear in directional order with a connector', () => {
+  // ---- POSITIVE cases: real Google Flights page text shapes ----
+
+  it('matches the page header "Flights from BDS to JFK"', () => {
     const text = 'Flights from BDS to JFK\n€96\nTurkish Airlines\nDeparts Wed Nov 9';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
   });
 
-  it('accepts arrow connectors used in flight cards', () => {
+  it('matches the airport-name header "BDS Brindisi to JFK"', () => {
+    // Google often renders the search bar with airport names mixed with codes.
+    const text = 'BDS Brindisi to JFK John F. Kennedy';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  });
+
+  it('matches arrow connectors', () => {
     const text = 'BDS → JFK · 14h 20m · 1 stop';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
   });
 
-  it('accepts long flight-card context between codes (~120 chars)', () => {
-    // Real flight cards put airline, duration, stops, time between codes.
-    const text = 'BDS 6:35 PM Turkish Airlines TK 1882 14h 20m 1 stop in IST JFK 9:55 PM';
-    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  it('matches dash connectors with adjacent codes', () => {
+    expect(pageHasRequestedRoute('BDS - JFK', 'BDS', 'JFK')).toBe(true);
+    expect(pageHasRequestedRoute('BDS – JFK', 'BDS', 'JFK')).toBe(true);
+    expect(pageHasRequestedRoute('BDS — JFK', 'BDS', 'JFK')).toBe(true);
+    expect(pageHasRequestedRoute('BDS-JFK', 'BDS', 'JFK')).toBe(true);
   });
 
-  it('returns false when origin code is missing (homepage fallback case)', () => {
+  // ---- NEGATIVE cases: silent-corruption modes that previously leaked ----
+
+  it('rejects a chained route "BDS Brindisi to LHR via JFK"', () => {
+    // Audit cycle 3 caught this: previous loose regex matched
+    // BDS .* to .* JFK across the whole string, ignoring that the actual
+    // route is BDS to LHR with JFK as a layover.
+    const text = 'BDS Brindisi to LHR via JFK';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
+  it('rejects a multi-leg sentence "BDS to FCO and FCO to JFK"', () => {
+    // Two legitimate routes back to back must not satisfy a single-route
+    // tracker. The lazy match of unrelated context blocks IATA codes from
+    // appearing between origin and destination.
+    const text = 'BDS to FCO and FCO to JFK';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
+  it('rejects a flight card with no header connector ("BDS 6:35 PM ... JFK 9:55 PM")', () => {
+    // A previous test of this exact text passed only because "stop" contains
+    // "to" inside an unbounded regex. With strict tokenization the page text
+    // must carry an explicit "to", arrow, or dash adjacent to both codes,
+    // which only the page header reliably has.
+    const text = 'BDS 6:35 PM Turkish Airlines TK 1882 14h 20m 1 stop in IST JFK 9:55 PM';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
+  it('rejects when origin code is missing (homepage fallback)', () => {
     const text = 'Top destinations from Rome (FCO): JFK New York, LHR London';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 
-  it('returns false when destination code is missing (route substitution)', () => {
+  it('rejects route substitution (BDS to FCO when user wanted BDS to JFK)', () => {
     const text = 'Cheapest flights from BDS to FCO: €45';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 
-  it('returns false when codes appear but in WRONG direction (swap regression)', () => {
-    // Critical: a page for JFK→BDS contains both codes. The directional
-    // regex must reject it because the user requested BDS→JFK, and writing
-    // JFK→BDS prices under a BDS→JFK tracker is silent corruption.
+  it('rejects swapped route (JFK to BDS when user wanted BDS to JFK)', () => {
     const text = 'Flights from JFK to BDS\n€350\nDelta';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 
-  it('returns false when codes appear in unrelated suggestion lists with no directional context', () => {
-    // Both codes exist on the homepage in disjointed contexts — there is no
-    // connector linking them in the requested direction.
+  it('rejects unrelated suggestion lists with codes scattered', () => {
     const text = `Recent searches:
       LHR to JFK
       MAD to FCO
@@ -229,6 +259,12 @@ describe('pageHasRequestedRoute (post-navigation defense)', () => {
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 
+  it('rejects "to" appearing inside other words ("stop", "Toronto", "destination")', () => {
+    // These contain "to" as a substring but never as a tokenized word.
+    const text = 'BDS sets a stop record at the destination Toronto and JFK';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
   it('uses word boundaries so codes inside other tokens do not false-match', () => {
     const text = 'Booking under PAYTON, John\nDeparts ISTANBUL';
     expect(pageHasRequestedRoute(text, 'IST', 'AYT')).toBe(false);
@@ -236,6 +272,13 @@ describe('pageHasRequestedRoute (post-navigation defense)', () => {
 
   it('matches case-sensitively (IATA codes are uppercase)', () => {
     const text = 'flights from bds to jfk are available';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
+  });
+
+  it('rejects dashes inside dates and durations from connecting unrelated codes', () => {
+    // A time range "BDS 6:35 - 9:55 JFK" has a dash but it connects times
+    // not codes. The dash pattern requires immediate adjacency to both codes.
+    const text = 'BDS 6:35 - 9:55 JFK';
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false);
   });
 });

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -312,6 +312,35 @@ describe('pageHasRequestedRoute (strict directional defense)', () => {
     expect(pageHasRequestedRoute(text, 'IST', 'AYT')).toBe(true);
   });
 
+  it.each([
+    'CNY', 'INR', 'MXN', 'BRL', 'KRW', 'SGD', 'HKD',
+    'SEK', 'NOK', 'DKK', 'NZD', 'THB', 'COP', 'ARS',
+  ])('accepts every settings-supported currency in the gap (%s)', (curr) => {
+    // The settings dropdown lets users pick any of these currencies.
+    // pageHasRequestedRoute must allow each one in the gap so the locales
+    // we explicitly support never produce silent rejection.
+    const text = `BDS Brindisi to ${curr} fares JFK`;
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(true);
+  });
+
+  it('accepts a dynamically supplied custom currency code', () => {
+    // Settings exposes "Other..." which lets the user type any 3-letter ISO
+    // 4217 code. Those are not in the static list but must still be allowed.
+    // ZAR (South African Rand) is a real ISO code not in the dropdown.
+    const text = 'BDS Brindisi to ZAR fares JFK';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK')).toBe(false); // not in static list
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK', 'ZAR')).toBe(true); // dynamic param allows it
+  });
+
+  it('ignores a malformed dynamic currency (not 3 uppercase)', () => {
+    // Defensive: callers passing junk like 'eur', 'EU', '$$$' must not
+    // expand the allowlist with arbitrary tokens.
+    const text = 'BDS Brindisi to LHR fares JFK';
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK', 'lhr')).toBe(false);
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK', 'LH')).toBe(false);
+    expect(pageHasRequestedRoute(text, 'BDS', 'JFK', '$$$')).toBe(false);
+  });
+
   it('still rejects unknown 3-letter uppercase codes (real airport layovers)', () => {
     // Allowlist must NOT swallow real airport codes that are layovers.
     expect(pageHasRequestedRoute('BDS to LHR via JFK', 'BDS', 'JFK')).toBe(false);

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -341,21 +341,24 @@ describe('pageHasRequestedRoute (strict directional defense)', () => {
     expect(pageHasRequestedRoute(text, 'BDS', 'JFK', '$$$')).toBe(false);
   });
 
-  it('documents the currency/IATA overlap residual risk', () => {
+  it('rejects chained routes even when the layover code is allowlisted (currency/IATA overlap)', () => {
     // Several allowlisted currency codes are ALSO real (small) IATA airport
     // codes: HKD = Hakodate, BRL = Borba, CAD = Cadillac, CHF = Chefornak.
-    // A chained-route phrase using one of those as a layover technically
-    // passes the route validator. We accept this because:
-    //
-    // (a) Real Google Flights pages do not render "BDS to HKD via JFK" as
-    //     a header for a JFK booking — Hakodate is not a layover hop on
-    //     EU-to-NA routes.
-    // (b) Removing overlapping currencies would resurface the cycle-5/6
-    //     false-negative bugs for users actually transacting in HKD/BRL/etc.
-    //
-    // This test exists to make the trade-off explicit so a future change
-    // that wants stricter behavior knows what it is overriding.
-    expect(pageHasRequestedRoute('BDS to HKD via JFK', 'BDS', 'JFK')).toBe(true);
+    // A naive allowlist would let "BDS to HKD via JFK" pass because HKD
+    // is allowed as a currency. The fix is structural: we block the
+    // chaining keywords (`via`, `layover`, `through`, `connecting`) inside
+    // the gap. Real Google Flights route headers never carry those words
+    // between the airport pair, so legitimate pages are unaffected, while
+    // any chained phrase fails immediately at `via`.
+    expect(pageHasRequestedRoute('BDS to HKD via JFK', 'BDS', 'JFK')).toBe(false);
+    expect(pageHasRequestedRoute('BDS to BRL via JFK', 'BDS', 'JFK')).toBe(false);
+    expect(pageHasRequestedRoute('BDS to CAD via JFK', 'BDS', 'JFK')).toBe(false);
+  });
+
+  it('rejects chained routes phrased with "layover", "through", "connecting"', () => {
+    expect(pageHasRequestedRoute('BDS to HKD layover JFK', 'BDS', 'JFK')).toBe(false);
+    expect(pageHasRequestedRoute('BDS to FCO through JFK', 'BDS', 'JFK')).toBe(false);
+    expect(pageHasRequestedRoute('BDS to LHR connecting JFK', 'BDS', 'JFK')).toBe(false);
   });
 
   it('still rejects unknown 3-letter uppercase codes (real airport layovers)', () => {

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -53,58 +53,123 @@ export interface NavigationResult {
   source: NavigationSource;
 }
 
-function buildQueryString(params: FlightSearchParams): string {
-  const qs = ['hl=en'];
-  if (params.currency) qs.push(`curr=${params.currency}`);
-  if (params.country) qs.push(`gl=${params.country}`);
-  return qs.join('&');
+// IATA codes are exactly 3 uppercase A-Z. Anything else means the upstream
+// query parser wrote garbage (or a user-supplied code escaped sanitization)
+// and would otherwise corrupt the URL via raw interpolation.
+const IATA_CODE = /^[A-Z]{3}$/;
+
+function assertValidIataCode(code: string, role: 'origin' | 'destination'): void {
+  if (!IATA_CODE.test(code)) {
+    throw new Error(`Invalid IATA ${role} code: ${JSON.stringify(code)}`);
+  }
+}
+
+function isoDate(d: Date): string {
+  // toISOString().split('T')[0] returns the UTC calendar day. Callers that
+  // construct dates in non-UTC timezones can see a day shift here; that risk
+  // predates this file and is tracked separately.
+  return d.toISOString().split('T')[0]!;
+}
+
+function buildFlightsUrl(qPhrase: string, params: FlightSearchParams): string {
+  const url = new URL('https://www.google.com/travel/flights');
+  url.searchParams.set('q', qPhrase);
+  url.searchParams.set('hl', 'en');
+  if (params.currency) url.searchParams.set('curr', params.currency);
+  if (params.country) url.searchParams.set('gl', params.country);
+  return url.toString();
 }
 
 export function buildGoogleFlightsUrl(params: FlightSearchParams): string {
-  // Verbose phrase form. For one-way searches we omit "+to+${dateTo}" — Google
-  // Flights' NLU misparses "on YYYY-MM-DD to YYYY-MM-DD" for less-trafficked
-  // airport codes (e.g. BDS, BRI) and falls back to the bare homepage. See #65.
-  const dateFrom = params.dateFrom.toISOString().split('T')[0];
-  const dateTo = params.dateTo.toISOString().split('T')[0];
-  const oneWay = params.tripType === 'one_way';
-  const oneWayPrefix = oneWay ? 'one+way+' : '';
-  const datePart = oneWay ? `+on+${dateFrom}` : `+on+${dateFrom}+to+${dateTo}`;
+  // Verbose phrase form. For one-way searches we omit the trailing "to ${dateTo}"
+  // because Google Flights' NLU misparses "on YYYY-MM-DD to YYYY-MM-DD" for
+  // less popular airport codes (BDS, BRI) and falls back to the bare homepage.
+  // See #65.
+  assertValidIataCode(params.origin, 'origin');
+  assertValidIataCode(params.destination, 'destination');
 
-  return `https://www.google.com/travel/flights?q=${oneWayPrefix}flights+from+${params.origin}+to+${params.destination}${datePart}&${buildQueryString(params)}`;
+  const dateFrom = isoDate(params.dateFrom);
+  const dateTo = isoDate(params.dateTo);
+  const oneWay = params.tripType === 'one_way';
+  const oneWayPrefix = oneWay ? 'one way ' : '';
+  const datePart = oneWay ? `on ${dateFrom}` : `on ${dateFrom} to ${dateTo}`;
+
+  return buildFlightsUrl(
+    `${oneWayPrefix}flights from ${params.origin} to ${params.destination} ${datePart}`,
+    params,
+  );
 }
 
 /**
- * Build alternative Google Flights URL formats. The verbose `q=` text URL
- * (buildGoogleFlightsUrl) is what humans land on, but it depends on Google's
- * NLU and is unreliable for less-trafficked airport codes. Each candidate is
- * a text URL that *carries the requested dates* — we deliberately avoid the
- * `/travel/flights/flights-from-X-to-Y.html` SEO path because it omits dates
- * and trip type, and Google fills it with defaults that would silently write
- * snapshots for the wrong travelDate.
+ * Build three structurally distinct Google Flights URL candidates. The verbose
+ * `q=` text URL is what humans land on, but it depends on Google's NLU and is
+ * unreliable for less popular airport codes. Each candidate is a text URL that
+ * carries the requested dates AND an unambiguous trip-type token — we
+ * deliberately avoid date-less or trip-less URLs (SEO landings, partial
+ * phrases) because Google fills missing fields with defaults and Playwright
+ * would still see [data-gs], silently writing snapshots tagged with the
+ * user's travelDate but priced for the wrong departure.
  */
 export function buildGoogleFlightsUrlCandidates(params: FlightSearchParams): string[] {
-  const dateFrom = params.dateFrom.toISOString().split('T')[0];
-  const dateTo = params.dateTo.toISOString().split('T')[0];
+  assertValidIataCode(params.origin, 'origin');
+  assertValidIataCode(params.destination, 'destination');
+
+  const dateFrom = isoDate(params.dateFrom);
+  const dateTo = isoDate(params.dateTo);
   const oneWay = params.tripType === 'one_way';
-  const qs = buildQueryString(params);
+  const oneWayPrefix = oneWay ? 'one way ' : '';
 
   // Variant 1: verbose phrase, fixed for one-way (above).
   const verbose = buildGoogleFlightsUrl(params);
 
   // Variant 2: terse codes + date — fewer NLU tokens for Google to misinterpret.
-  const terseDate = oneWay ? `+${dateFrom}` : `+${dateFrom}+to+${dateTo}`;
-  const terse = `https://www.google.com/travel/flights?q=${params.origin}+to+${params.destination}${terseDate}&${qs}`;
+  // Always include the one-way token so Google does not infer round trip.
+  const terseDate = oneWay ? dateFrom : `${dateFrom} to ${dateTo}`;
+  const terse = buildFlightsUrl(
+    `${oneWayPrefix}${params.origin} to ${params.destination} ${terseDate}`,
+    params,
+  );
 
-  // Variant 3: reworded phrase — different verb ("departing"/"returning") and
+  // Variant 3: reworded phrase — different verbs ("departing"/"returning") and
   // a different word order put the airport codes adjacent to the keywords
-  // Google's NLU is most confident about, while still carrying the date(s).
-  const oneWayPrefix = oneWay ? 'one+way+' : '';
+  // Google's NLU is most confident about, while still carrying the date(s)
+  // and an explicit one-way marker for one-way trips.
   const dateClause = oneWay
-    ? `departing+${dateFrom}`
-    : `departing+${dateFrom}+returning+${dateTo}`;
-  const reworded = `https://www.google.com/travel/flights?q=${oneWayPrefix}flights+to+${params.destination}+from+${params.origin}+${dateClause}&${qs}`;
+    ? `departing ${dateFrom}`
+    : `departing ${dateFrom} returning ${dateTo}`;
+  const reworded = buildFlightsUrl(
+    `${oneWayPrefix}flights to ${params.destination} from ${params.origin} ${dateClause}`,
+    params,
+  );
 
   return [verbose, terse, reworded];
+}
+
+/** Stable label per candidate index, used in logs so failures are diagnosable. */
+const CANDIDATE_NAMES = ['verbose', 'terse', 'reworded'] as const;
+
+/**
+ * Verify the loaded Google Flights page is actually showing the requested
+ * route. Google's NLU can silently resolve an ambiguous query to a different
+ * airport pair, default dates, or the bare homepage and still render
+ * `[data-gs]`-bearing content. Without this guard, we would write snapshots
+ * tagged with the user's travelDate but priced for the wrong route.
+ *
+ * The check is intentionally narrow: we only assert the requested IATA codes
+ * appear in the visible text. Date validation is harder (Google renders dates
+ * in many formats) and a URL-rotation candidate that arrived at the right
+ * airports but the wrong date is much less plausible than a homepage fallback.
+ */
+export function pageHasRequestedRoute(
+  pageText: string,
+  origin: string,
+  destination: string,
+): boolean {
+  // Word-boundary match prevents "AYT" matching inside other tokens like
+  // "PAYTON". Codes are 3 uppercase letters, so this is safe.
+  const originRe = new RegExp(`\\b${origin}\\b`);
+  const destRe = new RegExp(`\\b${destination}\\b`);
+  return originRe.test(pageText) && destRe.test(pageText);
 }
 
 export async function navigateGoogleFlights(
@@ -120,13 +185,14 @@ export async function navigateGoogleFlights(
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const url = urlCandidates[attempt - 1]!;
+    const candidateName = CANDIDATE_NAMES[attempt - 1] ?? 'unknown';
     const browser = await launchBrowser({ proxyUrl });
     const attemptStart = Date.now();
 
     try {
       const context = await createStealthContext(browser, { countryProfile, proxyUrl });
       const page = await context.newPage();
-      console.log(`[navigate] attempt ${attempt}/${maxAttempts} → ${url}`);
+      console.log(`[navigate] attempt ${attempt}/${maxAttempts} (${candidateName}) → ${url}`);
 
       const gotoStart = Date.now();
       await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
@@ -168,22 +234,38 @@ export async function navigateGoogleFlights(
       // of HTML but only ~3k of visible text, and flight data starts deep in the DOM
       // where a 50k char cap would never reach it
       const html = await page.evaluate(() => document.body.innerText);
-      console.log(`[navigate] attempt ${attempt}: resultsFound=${resultsFound}, textLength=${html.length}, elapsed=${Date.now() - attemptStart}ms`);
+      const finalUrl = page.url();
+
+      // Belt-and-suspenders defense against silent route corruption: even when
+      // [data-gs] resolves, Google may have landed on a different airport pair,
+      // a homepage fallback, or default-date results. Verify the requested
+      // codes appear in the visible text before treating the attempt as a
+      // success — a false success here would write snapshots labeled with the
+      // user's travelDate but priced for the wrong route.
+      if (resultsFound && !pageHasRequestedRoute(html, params.origin, params.destination)) {
+        console.log(`[navigate] page text missing requested airports (origin=${params.origin}, dest=${params.destination}, finalUrl=${finalUrl}) — treating attempt ${attempt} (${candidateName}) as failed`);
+        resultsFound = false;
+      }
+
+      console.log(`[navigate] attempt ${attempt} (${candidateName}): resultsFound=${resultsFound}, textLength=${html.length}, finalUrl=${finalUrl}, elapsed=${Date.now() - attemptStart}ms`);
 
       await context.close();
 
       // Retry with fresh browser if no results and we have attempts left
       if (!resultsFound && attempt < maxAttempts) {
-        console.log(`[navigate] no results on attempt ${attempt}, retrying after delay…`);
+        console.log(`[navigate] no results on attempt ${attempt} (${candidateName}), retrying with next URL after delay…`);
         await new Promise((r) => setTimeout(r, 3000 + Math.random() * 4000));
         continue;
       }
 
+      if (resultsFound) {
+        console.log(`[navigate] succeeded with ${candidateName} candidate (final URL: ${finalUrl})`);
+      }
       return { html, url, resultsFound, source: 'google_flights' };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const isCrash = /crashed|target closed|disposed/i.test(message);
-      console.error(`[navigate] attempt ${attempt} failed (crash=${isCrash}, elapsed=${Date.now() - attemptStart}ms): ${message}`);
+      console.error(`[navigate] attempt ${attempt} (${candidateName}) failed (crash=${isCrash}, elapsed=${Date.now() - attemptStart}ms): ${message}`);
 
       if (attempt < maxAttempts) {
         await new Promise((r) => setTimeout(r, 3000 + Math.random() * 4000));

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -240,18 +240,43 @@ export function pageHasRequestedRoute(
   const allowedInGap = [origin, destination, ...dynamicCurrency, ...ALLOWED_CURRENCY_TOKENS]
     .map(escapeRegex)
     .join('|');
-  // Chaining keywords are matched case-insensitively. JS regex has no inline
-  // (?i) flag and the top-level /i flag would break the [A-Z]{3} IATA guard
-  // in this same alternation, so we expand each lowercase letter into a
-  // character class. "Via" / "VIA" / "via" all match.
-  // We deliberately do NOT include "stop" / "stopping" / "stops": those
-  // appear legitimately in flight-card metadata ("1 stop", "Nonstop") and
-  // would over-block the gap. Chained routes that use a non-currency IATA
-  // code as layover are still rejected by the IATA-allowlist guard below.
-  const eachCase = (word: string): string =>
-    word.split('').map((ch) => `[${ch.toLowerCase()}${ch.toUpperCase()}]`).join('');
-  const chainWords = ['via', 'layover', 'through', 'connecting', 'stopover'];
-  const blockingChainKeyword = `\\b(?:${chainWords.map(eachCase).join('|')})\\b`;
+  // Chaining keywords matched case-insensitively. JS regex has no inline (?i)
+  // flag and the top-level /i flag would break the [A-Z]{3} IATA guard in
+  // the same alternation, so each ASCII letter is expanded to a character
+  // class via `ci` below. The helper hard-fails on regex metacharacters so a
+  // future addition to the phrase list cannot silently inject regex syntax.
+  //
+  // Phrase coverage: bare chain words (via / layover / through / connecting /
+  // stopover) plus phrase-form variants that close the currency/IATA overlap
+  // for `stop`-family chained routes ("stopping at", "stops in", "with a
+  // stop at", "connection in"). Bare `stop`/`stops`/`stopping` is NOT
+  // blocked because real flight-card metadata (`1 stop`, `Nonstop`) sits in
+  // the 80-char gap on legitimate pages.
+  const ci = (word: string): string => {
+    if (!/^[a-z]+$/.test(word)) {
+      throw new Error(`pageHasRequestedRoute: ci() expects lowercase ASCII letters only, got ${JSON.stringify(word)}`);
+    }
+    return word.split('').map((ch) => `[${ch}${ch.toUpperCase()}]`).join('');
+  };
+  const chainPhrases = [
+    ci('via'),
+    ci('layover'),
+    ci('through'),
+    ci('connecting'),
+    ci('stopover'),
+    // "stop over" / "stop-over"
+    `${ci('stop')}[-\\s]+${ci('over')}`,
+    // "stop at"/"stop in"/"stops at"/"stops in"
+    `${ci('stop')}${ci('s')}?\\s+${ci('at')}`,
+    `${ci('stop')}${ci('s')}?\\s+${ci('in')}`,
+    // "stopping at"/"stopping in"
+    `${ci('stopping')}\\s+(?:${ci('at')}|${ci('in')})`,
+    // "with stop"/"with a stop"/"with stopover"/"with a stopover"
+    `${ci('with')}\\s+(?:${ci('a')}\\s+)?${ci('stop')}(?:${ci('over')})?`,
+    // "connection"/"connection at"/"connection in"/"connection through"
+    `${ci('connection')}(?:\\s+(?:${ci('at')}|${ci('in')}|${ci('through')}))?`,
+  ];
+  const blockingChainKeyword = `\\b(?:${chainPhrases.join('|')})\\b`;
   const noOtherIata = `(?:(?!${blockingChainKeyword})(?!\\b(?!(?:${allowedInGap})\\b)[A-Z]{3}\\b)[\\s\\S])`;
   const strict: RegExp[] = [
     // "from BDS to JFK" / "from BDS Brindisi to John F. Kennedy JFK".

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -76,8 +76,11 @@ export function buildGoogleFlightsUrl(params: FlightSearchParams): string {
 /**
  * Build alternative Google Flights URL formats. The verbose `q=` text URL
  * (buildGoogleFlightsUrl) is what humans land on, but it depends on Google's
- * NLU and is unreliable for less-trafficked airport codes. We rotate through
- * progressively terser forms on retry.
+ * NLU and is unreliable for less-trafficked airport codes. Each candidate is
+ * a text URL that *carries the requested dates* — we deliberately avoid the
+ * `/travel/flights/flights-from-X-to-Y.html` SEO path because it omits dates
+ * and trip type, and Google fills it with defaults that would silently write
+ * snapshots for the wrong travelDate.
  */
 export function buildGoogleFlightsUrlCandidates(params: FlightSearchParams): string[] {
   const dateFrom = params.dateFrom.toISOString().split('T')[0];
@@ -85,19 +88,23 @@ export function buildGoogleFlightsUrlCandidates(params: FlightSearchParams): str
   const oneWay = params.tripType === 'one_way';
   const qs = buildQueryString(params);
 
-  // Variant 1: verbose phrase, fixed for one-way (above)
+  // Variant 1: verbose phrase, fixed for one-way (above).
   const verbose = buildGoogleFlightsUrl(params);
 
-  // Variant 2: terse codes + date — fewer NLU tokens for Google to misinterpret
+  // Variant 2: terse codes + date — fewer NLU tokens for Google to misinterpret.
   const terseDate = oneWay ? `+${dateFrom}` : `+${dateFrom}+to+${dateTo}`;
   const terse = `https://www.google.com/travel/flights?q=${params.origin}+to+${params.destination}${terseDate}&${qs}`;
 
-  // Variant 3: SEO route landing — does NOT include dates, but reliably
-  // resolves to a valid Flights page where the search form is pre-populated
-  // with the airport pair, preventing the "redirected to homepage" failure.
-  const path = `https://www.google.com/travel/flights/flights-from-${params.origin}-to-${params.destination}.html?${qs}`;
+  // Variant 3: reworded phrase — different verb ("departing"/"returning") and
+  // a different word order put the airport codes adjacent to the keywords
+  // Google's NLU is most confident about, while still carrying the date(s).
+  const oneWayPrefix = oneWay ? 'one+way+' : '';
+  const dateClause = oneWay
+    ? `departing+${dateFrom}`
+    : `departing+${dateFrom}+returning+${dateTo}`;
+  const reworded = `https://www.google.com/travel/flights?q=${oneWayPrefix}flights+to+${params.destination}+from+${params.origin}+${dateClause}&${qs}`;
 
-  return [verbose, terse, path];
+  return [verbose, terse, reworded];
 }
 
 export async function navigateGoogleFlights(

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -201,7 +201,14 @@ export function pageHasRequestedRoute(
   // appear in flight pages but are not airport codes (currency labels).
   // Other 3-letter uppercase tokens (LHR, FCO, NYC, USA) block the gap so
   // chained-route phrases like "BDS Brindisi to LHR via JFK" never match.
-  const allowedInGap = [origin, destination, 'USD', 'EUR', 'GBP', 'JPY', 'CHF', 'CAD', 'AUD']
+  // Currency allowlist covers the locales we have actual users in — TRY is
+  // critical because Fairtrail's #64 example was IST/AYT (Turkish market) and
+  // Turkish Lira labels appear in those headers.
+  const allowedInGap = [
+    origin,
+    destination,
+    'USD', 'EUR', 'GBP', 'JPY', 'CHF', 'CAD', 'AUD', 'TRY',
+  ]
     .map(escapeRegex)
     .join('|');
   const noOtherIata = `(?:(?!\\b(?!(?:${allowedInGap})\\b)[A-Z]{3}\\b)[\\s\\S])`;

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -226,13 +226,22 @@ export function pageHasRequestedRoute(
   // 3. The standard supported currency list (above): covers cases where the
   //    query has currency=null and Google auto-detects locale-appropriate.
   //
-  // Any OTHER 3-letter uppercase token (LHR, FCO, NYC, USA) blocks the gap.
-  // That is what stops "BDS Brindisi to LHR via JFK" from matching.
+  // Two things block the gap:
+  //
+  // (a) Any 3-letter uppercase token NOT in the allowlist (LHR, FCO, NYC,
+  //     USA) blocks. That stops "BDS Brindisi to LHR via JFK" from matching.
+  // (b) The chaining keywords `via`, `layover`, `through`, `connecting`
+  //     block. That closes the currency/IATA overlap edge case (HKD is
+  //     also Hakodate airport): "BDS to HKD via JFK" still has `via` in
+  //     the gap, so the lazy match cannot reach JFK regardless of whether
+  //     HKD is treated as currency or airport. Real Google Flights route
+  //     headers never use these words between the airport pair.
   const dynamicCurrency = currency && /^[A-Z]{3}$/.test(currency) ? [currency] : [];
   const allowedInGap = [origin, destination, ...dynamicCurrency, ...ALLOWED_CURRENCY_TOKENS]
     .map(escapeRegex)
     .join('|');
-  const noOtherIata = `(?:(?!\\b(?!(?:${allowedInGap})\\b)[A-Z]{3}\\b)[\\s\\S])`;
+  const blockingChainKeyword = `\\b(?:via|layover|through|connecting)\\b`;
+  const noOtherIata = `(?:(?!${blockingChainKeyword})(?!\\b(?!(?:${allowedInGap})\\b)[A-Z]{3}\\b)[\\s\\S])`;
   const strict: RegExp[] = [
     // "from BDS to JFK" / "from BDS Brindisi to John F. Kennedy JFK".
     new RegExp(`\\bfrom\\s+${o}\\b${noOtherIata}{0,80}\\bto\\b${noOtherIata}{0,80}\\b${d}\\b`),

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -183,13 +183,24 @@ function escapeRegex(s: string): string {
  * silently overwriting good snapshots.
  */
 /**
- * Currencies the Fairtrail settings UI exposes (apps/web/src/app/settings/
- * page.tsx). When pageHasRequestedRoute walks the gap between airport codes
- * it allows these tokens through because they are 3-letter uppercase but
- * never airport codes — Google Flights commonly renders currency labels in
- * headers ("BDS Brindisi to TRY area JFK"). Keep this list in sync with the
- * settings dropdown; users selecting "Other..." pass the custom code via
- * the `currency` arg, which is also allowed dynamically.
+ * Currencies allowed inside the route-validation gap. The first 21 entries
+ * mirror the dropdown in apps/web/src/app/settings/page.tsx; TRY is added
+ * because Fairtrail's #64 example was IST/AYT (Turkish market) and TRY
+ * labels appear in those headers even though TRY is not in the settings
+ * dropdown today.
+ *
+ * Accepted residual risk: several of these codes are also valid IATA
+ * airport codes (HKD = Hakodate, BRL = Borba, CAD = Cadillac, CHF = Chefornak,
+ * NOK = Nogales, DKK = Dakar military, ARS = Aragarcas, etc.). A chained
+ * route like "BDS to HKD via JFK" therefore accepts under current policy.
+ * Real Google Flights pages do not render that phrasing for a JFK booking,
+ * so the practical corruption frequency is near zero, but the invariant is
+ * not "currencies are never airport codes". Removing overlapping codes
+ * would re-introduce false negatives for users in those currency locales,
+ * which is the actual reported bug; on balance we keep them.
+ *
+ * Users selecting "Other..." in settings pass the custom code via the
+ * `currency` arg to pageHasRequestedRoute, allowed dynamically.
  */
 const ALLOWED_CURRENCY_TOKENS = [
   'USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD', 'CHF', 'CNY', 'INR', 'MXN',

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -148,66 +148,68 @@ export function buildGoogleFlightsUrlCandidates(params: FlightSearchParams): str
 /** Stable label per candidate index, used in logs so failures are diagnosable. */
 const CANDIDATE_NAMES = ['verbose', 'terse', 'reworded'] as const;
 
-/** Directional connectors between origin and destination on Flights pages.
- *  Google renders any of these, plus locale variants. The literal word "to"
- *  is the most common in en-US.
- */
-const ROUTE_CONNECTORS = ['to', '→', '⇒', '–', '—', '-'];
-
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
- * Verify the loaded Google Flights page is actually showing the requested
- * route IN THE REQUESTED DIRECTION. Google's NLU can silently resolve an
- * ambiguous query to:
+ * Verify the loaded Google Flights page shows the requested route IN THE
+ * REQUESTED DIRECTION via at least one strict pattern. Loose membership +
+ * proximity checks were rejected by audit because:
  *
- * 1. The bare homepage (codes absent) -- caught by membership check.
- * 2. The swapped route (codes present, wrong direction) -- caught by the
- *    directional regex below: origin must appear BEFORE destination near a
- *    connector token like "to", "→", or "—".
- * 3. A nearby-airport substitution (one code missing, another shown) --
- *    caught by membership check.
+ * * Chained routes leak: "BDS Brindisi to LHR via JFK" matched
+ *   `BDS ... to ... JFK` even though the requested route never appears.
+ * * Plain "to" is not token-bounded: matches inside "stop", "Toronto",
+ *   "destination", so any flight card with a stop satisfies the regex
+ *   regardless of the actual airports.
+ * * Plain dash characters appear in dates, durations, and price ranges,
+ *   so a wide context window around any dash gives false positives.
  *
- * Remaining gaps that this function intentionally does NOT cover:
+ * Strict patterns demand immediate adjacency between the airport codes and
+ * a route connector. That is what Google actually renders on results
+ * pages: the search-bar header, breadcrumbs, and route chips all show
+ * `from BDS to JFK`, `BDS - John F. Kennedy`, or `BDS → JFK` with the
+ * codes adjacent to the connector.
  *
- * * Wrong date: Google renders dates in too many formats to match reliably.
- *   A nearby acceptable failure is that wrong-date pages still tend to drop
- *   one of the two codes from the visible text when Google falls back to
- *   default dates.
- * * Wrong trip type: requires inspecting trip-type chips, which are
- *   selector-fragile. The pre-navigation `one way` token plus URL rotation
- *   covers the URL side; this guard covers the route side.
+ * Failure modes this function does NOT cover:
  *
- * If the directional check passes but the page still has wrong dates or
- * wrong trip type, the LLM extractor downstream uses the page text directly
- * and would still produce snapshots labelled with the user's travelDate but
- * priced from a different date. Tracking this as a known residual risk;
- * mitigations beyond URL/text are out of scope for this PR.
+ * * Wrong date with the right route. Google renders dates in too many
+ *   formats to match reliably; mitigated by carrying the date in every
+ *   URL candidate and by URL rotation.
+ * * Wrong trip type. Mitigated by the explicit `one way` token in every
+ *   one-way URL candidate.
+ *
+ * Both residual risks fail-soft (the next candidate retries) rather than
+ * silently overwriting good snapshots.
  */
 export function pageHasRequestedRoute(
   pageText: string,
   origin: string,
   destination: string,
 ): boolean {
-  // Word-boundary match prevents "AYT" matching inside other tokens like
-  // "PAYTON". Codes are 3 uppercase letters, so this is safe.
-  const originRe = new RegExp(`\\b${origin}\\b`);
-  const destRe = new RegExp(`\\b${destination}\\b`);
-  if (!originRe.test(pageText) || !destRe.test(pageText)) {
-    return false;
-  }
+  const o = escapeRegex(origin);
+  const d = escapeRegex(destination);
 
-  // Directional check: somewhere in the page, origin must appear before
-  // destination separated by a connector and at most ~120 chars of context.
-  // 120 chars accommodates flight cards that show airline + duration + stops
-  // between the codes (`BDS 6:35 PM ... 14h 20m ... JFK 9:55 PM`).
-  const connectors = ROUTE_CONNECTORS.map(escapeRegex).join('|');
-  const directional = new RegExp(
-    `\\b${escapeRegex(origin)}\\b[\\s\\S]{0,120}(?:${connectors})[\\s\\S]{0,120}\\b${escapeRegex(destination)}\\b`,
-  );
-  return directional.test(pageText);
+  // Each pattern requires the airport codes adjacent to a connector with
+  // no other airport code between them. "?" / "*" quantifiers are bounded
+  // tightly to avoid the chained-route leak.
+  // "noOtherIata" matches a single character that is NOT the start of a
+  // 3-letter uppercase IATA code. Used to allow airport names ("Brindisi",
+  // "John F. Kennedy") between codes while blocking other airport codes
+  // (LHR, FCO) from being layovers in chained-route phrases.
+  const noOtherIata = `(?:(?!\\b[A-Z]{3}\\b)[\\s\\S])`;
+  const strict: RegExp[] = [
+    // "from BDS to JFK" / "from BDS Brindisi to John F. Kennedy JFK".
+    new RegExp(`\\bfrom\\s+${o}\\b${noOtherIata}{0,80}\\bto\\b${noOtherIata}{0,80}\\b${d}\\b`),
+    // "BDS to JFK" / "BDS Brindisi to JFK" with no other IATA in between.
+    new RegExp(`\\b${o}\\b${noOtherIata}{0,80}\\bto\\b${noOtherIata}{0,80}\\b${d}\\b`),
+    // "BDS → JFK" / "BDS ⇒ JFK" — immediate adjacency.
+    new RegExp(`\\b${o}\\s*[→⇒]\\s*${d}\\b`),
+    // "BDS - JFK" / "BDS – JFK" / "BDS — JFK" / "BDS-JFK" — immediate adjacency.
+    new RegExp(`\\b${o}\\s*[-–—]\\s*${d}\\b`),
+  ];
+
+  return strict.some((re) => re.test(pageText));
 }
 
 /**

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -53,15 +53,51 @@ export interface NavigationResult {
   source: NavigationSource;
 }
 
+function buildQueryString(params: FlightSearchParams): string {
+  const qs = ['hl=en'];
+  if (params.currency) qs.push(`curr=${params.currency}`);
+  if (params.country) qs.push(`gl=${params.country}`);
+  return qs.join('&');
+}
+
 export function buildGoogleFlightsUrl(params: FlightSearchParams): string {
+  // Verbose phrase form. For one-way searches we omit "+to+${dateTo}" — Google
+  // Flights' NLU misparses "on YYYY-MM-DD to YYYY-MM-DD" for less-trafficked
+  // airport codes (e.g. BDS, BRI) and falls back to the bare homepage. See #65.
   const dateFrom = params.dateFrom.toISOString().split('T')[0];
   const dateTo = params.dateTo.toISOString().split('T')[0];
-  const oneWayPrefix = params.tripType === 'one_way' ? 'one+way+' : '';
+  const oneWay = params.tripType === 'one_way';
+  const oneWayPrefix = oneWay ? 'one+way+' : '';
+  const datePart = oneWay ? `+on+${dateFrom}` : `+on+${dateFrom}+to+${dateTo}`;
 
-  let url = `https://www.google.com/travel/flights?q=${oneWayPrefix}flights+from+${params.origin}+to+${params.destination}+on+${dateFrom}+to+${dateTo}&hl=en`;
-  if (params.currency) url += `&curr=${params.currency}`;
-  if (params.country) url += `&gl=${params.country}`;
-  return url;
+  return `https://www.google.com/travel/flights?q=${oneWayPrefix}flights+from+${params.origin}+to+${params.destination}${datePart}&${buildQueryString(params)}`;
+}
+
+/**
+ * Build alternative Google Flights URL formats. The verbose `q=` text URL
+ * (buildGoogleFlightsUrl) is what humans land on, but it depends on Google's
+ * NLU and is unreliable for less-trafficked airport codes. We rotate through
+ * progressively terser forms on retry.
+ */
+export function buildGoogleFlightsUrlCandidates(params: FlightSearchParams): string[] {
+  const dateFrom = params.dateFrom.toISOString().split('T')[0];
+  const dateTo = params.dateTo.toISOString().split('T')[0];
+  const oneWay = params.tripType === 'one_way';
+  const qs = buildQueryString(params);
+
+  // Variant 1: verbose phrase, fixed for one-way (above)
+  const verbose = buildGoogleFlightsUrl(params);
+
+  // Variant 2: terse codes + date — fewer NLU tokens for Google to misinterpret
+  const terseDate = oneWay ? `+${dateFrom}` : `+${dateFrom}+to+${dateTo}`;
+  const terse = `https://www.google.com/travel/flights?q=${params.origin}+to+${params.destination}${terseDate}&${qs}`;
+
+  // Variant 3: SEO route landing — does NOT include dates, but reliably
+  // resolves to a valid Flights page where the search form is pre-populated
+  // with the airport pair, preventing the "redirected to homepage" failure.
+  const path = `https://www.google.com/travel/flights/flights-from-${params.origin}-to-${params.destination}.html?${qs}`;
+
+  return [verbose, terse, path];
 }
 
 export async function navigateGoogleFlights(
@@ -69,10 +105,14 @@ export async function navigateGoogleFlights(
   countryProfile?: CountryProfile,
   proxyUrl?: string
 ): Promise<NavigationResult> {
-  const url = buildGoogleFlightsUrl(params);
-  const maxAttempts = 3;
+  // Rotate URL formats per attempt — text URLs are unreliable for less-common
+  // airport codes (#65), so retrying the same URL only ever hits the same
+  // homepage redirect. Each attempt tries a structurally different URL.
+  const urlCandidates = buildGoogleFlightsUrlCandidates(params);
+  const maxAttempts = urlCandidates.length;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const url = urlCandidates[attempt - 1]!;
     const browser = await launchBrowser({ proxyUrl });
     const attemptStart = Date.now();
 

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -148,17 +148,43 @@ export function buildGoogleFlightsUrlCandidates(params: FlightSearchParams): str
 /** Stable label per candidate index, used in logs so failures are diagnosable. */
 const CANDIDATE_NAMES = ['verbose', 'terse', 'reworded'] as const;
 
+/** Directional connectors between origin and destination on Flights pages.
+ *  Google renders any of these, plus locale variants. The literal word "to"
+ *  is the most common in en-US.
+ */
+const ROUTE_CONNECTORS = ['to', '→', '⇒', '–', '—', '-'];
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Verify the loaded Google Flights page is actually showing the requested
- * route. Google's NLU can silently resolve an ambiguous query to a different
- * airport pair, default dates, or the bare homepage and still render
- * `[data-gs]`-bearing content. Without this guard, we would write snapshots
- * tagged with the user's travelDate but priced for the wrong route.
+ * route IN THE REQUESTED DIRECTION. Google's NLU can silently resolve an
+ * ambiguous query to:
  *
- * The check is intentionally narrow: we only assert the requested IATA codes
- * appear in the visible text. Date validation is harder (Google renders dates
- * in many formats) and a URL-rotation candidate that arrived at the right
- * airports but the wrong date is much less plausible than a homepage fallback.
+ * 1. The bare homepage (codes absent) -- caught by membership check.
+ * 2. The swapped route (codes present, wrong direction) -- caught by the
+ *    directional regex below: origin must appear BEFORE destination near a
+ *    connector token like "to", "→", or "—".
+ * 3. A nearby-airport substitution (one code missing, another shown) --
+ *    caught by membership check.
+ *
+ * Remaining gaps that this function intentionally does NOT cover:
+ *
+ * * Wrong date: Google renders dates in too many formats to match reliably.
+ *   A nearby acceptable failure is that wrong-date pages still tend to drop
+ *   one of the two codes from the visible text when Google falls back to
+ *   default dates.
+ * * Wrong trip type: requires inspecting trip-type chips, which are
+ *   selector-fragile. The pre-navigation `one way` token plus URL rotation
+ *   covers the URL side; this guard covers the route side.
+ *
+ * If the directional check passes but the page still has wrong dates or
+ * wrong trip type, the LLM extractor downstream uses the page text directly
+ * and would still produce snapshots labelled with the user's travelDate but
+ * priced from a different date. Tracking this as a known residual risk;
+ * mitigations beyond URL/text are out of scope for this PR.
  */
 export function pageHasRequestedRoute(
   pageText: string,
@@ -169,7 +195,34 @@ export function pageHasRequestedRoute(
   // "PAYTON". Codes are 3 uppercase letters, so this is safe.
   const originRe = new RegExp(`\\b${origin}\\b`);
   const destRe = new RegExp(`\\b${destination}\\b`);
-  return originRe.test(pageText) && destRe.test(pageText);
+  if (!originRe.test(pageText) || !destRe.test(pageText)) {
+    return false;
+  }
+
+  // Directional check: somewhere in the page, origin must appear before
+  // destination separated by a connector and at most ~120 chars of context.
+  // 120 chars accommodates flight cards that show airline + duration + stops
+  // between the codes (`BDS 6:35 PM ... 14h 20m ... JFK 9:55 PM`).
+  const connectors = ROUTE_CONNECTORS.map(escapeRegex).join('|');
+  const directional = new RegExp(
+    `\\b${escapeRegex(origin)}\\b[\\s\\S]{0,120}(?:${connectors})[\\s\\S]{0,120}\\b${escapeRegex(destination)}\\b`,
+  );
+  return directional.test(pageText);
+}
+
+/**
+ * Detect the specific failure mode reported in #65: Google strips the `q`
+ * parameter and redirects to the bare /travel/flights homepage. The input
+ * URL has a q param; the resolved URL does not.
+ */
+export function pageRedirectedToHomepage(inputUrl: string, finalUrl: string): boolean {
+  try {
+    const had = new URL(inputUrl).searchParams.has('q');
+    const has = new URL(finalUrl).searchParams.has('q');
+    return had && !has;
+  } catch {
+    return false;
+  }
 }
 
 export async function navigateGoogleFlights(
@@ -236,14 +289,22 @@ export async function navigateGoogleFlights(
       const html = await page.evaluate(() => document.body.innerText);
       const finalUrl = page.url();
 
-      // Belt-and-suspenders defense against silent route corruption: even when
-      // [data-gs] resolves, Google may have landed on a different airport pair,
-      // a homepage fallback, or default-date results. Verify the requested
-      // codes appear in the visible text before treating the attempt as a
-      // success — a false success here would write snapshots labeled with the
-      // user's travelDate but priced for the wrong route.
+      // Belt-and-suspenders defense against silent route corruption. Three
+      // layers; any failure marks the attempt failed and rotates to the next
+      // URL candidate. A false success here would write snapshots labeled
+      // with the user's travelDate but priced for a different route.
+      //
+      // 1. Homepage redirect: Google strips q= and lands on the bare
+      //    /travel/flights URL. This is the headline #65 failure mode.
+      // 2. Route membership + direction: both IATA codes must appear in the
+      //    visible text AND in the requested order separated by a route
+      //    connector (catches swapped routes and unrelated suggestion lists).
+      if (resultsFound && pageRedirectedToHomepage(url, finalUrl)) {
+        console.log(`[navigate] q= dropped on redirect (input=${url}, final=${finalUrl}) — treating attempt ${attempt} (${candidateName}) as failed`);
+        resultsFound = false;
+      }
       if (resultsFound && !pageHasRequestedRoute(html, params.origin, params.destination)) {
-        console.log(`[navigate] page text missing requested airports (origin=${params.origin}, dest=${params.destination}, finalUrl=${finalUrl}) — treating attempt ${attempt} (${candidateName}) as failed`);
+        console.log(`[navigate] page text missing requested directional route (origin=${params.origin}, dest=${params.destination}, finalUrl=${finalUrl}) — treating attempt ${attempt} (${candidateName}) as failed`);
         resultsFound = false;
       }
 

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -194,10 +194,17 @@ export function pageHasRequestedRoute(
   // no other airport code between them. "?" / "*" quantifiers are bounded
   // tightly to avoid the chained-route leak.
   // "noOtherIata" matches a single character that is NOT the start of a
-  // 3-letter uppercase IATA code. Used to allow airport names ("Brindisi",
-  // "John F. Kennedy") between codes while blocking other airport codes
-  // (LHR, FCO) from being layovers in chained-route phrases.
-  const noOtherIata = `(?:(?!\\b[A-Z]{3}\\b)[\\s\\S])`;
+  // 3-letter uppercase IATA-shaped token, with two exceptions: the origin
+  // and destination codes themselves (Google headers often render the code
+  // both as a label and a parenthetical alias, e.g. "BDS Brindisi (BDS) to
+  // JFK"), and a small allowlist of common 3-letter uppercase tokens that
+  // appear in flight pages but are not airport codes (currency labels).
+  // Other 3-letter uppercase tokens (LHR, FCO, NYC, USA) block the gap so
+  // chained-route phrases like "BDS Brindisi to LHR via JFK" never match.
+  const allowedInGap = [origin, destination, 'USD', 'EUR', 'GBP', 'JPY', 'CHF', 'CAD', 'AUD']
+    .map(escapeRegex)
+    .join('|');
+  const noOtherIata = `(?:(?!\\b(?!(?:${allowedInGap})\\b)[A-Z]{3}\\b)[\\s\\S])`;
   const strict: RegExp[] = [
     // "from BDS to JFK" / "from BDS Brindisi to John F. Kennedy JFK".
     new RegExp(`\\bfrom\\s+${o}\\b${noOtherIata}{0,80}\\bto\\b${noOtherIata}{0,80}\\b${d}\\b`),

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -240,7 +240,18 @@ export function pageHasRequestedRoute(
   const allowedInGap = [origin, destination, ...dynamicCurrency, ...ALLOWED_CURRENCY_TOKENS]
     .map(escapeRegex)
     .join('|');
-  const blockingChainKeyword = `\\b(?:via|layover|through|connecting)\\b`;
+  // Chaining keywords are matched case-insensitively. JS regex has no inline
+  // (?i) flag and the top-level /i flag would break the [A-Z]{3} IATA guard
+  // in this same alternation, so we expand each lowercase letter into a
+  // character class. "Via" / "VIA" / "via" all match.
+  // We deliberately do NOT include "stop" / "stopping" / "stops": those
+  // appear legitimately in flight-card metadata ("1 stop", "Nonstop") and
+  // would over-block the gap. Chained routes that use a non-currency IATA
+  // code as layover are still rejected by the IATA-allowlist guard below.
+  const eachCase = (word: string): string =>
+    word.split('').map((ch) => `[${ch.toLowerCase()}${ch.toUpperCase()}]`).join('');
+  const chainWords = ['via', 'layover', 'through', 'connecting', 'stopover'];
+  const blockingChainKeyword = `\\b(?:${chainWords.map(eachCase).join('|')})\\b`;
   const noOtherIata = `(?:(?!${blockingChainKeyword})(?!\\b(?!(?:${allowedInGap})\\b)[A-Z]{3}\\b)[\\s\\S])`;
   const strict: RegExp[] = [
     // "from BDS to JFK" / "from BDS Brindisi to John F. Kennedy JFK".

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -182,33 +182,43 @@ function escapeRegex(s: string): string {
  * Both residual risks fail-soft (the next candidate retries) rather than
  * silently overwriting good snapshots.
  */
+/**
+ * Currencies the Fairtrail settings UI exposes (apps/web/src/app/settings/
+ * page.tsx). When pageHasRequestedRoute walks the gap between airport codes
+ * it allows these tokens through because they are 3-letter uppercase but
+ * never airport codes — Google Flights commonly renders currency labels in
+ * headers ("BDS Brindisi to TRY area JFK"). Keep this list in sync with the
+ * settings dropdown; users selecting "Other..." pass the custom code via
+ * the `currency` arg, which is also allowed dynamically.
+ */
+const ALLOWED_CURRENCY_TOKENS = [
+  'USD', 'EUR', 'GBP', 'JPY', 'CAD', 'AUD', 'CHF', 'CNY', 'INR', 'MXN',
+  'BRL', 'KRW', 'SGD', 'HKD', 'SEK', 'NOK', 'DKK', 'NZD', 'THB', 'COP',
+  'ARS', 'TRY',
+] as const;
+
 export function pageHasRequestedRoute(
   pageText: string,
   origin: string,
   destination: string,
+  currency?: string | null,
 ): boolean {
   const o = escapeRegex(origin);
   const d = escapeRegex(destination);
 
-  // Each pattern requires the airport codes adjacent to a connector with
-  // no other airport code between them. "?" / "*" quantifiers are bounded
-  // tightly to avoid the chained-route leak.
-  // "noOtherIata" matches a single character that is NOT the start of a
-  // 3-letter uppercase IATA-shaped token, with two exceptions: the origin
-  // and destination codes themselves (Google headers often render the code
-  // both as a label and a parenthetical alias, e.g. "BDS Brindisi (BDS) to
-  // JFK"), and a small allowlist of common 3-letter uppercase tokens that
-  // appear in flight pages but are not airport codes (currency labels).
-  // Other 3-letter uppercase tokens (LHR, FCO, NYC, USA) block the gap so
-  // chained-route phrases like "BDS Brindisi to LHR via JFK" never match.
-  // Currency allowlist covers the locales we have actual users in — TRY is
-  // critical because Fairtrail's #64 example was IST/AYT (Turkish market) and
-  // Turkish Lira labels appear in those headers.
-  const allowedInGap = [
-    origin,
-    destination,
-    'USD', 'EUR', 'GBP', 'JPY', 'CHF', 'CAD', 'AUD', 'TRY',
-  ]
+  // Tokens the strict regex allows inside the gap between origin and destination:
+  //
+  // 1. Origin and destination themselves: Google headers render the code both
+  //    as a label and a parenthetical alias ("BDS Brindisi (BDS) to JFK").
+  // 2. The currency the query uses: passed dynamically so users who selected
+  //    "Other..." in settings (any ISO 4217 3-letter code) are covered.
+  // 3. The standard supported currency list (above): covers cases where the
+  //    query has currency=null and Google auto-detects locale-appropriate.
+  //
+  // Any OTHER 3-letter uppercase token (LHR, FCO, NYC, USA) blocks the gap.
+  // That is what stops "BDS Brindisi to LHR via JFK" from matching.
+  const dynamicCurrency = currency && /^[A-Z]{3}$/.test(currency) ? [currency] : [];
+  const allowedInGap = [origin, destination, ...dynamicCurrency, ...ALLOWED_CURRENCY_TOKENS]
     .map(escapeRegex)
     .join('|');
   const noOtherIata = `(?:(?!\\b(?!(?:${allowedInGap})\\b)[A-Z]{3}\\b)[\\s\\S])`;
@@ -319,7 +329,7 @@ export async function navigateGoogleFlights(
         console.log(`[navigate] q= dropped on redirect (input=${url}, final=${finalUrl}) — treating attempt ${attempt} (${candidateName}) as failed`);
         resultsFound = false;
       }
-      if (resultsFound && !pageHasRequestedRoute(html, params.origin, params.destination)) {
+      if (resultsFound && !pageHasRequestedRoute(html, params.origin, params.destination, params.currency)) {
         console.log(`[navigate] page text missing requested directional route (origin=${params.origin}, dest=${params.destination}, finalUrl=${finalUrl}) — treating attempt ${attempt} (${candidateName}) as failed`);
         resultsFound = false;
       }


### PR DESCRIPTION
## Summary

Fix the Google Flights scraper failing for less popular EU airport pairs (BRI/BDS to JFK from EU IPs).

**Root cause**: the URL `?q=one+way+flights+from+BDS+to+JFK+on+2026-11-09+to+2026-11-09` carried a redundant `+to+${dateTo}` for one-way searches, and Google's NLU misparsed the duplicate date for less confident airport codes. Retries hit the same URL 3x, so once Google rejected the parse all attempts spent quota on the same dead end.

## Defense in depth

This branch went through 10 `/codex` audit cycles. Each cycle caught a real concern and was addressed with a concrete fix rather than documented as residual risk.

| Layer | Defends against | Commit |
|---|---|---|
| URL fix: drop redundant `+to+${dateTo}` for one-way | The headline #65 misparse | `3e62be2` |
| URL rotation: 3 structurally distinct text URLs | Repeated retry of a URL Google has already rejected | `3e62be2` |
| Drop SEO landing fallback | Date-less URL would silently use Google defaults | `0027605` |
| Post-navigation route check | Page rendering wrong route after Google NLU resolve | `50441a4` |
| `URL`/`URLSearchParams` + IATA validation | Query-param injection via raw interpolation | `50441a4` |
| Per-candidate logging | Diagnose which URL format Google's parser accepts | `50441a4` |
| Homepage redirect detection | Google strips `q=` and lands on bare homepage | `a19c272` |
| Strict directional regex | Membership-only check accepted swapped routes | `b5f5b91` |
| Allowlist origin/destination + currency tokens | False negatives on parenthetical aliases ("BDS Brindisi (BDS) to JFK") | `f56c1cf` |
| TRY in static currency list | Turkish market headers (#64 IST/AYT example) | `e18dd68` |
| Full settings-currency parity + dynamic currency arg | False negatives on 14 settings-supported currencies | `3cfae34` |
| Chaining keyword block (`via`/`layover`/`through`/`connecting`/`stopover`) | Currency/IATA overlap (HKD = Hakodate) bypassing the IATA guard | `da10403` |
| Case-insensitive chain keywords | `Via`/`VIA`/`Connecting` bypassing | `cb629eb` |
| Phrase-form chain blockers (`stops at`, `with a stop`, `connection at`) | Stop-family chained phrasings still passing | `a4835fb` |

## What did NOT change

* Bare `stop` / `1 stop` / `Nonstop` still accepted: real flight cards use them as metadata.
* `transit at/in/through` not blocked: codex flagged as a hardening follow-up not a blocker, no evidence Google uses this phrasing in route headers.

## Test plan

- [x] 223 scraper tests pass (`npx vitest run src/lib/scraper/`)
- [x] 93 navigate tests cover URL builder, candidate rotation, route validator, homepage redirect, IATA validation, currency allowlist, all chain keyword variants
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [ ] Manual: re-test BDS→JFK and BRI→JFK on the deployed instance and confirm `[data-gs]` resolves on at least one of the three URL formats

Refs #65.
