### PR TITLE
fix(deploy): smoke test exit code + prisma version pin enforcement

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -55,8 +55,13 @@ done
 echo "[setup] Database is ready"
 
 # --- Run migrations ---
+# Pin prisma to the major version that matches the schema (currently v6).
+# Without the pin, `npx prisma` fetches whatever the npm registry serves
+# as latest, which broke deploys when Prisma 7 dropped `url = env(...)`.
+# A future Dockerfile change should bundle the CLI + transitive deps so
+# this stops round-tripping the registry entirely.
 echo "[setup] Applying database schema..."
-npx prisma@6 db push --schema=apps/web/prisma/schema.prisma --skip-generate 2>&1 | tail -1
+npx prisma@^6 db push --schema=apps/web/prisma/schema.prisma --skip-generate 2>&1 | tail -1
 echo "[setup] Schema ready"
 
 # --- Self-hosted only: CLI auth + install ---

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -64,7 +64,12 @@ done
 info()  { echo "  [smoke] $*"; }
 pass()  { echo "  [smoke] PASS $*"; }
 fail()  { echo "  [smoke] FAIL $*"; }
-fatal() { echo "  [smoke] FATAL $*" >&2; cleanup; exit 1; }
+fatal() { echo "  [smoke] FATAL $*" >&2; exit 1; }
+# Don't call cleanup manually here — the EXIT trap fires it automatically
+# with the right $? (1, from this exit), whereas calling cleanup directly
+# would let `local status=$?` inside cleanup capture 0 from the prior
+# `echo` and then `exit "$status"` would exit successfully, masking the
+# fatal we just reported.
 
 cleanup() {
   # Capture the exit status that triggered this trap. Without this, a

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -26,6 +26,25 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
+# --- Precheck: Docker daemon must be reachable BEFORE any trap is set.
+# Without this, `docker compose build` fails on a missing socket and the
+# EXIT-trap cleanup masks the failure (the trap returns 0 because of the
+# `|| true` in `down`, and bash uses that as the exit code). The release
+# gate then reports "passed" even though no checks ran. See
+# https://github.com/affromero/fairtrail/pull/...
+if ! docker info >/dev/null 2>&1; then
+  cat >&2 <<EOF
+  [smoke] FATAL Docker daemon is not reachable.
+
+  Start Docker Desktop (macOS) or the docker service (Linux), wait for
+  the daemon to come up, and re-run:
+
+      ./scripts/docker-smoke-test.sh
+
+EOF
+  exit 1
+fi
+
 # --- Config ---
 COMPOSE_FILES="-f docker-compose.yml -f docker-compose.test.yml"
 CRON_SECRET="smoke-test-secret-$(date +%s)"
@@ -48,6 +67,11 @@ fail()  { echo "  [smoke] FAIL $*"; }
 fatal() { echo "  [smoke] FATAL $*" >&2; cleanup; exit 1; }
 
 cleanup() {
+  # Capture the exit status that triggered this trap. Without this, a
+  # successful `docker compose down` later in the cleanup overwrites the
+  # original failure code and the script reports a false "all checks
+  # passed". The trap restores it via `exit "$status"` at the end.
+  local status=$?
   info "Tearing down..."
   CRON_SECRET="$CRON_SECRET" HOST_PORT="$HOST_PORT" \
     docker compose $COMPOSE_FILES down -v --remove-orphans 2>/dev/null || true
@@ -57,6 +81,8 @@ cleanup() {
   else
     rm -f "$REPO_ROOT/.env" "$REPO_ROOT/.env.smoke-backup"
   fi
+  # Propagate the original failure to the shell.
+  exit "$status"
 }
 
 trap cleanup EXIT

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -204,6 +204,32 @@ test_install_supports_arch_family() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: docker-entrypoint.sh pins the prisma major version
+# Regression test against the v0.5.2 deploy: `npx prisma` (no version)
+# in the runtime entrypoint round-trips to the npm registry every startup
+# and Prisma 7 dropped `url = env("DATABASE_URL")`, breaking schema
+# parsing on every startup until pinned.
+#
+# Bundling the CLI in the runtime image is the proper fix but requires
+# also bundling its transitive deps (effect, @prisma/config, ...). Until
+# that lands, the version pin is the cheap insurance.
+# ---------------------------------------------------------------------------
+test_entrypoint_pins_prisma_major() {
+  local entrypoint="docker-entrypoint.sh"
+  local code_only
+  code_only=$(grep -vE '^\s*#' "$entrypoint")
+  if printf '%s\n' "$code_only" | grep -qE 'npx prisma@(\^|~)?[0-9]'; then
+    pass "docker-entrypoint.sh pins the prisma major version"
+  else
+    fail "docker-entrypoint.sh must pin prisma (e.g. 'npx prisma@^6 db push'), never run unpinned 'npx prisma'"
+  fi
+  # Specifically forbid unpinned 'npx prisma' (no @version) inside code.
+  if printf '%s\n' "$code_only" | grep -qE 'npx prisma( |$)'; then
+    fail "docker-entrypoint.sh contains unpinned 'npx prisma' which silently picks up new majors"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 echo ""
@@ -223,6 +249,7 @@ test_cli_has_cmd_tui
 test_install_supports_no_browser
 test_dockerfile_ships_cli
 test_install_supports_arch_family
+test_entrypoint_pins_prisma_major
 
 echo ""
 printf "${BOLD}Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}\n" "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Two repo-level resilience fixes after the v0.5.2 deploy. The `~/.claude/skills/deploy-fairtrail/skill.md` was also updated locally with three additional improvements (prisma@^6 pin in the explicit migration step, postgres password reconcile precheck, server-side log file via tee) — those are not part of this PR since the skill lives in user config.

## Why it happened (v0.5.2 deploy retro)

The v0.5.2 deploy turned a 2-minute job into a 30-minute debugging session because two unrelated bugs compounded:

1. **Pre-release gate silently passed when Docker was off**. The smoke test reported "ALL CHECKS PASSED" while the docker socket was missing. The release went out anyway. Root cause: `cleanup()` ran on EXIT, ended on `docker compose down 2>/dev/null || true` which returns 0, and bash propagated that as the script exit code. The actual build failure was masked.

2. **`npx prisma db push` (no version) inside the entrypoint round-tripped the npm registry on every startup**. Prisma 7 dropped `url = env("DATABASE_URL")` and broke schema parsing. The entrypoint was already pinned to `@6`, but the pin wasn't enforced anywhere and the deploy script bypassed the entrypoint with `--entrypoint ""`, calling unpinned `npx prisma`.

## Fix

### `scripts/docker-smoke-test.sh`

* Add a `docker info` precheck before any trap is set. If the daemon is down, exit 1 with a runbook message telling the user to start Docker and re-run.
* Capture the trigger exit status at the top of `cleanup()` and propagate it via `exit "$status"`. A non-zero failure during build/health/scrape now surfaces correctly even after cleanup.

Verified: `DOCKER_HOST=unix:///nonexistent.sock bash scripts/docker-smoke-test.sh` exits 1 with the runbook (was: exit 0 with a false pass).

### `docker-entrypoint.sh`

* Tighten the prisma version pin from `@6` to `@^6` (semver caret). Any 6.x patch still applies; a major bump is rejected loudly.
* Add a comment noting that the proper fix is to bundle the CLI in the runtime image. That requires also copying transitive deps (`effect`, `@prisma/config`, ...) which is a bigger Dockerfile change tracked separately.

### `scripts/install-flow-test.sh`

New regression `test_entrypoint_pins_prisma_major`: asserts the entrypoint pins the prisma major version (`npx prisma@^|~|N`) and explicitly forbids unpinned `npx prisma`. Strips shell comments before grepping so the explanatory comment that names the forbidden form doesn't falsely trip the check.

## Out of scope (tracked, not in this PR)

* **Bundle the full prisma CLI in the runtime image** so deploys never round-trip the registry. Tried in this PR but reverted: requires copying ~10 transitive deps (`effect`, `@prisma/config`, etc.) and the `.bin/prisma` symlink can't be `COPY`'d directly because Docker dereferences symlinks and detaches the entry script from its `prisma_schema_build_bg.wasm` sibling. Worth doing in a follow-up that either copies the full proddeps `node_modules` to a side path, or keeps a thin runner-stage `npm install --production prisma`.
* **Sotto.fm/Fairtrail shared `.env` clobber** that caused the postgres password mismatch. Needs coordination with the sotto deploy script — neither side currently namespaces its `.env` regen.

## Test plan

- [x] `bash scripts/install-flow-test.sh` (14/14 passing)
- [x] `bash scripts/docker-smoke-test.sh` (full smoke against the new entrypoint)
- [x] `DOCKER_HOST=unix:///nonexistent.sock bash scripts/docker-smoke-test.sh` exits 1 with runbook (was exit 0)
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean

Refs v0.5.2 deploy retro.
