### PR TITLE
fix(install): distinguish docker permission denied from daemon down

### DIFF
--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -159,25 +159,45 @@ else
 fi
 
 if [ "$CONTAINER_CMD" = "docker" ]; then
-  if ! docker info &>/dev/null 2>&1; then
-    case "$OS" in
-      macos)
-        fail "Docker Desktop is not running.\n\n  Open Docker Desktop from Applications, wait for it to start, then re-run:\n  ${BOLD}curl -fsSL https://fairtrail.org/install.sh | bash${RESET}"
-        ;;
-      linux|wsl)
-        warn "Docker daemon is not running."
-        printf "  ${DIM}Trying to start it...${RESET}\n"
-        if command -v sudo &>/dev/null; then
-          sudo systemctl start docker 2>/dev/null || sudo service docker start 2>/dev/null || true
-          sleep 2
-        fi
-        if ! docker info &>/dev/null 2>&1; then
-          fail "Could not start Docker.\n\n  Start it manually: ${BOLD}sudo systemctl start docker${RESET}\n  Then re-run this installer."
-        fi
-        ok "Docker daemon started"
+  # Capture stderr so we can distinguish permission-denied (user is not in
+  # the docker group / shell session has not picked up new group membership)
+  # from daemon-down. The previous version always told the user to start the
+  # daemon, which is wrong on the common Manjaro/Arch path where the daemon
+  # is already running but the current shell cannot reach the socket. See #62.
+  docker_info_err=$(docker info 2>&1 1>/dev/null || true)
+  if [ -n "$docker_info_err" ]; then
+    case "$docker_info_err" in
+      *"permission denied"*|*"Permission denied"*)
+        case "$OS" in
+          linux|wsl)
+            fail "Docker is running but your user cannot access the socket.\n\n  This usually means you are not in the ${BOLD}docker${RESET} group, or your\n  current shell session has not picked up that membership yet.\n\n  Try one of these:\n    ${BOLD}newgrp docker${RESET}  ${DIM}# refresh group in this shell, then re-run${RESET}\n    Log out and back in fully (close all terminals), then re-run\n    Reboot, then re-run\n\n  If you are not yet in the docker group:\n    ${BOLD}sudo usermod -aG docker \$USER${RESET}  ${DIM}# then log out + in${RESET}"
+            ;;
+          *)
+            fail "Docker socket is not accessible (permission denied).\n  Run this installer as a user that can access the docker socket."
+            ;;
+        esac
         ;;
       *)
-        fail "Docker is not running. Start Docker and try again."
+        case "$OS" in
+          macos)
+            fail "Docker Desktop is not running.\n\n  Open Docker Desktop from Applications, wait for it to start, then re-run:\n  ${BOLD}curl -fsSL https://fairtrail.org/install.sh | bash${RESET}"
+            ;;
+          linux|wsl)
+            warn "Docker daemon is not running."
+            printf "  ${DIM}Trying to start it...${RESET}\n"
+            if command -v sudo &>/dev/null; then
+              sudo systemctl start docker 2>/dev/null || sudo service docker start 2>/dev/null || true
+              sleep 2
+            fi
+            if ! docker info &>/dev/null 2>&1; then
+              fail "Could not start Docker.\n\n  Start it manually: ${BOLD}sudo systemctl start docker${RESET}\n  Then re-run this installer."
+            fi
+            ok "Docker daemon started"
+            ;;
+          *)
+            fail "Docker is not running. Start Docker and try again."
+            ;;
+        esac
         ;;
     esac
   fi

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -164,8 +164,10 @@ if [ "$CONTAINER_CMD" = "docker" ]; then
   # from daemon-down. The previous version always told the user to start the
   # daemon, which is wrong on the common Manjaro/Arch path where the daemon
   # is already running but the current shell cannot reach the socket. See #62.
-  docker_info_err=$(docker info 2>&1 1>/dev/null || true)
-  if [ -n "$docker_info_err" ]; then
+  #
+  # Gate on exit status, not stderr presence: docker info can exit 0 while
+  # writing warnings to stderr (deprecated config, plugin notices, etc).
+  if ! docker_info_err=$(docker info 2>&1 1>/dev/null); then
     case "$docker_info_err" in
       *"permission denied"*|*"Permission denied"*)
         case "$OS" in

--- a/apps/web/src/lib/scraper/install-scripts.test.ts
+++ b/apps/web/src/lib/scraper/install-scripts.test.ts
@@ -168,6 +168,60 @@ describe('install.sh', () => {
     const beforeDocker = lines.slice(Math.max(0, dockerOllamaIdx - 3), dockerOllamaIdx).join('\n');
     expect(beforeDocker).toContain('else');
   });
+
+  describe('Docker reachability detection (regression: #62)', () => {
+    // The previous version always interpreted `docker info` failure as
+    // "daemon down" and told the user to run `systemctl start docker`. On
+    // Manjaro/Arch the more common failure is permission denied (user is
+    // not in the docker group, or the current shell session has not picked
+    // up the new group). Telling them to start an already-running daemon
+    // dead-ended the install.
+
+    it('captures docker info stderr instead of discarding it', () => {
+      // The new branch needs the actual error text to distinguish failure
+      // modes; the old `docker info &>/dev/null 2>&1` form lost it.
+      expect(INSTALL_SH).toMatch(/docker info\s+2>&1\s+1>\/dev\/null/);
+    });
+
+    it('matches "permission denied" branch separately from daemon-down', () => {
+      // Both case variants because docker error output has differed by
+      // version (lowercase older, capital P newer).
+      expect(INSTALL_SH).toContain('"permission denied"');
+      expect(INSTALL_SH).toContain('"Permission denied"');
+    });
+
+    it('permission-denied branch tells the user about the docker group', () => {
+      // Without this, a user who just ran `usermod -aG docker $USER` but
+      // never logged out gets sent to `systemctl start docker`, which
+      // does nothing.
+      const dockerGroupBlock = INSTALL_SH.split('permission denied')[1] ?? '';
+      expect(dockerGroupBlock).toContain('docker');
+      expect(dockerGroupBlock).toContain('group');
+      expect(dockerGroupBlock).toContain('newgrp');
+    });
+
+    it('daemon-down branch still suggests systemctl start docker', () => {
+      // Existing behavior must still work for the "daemon really is not
+      // running" case — verify the systemctl message survives the refactor.
+      expect(INSTALL_SH).toContain('sudo systemctl start docker');
+    });
+
+    it('does NOT issue the daemon-down message before checking the failure mode', () => {
+      // Regression guard: the old code unconditionally said "Could not
+      // start Docker" on any docker info failure. With the new branching,
+      // that fail() must only fire inside the daemon-down case, after the
+      // permission-denied case has already been excluded.
+      const lines = INSTALL_SH.split('\n');
+      const couldNotStartIdx = lines.findIndex((l) =>
+        l.includes('Could not start Docker')
+      );
+      const permissionDeniedIdx = lines.findIndex((l) =>
+        l.includes('"permission denied"')
+      );
+      expect(permissionDeniedIdx).toBeGreaterThan(-1);
+      expect(couldNotStartIdx).toBeGreaterThan(permissionDeniedIdx);
+    });
+  });
 });
 
 describe('fairtrail-cli', () => {

--- a/apps/web/src/lib/scraper/install-scripts.test.ts
+++ b/apps/web/src/lib/scraper/install-scripts.test.ts
@@ -172,50 +172,71 @@ describe('install.sh', () => {
   describe('Docker reachability detection (regression: #62)', () => {
     // The previous version always interpreted `docker info` failure as
     // "daemon down" and told the user to run `systemctl start docker`. On
-    // Manjaro/Arch the more common failure is permission denied (user is
-    // not in the docker group, or the current shell session has not picked
-    // up the new group). Telling them to start an already-running daemon
-    // dead-ended the install.
+    // Manjaro/Arch the more common failure is permission denied (user not
+    // in docker group, or shell session hasn't picked up the group).
+    //
+    // Tests below operate on INSTALL_SH_CODE — the script with shell
+    // comments stripped — so a string-presence assertion can't pass just
+    // because the same word appears in a comment near the change.
+    const INSTALL_SH_CODE = INSTALL_SH.split('\n')
+      .map((l) => {
+        // Drop full-line comments (allowing leading whitespace) but keep
+        // shebang, and don't strip mid-line "#" since shell strings can
+        // contain them. Conservative line-level filter is enough here.
+        const trimmed = l.trimStart();
+        if (trimmed.startsWith('#') && !trimmed.startsWith('#!')) return '';
+        return l;
+      })
+      .join('\n');
 
-    it('captures docker info stderr instead of discarding it', () => {
-      // The new branch needs the actual error text to distinguish failure
-      // modes; the old `docker info &>/dev/null 2>&1` form lost it.
-      expect(INSTALL_SH).toMatch(/docker info\s+2>&1\s+1>\/dev\/null/);
+    it('gates on docker info exit status, not stderr presence', () => {
+      // docker info can exit 0 while emitting stderr warnings (deprecated
+      // config, plugin notices). Gating on `[ -n "$err" ]` would falsely
+      // trigger the failure branch in that case; gating on `if !
+      // var=$(...)` reads the actual exit status.
+      expect(INSTALL_SH_CODE).toMatch(/if\s+!\s+docker_info_err=\$\(docker info\s+2>&1\s+1>\/dev\/null\)/);
+      // The pre-fix pattern that ignored exit status must not reappear.
+      expect(INSTALL_SH_CODE).not.toMatch(/docker info\s+&>\/dev\/null\s+2>&1.*\n[^#]*case.*docker_info_err/s);
     });
 
     it('matches "permission denied" branch separately from daemon-down', () => {
       // Both case variants because docker error output has differed by
       // version (lowercase older, capital P newer).
-      expect(INSTALL_SH).toContain('"permission denied"');
-      expect(INSTALL_SH).toContain('"Permission denied"');
+      expect(INSTALL_SH_CODE).toContain('"permission denied"');
+      expect(INSTALL_SH_CODE).toContain('"Permission denied"');
     });
 
-    it('permission-denied branch tells the user about the docker group', () => {
-      // Without this, a user who just ran `usermod -aG docker $USER` but
-      // never logged out gets sent to `systemctl start docker`, which
-      // does nothing.
-      const dockerGroupBlock = INSTALL_SH.split('permission denied')[1] ?? '';
-      expect(dockerGroupBlock).toContain('docker');
-      expect(dockerGroupBlock).toContain('group');
-      expect(dockerGroupBlock).toContain('newgrp');
+    it('permission-denied branch tells the user about the docker group and newgrp', () => {
+      // Locate the permission case body via the literal case pattern, not
+      // generic substring. That way a future comment containing
+      // "permission denied" can't satisfy the test on its own.
+      const codeAfterPermPattern = INSTALL_SH_CODE.split('"permission denied"')[1] ?? '';
+      // Body should reach the matching `;;` of the permission case. Use a
+      // generous slice — we only need to confirm the user-facing message.
+      const caseBody = codeAfterPermPattern.split(';;')[0] ?? '';
+      expect(caseBody).toContain('docker');
+      expect(caseBody).toContain('group');
+      expect(caseBody).toContain('newgrp');
+      // And the suggestion to refresh group membership must include
+      // usermod, which is the canonical fix for users not yet in the group.
+      expect(caseBody).toContain('usermod');
     });
 
     it('daemon-down branch still suggests systemctl start docker', () => {
       // Existing behavior must still work for the "daemon really is not
       // running" case — verify the systemctl message survives the refactor.
-      expect(INSTALL_SH).toContain('sudo systemctl start docker');
+      expect(INSTALL_SH_CODE).toContain('sudo systemctl start docker');
     });
 
-    it('does NOT issue the daemon-down message before checking the failure mode', () => {
+    it('"Could not start Docker" only fires after permission-denied is excluded', () => {
       // Regression guard: the old code unconditionally said "Could not
-      // start Docker" on any docker info failure. With the new branching,
-      // that fail() must only fire inside the daemon-down case, after the
-      // permission-denied case has already been excluded.
-      const lines = INSTALL_SH.split('\n');
-      const couldNotStartIdx = lines.findIndex((l) =>
+      // start Docker" on any docker info failure. The new branching must
+      // place that fail() AFTER the permission-denied case body.
+      const codeLines = INSTALL_SH_CODE.split('\n');
+      const couldNotStartIdx = codeLines.findIndex((l) =>
         l.includes('Could not start Docker')
       );
-      const permissionDeniedIdx = lines.findIndex((l) =>
+      const permissionDeniedIdx = codeLines.findIndex((l) =>
         l.includes('"permission denied"')
       );
       expect(permissionDeniedIdx).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

Follow-up to #63 for issue #62. PR #63 fixed the install path on Manjaro/Arch (Docker via pacman). The reporter then said the installer kept telling them to start Docker via `systemctl` even though `htop` confirmed dockerd was already running. That comment never got a response.

## Why it happened

`install.sh` ran `docker info &>/dev/null 2>&1` and treated any failure as "daemon not running". The most common Manjaro/Arch failure mode is *permission denied on the docker socket* — the user has been added to the `docker` group via `usermod -aG docker $USER`, but the current shell session has not picked up that membership yet. The daemon is running and reachable; just not from this shell. The old error message dead-ended the install by suggesting `systemctl start docker`, which does nothing.

## Fix

Capture docker info stderr (previously discarded) and gate on exit status (not stderr presence — docker info can exit 0 while emitting deprecation warnings). Branch on the captured message:

* "permission denied" / "Permission denied" → tell the user about the docker group, suggest `newgrp docker` to refresh the current shell, full logout, or reboot. Mention `usermod -aG docker $USER` for users not yet in the group.
* anything else → existing daemon-down path: try `systemctl start docker`, then `service docker start`, then fail with the old "start it manually" message.

## Test plan

- [x] `bash -n` passes on `install.sh`
- [x] 30 install-scripts tests pass (`npx vitest run src/lib/scraper/install-scripts.test.ts`)
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `/codex review` passed (cycle 2 APPROVE; cycle 1 caught a stderr-vs-exit-status correctness bug, fixed in commit 41008e0)
- [ ] Manual: re-test on Manjaro from a fresh user that has just been added to docker group. Expect to see the `newgrp docker` message instead of `Could not start Docker`.

Tests are filtered through an `INSTALL_SH_CODE` constant that strips full-line shell comments before substring assertions, so a comment near the change cannot satisfy a test on its own.

Refs #62.
