### PR TITLE
fix(scraper): three followups for issue #65 (one-way airline URL, flex date iteration, silent extraction failures)

### DIFF
--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -165,7 +165,7 @@ function validatePreviewPayload(payload: PreviewRequestPayload): PreviewValidati
   const totalTasks = combos * datesToScrape.length;
 
   if (totalTasks > 24) {
-    throw new Error(`Too many date/route combinations (${totalTasks}). Max ${PREVIEW_MAX_DATES} dates x 4 routes = 28; cap is 24.`);
+    throw new Error(`Too many date/route combinations (${totalTasks}). Cap is 24 (combos x dates).`);
   }
 
   if (returnDates && outboundDates && !isOneWay && returnDates.length !== outboundDates.length) {

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -11,6 +11,9 @@ import { isKnownAirline } from '@/lib/scraper/airline-urls';
 import { extractPrices, type ExtractionFailureReason, type PriceData } from '@/lib/scraper/extract-prices';
 import { navigateAirlineDirect, navigateGoogleFlights } from '@/lib/scraper/navigate';
 import type { Airport } from '@/lib/scraper/parse-query';
+import { expandContinuousRangeToDates } from '@/lib/scraper/scrape-dates';
+
+const PREVIEW_MAX_DATES = 7;
 
 const RETRYABLE_FAILURES: ExtractionFailureReason[] = ['empty_extraction', 'page_not_loaded', 'no_json_in_response'];
 const MAX_ATTEMPTS = 2;
@@ -145,11 +148,18 @@ function validatePreviewPayload(payload: PreviewRequestPayload): PreviewValidati
   }
 
   const combos = origins.length * destinations.length;
-  const datesToScrape = outboundDates ?? [dateFrom];
+  // For continuous one-way ranges (no enumerated outboundDates), expand
+  // [dateFrom, dateTo] into per-day samples capped at PREVIEW_MAX_DATES so
+  // a +/- N flex query scrapes every day of the window. Round-trip continuous
+  // preview stays single-pair to fit the combos * dates <= 24 budget; the
+  // cron path does the wider grid.
+  const datesToScrape = outboundDates ?? (isOneWay
+    ? expandContinuousRangeToDates(dateFrom, dateTo, PREVIEW_MAX_DATES)
+    : [dateFrom]);
   const totalTasks = combos * datesToScrape.length;
 
   if (totalTasks > 24) {
-    throw new Error(`Too many date/route combinations (${totalTasks}). Max 6 dates x 4 routes = 24.`);
+    throw new Error(`Too many date/route combinations (${totalTasks}). Max ${PREVIEW_MAX_DATES} dates x 4 routes = 28; cap is 24.`);
   }
 
   if (returnDates && outboundDates && !isOneWay && returnDates.length !== outboundDates.length) {
@@ -320,7 +330,9 @@ async function runPreview(payload: PreviewRequestPayload): Promise<PreviewResult
     }
   }
 
-  const datesToScrape = outboundDates ?? [dateFrom];
+  const datesToScrape = outboundDates ?? (isOneWay
+    ? expandContinuousRangeToDates(dateFrom, dateTo, PREVIEW_MAX_DATES)
+    : [dateFrom]);
   const tasks: Array<{ combo: { origin: Airport; destination: Airport }; outboundDate: string; returnDate: string }> = [];
 
   for (const combo of combos) {

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -15,7 +15,13 @@ import { expandContinuousRangeToDates } from '@/lib/scraper/scrape-dates';
 
 const PREVIEW_MAX_DATES = 7;
 
-const RETRYABLE_FAILURES: ExtractionFailureReason[] = ['empty_extraction', 'page_not_loaded', 'no_json_in_response'];
+const RETRYABLE_FAILURES: ExtractionFailureReason[] = [
+  'empty_extraction',
+  'page_not_loaded',
+  'no_json_in_response',
+  'llm_error',
+  'json_parse_error',
+];
 const MAX_ATTEMPTS = 2;
 const DEBUG_DIR = '/tmp/fairtrail-debug';
 const PREVIEW_MAX_RESULTS = 20;
@@ -310,6 +316,8 @@ async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
     no_json_in_response: `Could not extract flight data from ${sourceName}`,
     empty_extraction: `No flights found - ${sourceName} may be rate-limiting`,
     all_filtered_out: 'Flights exist but none matched your filters',
+    llm_error: 'Extraction provider failed (timeout or rate limit). Try again in a moment.',
+    json_parse_error: 'Extraction provider returned malformed output. Try again in a moment.',
   };
 
   throw new Error(messages[lastFailureReason!] ?? 'Flight extraction failed');

--- a/apps/web/src/lib/scraper/ai-registry.test.ts
+++ b/apps/web/src/lib/scraper/ai-registry.test.ts
@@ -381,3 +381,46 @@ describe('ai-registry', () => {
     });
   });
 });
+
+describe('EXTRACT_TIMEOUT_MS env parsing (issue #65)', () => {
+  const ORIGINAL = process.env.EXTRACT_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.EXTRACT_TIMEOUT_MS;
+    else process.env.EXTRACT_TIMEOUT_MS = ORIGINAL;
+    vi.resetModules();
+  });
+
+  it('defaults to 90_000 ms when env var is unset', async () => {
+    delete process.env.EXTRACT_TIMEOUT_MS;
+    vi.resetModules();
+    const mod = await import('./ai-registry');
+    expect(mod.EXTRACT_TIMEOUT_MS).toBe(90_000);
+  });
+
+  it('respects a valid env var override', async () => {
+    process.env.EXTRACT_TIMEOUT_MS = '30000';
+    vi.resetModules();
+    const mod = await import('./ai-registry');
+    expect(mod.EXTRACT_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it('falls back to 90_000 when env var is not a number', async () => {
+    process.env.EXTRACT_TIMEOUT_MS = 'not-a-number';
+    vi.resetModules();
+    const mod = await import('./ai-registry');
+    expect(mod.EXTRACT_TIMEOUT_MS).toBe(90_000);
+  });
+
+  it('falls back to 90_000 when env var is zero or negative', async () => {
+    process.env.EXTRACT_TIMEOUT_MS = '0';
+    vi.resetModules();
+    let mod = await import('./ai-registry');
+    expect(mod.EXTRACT_TIMEOUT_MS).toBe(90_000);
+
+    process.env.EXTRACT_TIMEOUT_MS = '-5000';
+    vi.resetModules();
+    mod = await import('./ai-registry');
+    expect(mod.EXTRACT_TIMEOUT_MS).toBe(90_000);
+  });
+});

--- a/apps/web/src/lib/scraper/ai-registry.ts
+++ b/apps/web/src/lib/scraper/ai-registry.ts
@@ -1,5 +1,16 @@
 import Anthropic from '@anthropic-ai/sdk';
 
+/**
+ * Per-LLM-call timeout in ms. Without this, Gemini's SDK has no default
+ * request timeout and a hung call sits forever, which is what was happening
+ * in issue #65 (cron runs showed "[extract] sending ..." with no follow-up
+ * log line). 90s is conservative: Gemini Flash p99 for ~3k chars is ~30s.
+ * Configurable via env var EXTRACT_TIMEOUT_MS for ops tuning.
+ */
+const PARSED_TIMEOUT = parseInt(process.env.EXTRACT_TIMEOUT_MS ?? '90000', 10);
+export const EXTRACT_TIMEOUT_MS =
+  Number.isFinite(PARSED_TIMEOUT) && PARSED_TIMEOUT > 0 ? PARSED_TIMEOUT : 90_000;
+
 export interface ExtractionUsage {
   inputTokens: number;
   outputTokens: number;
@@ -66,12 +77,15 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
     ],
     extract: async (apiKey, model, systemPrompt, userPrompt) => {
       const client = new Anthropic({ apiKey });
-      const response = await client.messages.create({
-        model,
-        max_tokens: 8192,
-        system: systemPrompt,
-        messages: [{ role: 'user', content: userPrompt }],
-      });
+      const response = await client.messages.create(
+        {
+          model,
+          max_tokens: 8192,
+          system: systemPrompt,
+          messages: [{ role: 'user', content: userPrompt }],
+        },
+        { signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS) },
+      );
 
       const text = response.content
         .filter((block): block is Anthropic.TextBlock => block.type === 'text')
@@ -106,14 +120,17 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
         apiKey: apiKey || 'unused',
         baseURL: options?.baseUrl || process.env.OPENAI_BASE_URL || undefined,
       });
-      const response = await client.chat.completions.create({
-        model,
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userPrompt },
-        ],
-        max_tokens: 8192,
-      });
+      const response = await client.chat.completions.create(
+        {
+          model,
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+          ],
+          max_tokens: 8192,
+        },
+        { signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS) },
+      );
 
       return {
         content: response.choices[0]?.message.content ?? '',
@@ -136,14 +153,17 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
       const baseURL = options?.baseUrl
         || (process.env.OLLAMA_HOST ? process.env.OLLAMA_HOST + '/v1' : 'http://localhost:11434/v1');
       const client = new OpenAI({ apiKey: 'unused', baseURL });
-      const response = await client.chat.completions.create({
-        model,
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userPrompt },
-        ],
-        max_tokens: 8192,
-      });
+      const response = await client.chat.completions.create(
+        {
+          model,
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+          ],
+          max_tokens: 8192,
+        },
+        { signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS) },
+      );
 
       return {
         content: response.choices[0]?.message.content ?? '',
@@ -165,14 +185,17 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
       const { default: OpenAI } = await import('openai');
       const baseURL = options?.baseUrl || 'http://localhost:8080/v1';
       const client = new OpenAI({ apiKey: 'unused', baseURL });
-      const response = await client.chat.completions.create({
-        model,
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userPrompt },
-        ],
-        max_tokens: 8192,
-      });
+      const response = await client.chat.completions.create(
+        {
+          model,
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+          ],
+          max_tokens: 8192,
+        },
+        { signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS) },
+      );
 
       return {
         content: response.choices[0]?.message.content ?? '',
@@ -194,14 +217,17 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
       const { default: OpenAI } = await import('openai');
       const baseURL = options?.baseUrl || 'http://localhost:8000/v1';
       const client = new OpenAI({ apiKey: 'unused', baseURL });
-      const response = await client.chat.completions.create({
-        model,
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userPrompt },
-        ],
-        max_tokens: 8192,
-      });
+      const response = await client.chat.completions.create(
+        {
+          model,
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+          ],
+          max_tokens: 8192,
+        },
+        { signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS) },
+      );
 
       return {
         content: response.choices[0]?.message.content ?? '',
@@ -231,7 +257,13 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
         systemInstruction: systemPrompt,
       });
 
-      const result = await genModel.generateContent(userPrompt);
+      // @google/generative-ai 0.24+ accepts SingleRequestOptions as the second
+      // arg with native `signal` and `timeout` fields. Native signal aborts
+      // the underlying fetch (better than Promise.race which would leak).
+      const result = await genModel.generateContent(userPrompt, {
+        signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS),
+        timeout: EXTRACT_TIMEOUT_MS,
+      });
       const response = result.response;
 
       return {

--- a/apps/web/src/lib/scraper/airline-urls.test.ts
+++ b/apps/web/src/lib/scraper/airline-urls.test.ts
@@ -1,16 +1,32 @@
 import { describe, it, expect } from 'vitest';
 import { getAirlineUrl, isKnownAirline, getKnownAirlines } from './airline-urls';
+import type { FlightSearchParams } from './navigate';
 
-const baseParams = {
+const baseRT: FlightSearchParams = {
   origin: 'JFK',
   destination: 'LAX',
   dateFrom: new Date('2026-06-15'),
   dateTo: new Date('2026-06-22'),
+  tripType: 'round_trip',
 };
 
-describe('getAirlineUrl', () => {
+const baseOW: FlightSearchParams = {
+  origin: 'JFK',
+  destination: 'LAX',
+  dateFrom: new Date('2026-06-15'),
+  dateTo: new Date('2026-06-15'),
+  tripType: 'one_way',
+};
+
+const RETURN_KEY_PATTERN = /^(returnDate|return|inbound|inboundDate|dateIn|departure2|destination2|origin2)$/i;
+
+function paramKeys(url: string): string[] {
+  return Array.from(new URL(url).searchParams.keys());
+}
+
+describe('getAirlineUrl basics', () => {
   it('returns url for known airline', () => {
-    const url = getAirlineUrl('delta', baseParams);
+    const url = getAirlineUrl('delta', baseRT);
     expect(url).not.toBeNull();
     expect(url).toContain('delta.com');
     expect(url).toContain('JFK');
@@ -18,33 +34,125 @@ describe('getAirlineUrl', () => {
   });
 
   it('resolves IATA alias', () => {
-    const url = getAirlineUrl('DL', baseParams);
-    expect(url).toContain('delta.com');
+    expect(getAirlineUrl('DL', baseRT)).toContain('delta.com');
   });
 
   it('resolves full name alias', () => {
-    const url = getAirlineUrl('American Airlines', baseParams);
-    expect(url).toContain('aa.com');
+    expect(getAirlineUrl('American Airlines', baseRT)).toContain('aa.com');
   });
 
   it('returns null for unknown airline', () => {
-    expect(getAirlineUrl('FlyByNight', baseParams)).toBeNull();
+    expect(getAirlineUrl('FlyByNight', baseRT)).toBeNull();
   });
 
   it('normalizes case and whitespace', () => {
-    const url = getAirlineUrl('  DELTA  ', baseParams);
-    expect(url).toContain('delta.com');
+    expect(getAirlineUrl('  DELTA  ', baseRT)).toContain('delta.com');
   });
 
-  it('includes cabin class mapping', () => {
-    const url = getAirlineUrl('delta', { ...baseParams, cabinClass: 'business' });
+  it('formats outbound date as yyyy-mm-dd', () => {
+    const url = getAirlineUrl('delta', baseRT)!;
+    expect(url).toContain('2026-06-15');
+  });
+
+  it('throws on invalid IATA origin', () => {
+    expect(() => getAirlineUrl('delta', { ...baseRT, origin: 'NOT_IATA' })).toThrow(/Invalid IATA origin/);
+  });
+
+  it('throws on invalid IATA destination', () => {
+    expect(() => getAirlineUrl('delta', { ...baseRT, destination: 'lax' })).toThrow(/Invalid IATA destination/);
+  });
+});
+
+describe('round-trip URLs include return date', () => {
+  // Avianca uses departure2 for the return leg, not returnDate. Other carriers
+  // use one of: returnDate, return, inbound, inboundDate, dateIn.
+  it.each(getKnownAirlines())('%s round-trip URL contains return-leg encoding', (airline) => {
+    const url = getAirlineUrl(airline, baseRT)!;
+    const keys = paramKeys(url);
+    const hasReturnLeg = keys.some((k) => RETURN_KEY_PATTERN.test(k));
+    expect(hasReturnLeg).toBe(true);
+    expect(url).toContain('2026-06-22');
+  });
+});
+
+describe('one-way URLs do not leak return-leg parameters (issue #65)', () => {
+  it.each(getKnownAirlines())('%s one-way URL has no return-date-shaped param', (airline) => {
+    const url = getAirlineUrl(airline, baseOW)!;
+    const keys = paramKeys(url);
+    const leaked = keys.filter((k) => RETURN_KEY_PATTERN.test(k));
+    expect(leaked).toEqual([]);
+    // And no second occurrence of the dateTo (which equals dateFrom in oneway).
+    // Specifically, the return-leg key must be absent regardless of value.
+  });
+
+  it.each(getKnownAirlines())('%s one-way URL still contains origin and destination', (airline) => {
+    const url = getAirlineUrl(airline, baseOW)!;
+    expect(url).toContain('JFK');
+    expect(url).toContain('LAX');
+    expect(url).toContain('2026-06-15');
+  });
+});
+
+describe('per-airline tripType token (the 3 carriers that encode it)', () => {
+  it('southwest one-way has tripType=oneway', () => {
+    const url = new URL(getAirlineUrl('southwest', baseOW)!);
+    expect(url.searchParams.get('tripType')).toBe('oneway');
+  });
+
+  it('southwest round-trip has tripType=roundtrip', () => {
+    const url = new URL(getAirlineUrl('southwest', baseRT)!);
+    expect(url.searchParams.get('tripType')).toBe('roundtrip');
+  });
+
+  it('delta one-way has tripType=ONE_WAY', () => {
+    const url = new URL(getAirlineUrl('delta', baseOW)!);
+    expect(url.searchParams.get('tripType')).toBe('ONE_WAY');
+  });
+
+  it('delta round-trip has tripType=ROUND_TRIP', () => {
+    const url = new URL(getAirlineUrl('delta', baseRT)!);
+    expect(url.searchParams.get('tripType')).toBe('ROUND_TRIP');
+  });
+
+  it('american one-way has type=oneWay', () => {
+    const url = new URL(getAirlineUrl('american', baseOW)!);
+    expect(url.searchParams.get('type')).toBe('oneWay');
+  });
+
+  it('american round-trip has type=roundTrip', () => {
+    const url = new URL(getAirlineUrl('american', baseRT)!);
+    expect(url.searchParams.get('type')).toBe('roundTrip');
+  });
+});
+
+describe('cabin and currency still propagate for one-way', () => {
+  it('delta one-way with business cabin keeps BUSINESS', () => {
+    const url = getAirlineUrl('delta', { ...baseOW, cabinClass: 'business' })!;
     expect(url).toContain('BUSINESS');
   });
 
-  it('formats dates as yyyy-mm-dd', () => {
-    const url = getAirlineUrl('delta', baseParams)!;
-    expect(url).toContain('2026-06-15');
-    expect(url).toContain('2026-06-22');
+  it('avianca round-trip propagates currency', () => {
+    const url = new URL(getAirlineUrl('avianca', { ...baseRT, currency: 'COP' })!);
+    expect(url.searchParams.get('currency')).toBe('COP');
+  });
+
+  it('avianca one-way propagates currency', () => {
+    const url = new URL(getAirlineUrl('avianca', { ...baseOW, currency: 'COP' })!);
+    expect(url.searchParams.get('currency')).toBe('COP');
+  });
+
+  it('avianca one-way URL has no origin2/destination2/departure2', () => {
+    const url = new URL(getAirlineUrl('avianca', baseOW)!);
+    expect(url.searchParams.has('origin2')).toBe(false);
+    expect(url.searchParams.has('destination2')).toBe(false);
+    expect(url.searchParams.has('departure2')).toBe(false);
+  });
+
+  it('avianca round-trip URL has origin2/destination2/departure2', () => {
+    const url = new URL(getAirlineUrl('avianca', baseRT)!);
+    expect(url.searchParams.get('origin2')).toBe('LAX');
+    expect(url.searchParams.get('destination2')).toBe('JFK');
+    expect(url.searchParams.get('departure2')).toBe('2026-06-22');
   });
 });
 

--- a/apps/web/src/lib/scraper/airline-urls.ts
+++ b/apps/web/src/lib/scraper/airline-urls.ts
@@ -106,15 +106,29 @@ const AIRLINE_URL_SPECS: Record<string, AirlineSpec> = {
   },
 
   united: {
-    base: 'https://www.united.com/en-us/flight-search',
-    origin: 'from',
-    destination: 'to',
+    // Preserves the original path-based booking URL
+    // (https://www.united.com/en-us/flights-from-X-to-Y) which depends on
+    // the IATA codes being interpolated into the path, so this airline uses
+    // a customBuilder rather than the AirlineSpec query-string flow.
+    base: 'https://www.united.com',
+    origin: '__path',
+    destination: '__path',
     departureDate: 'departure',
-    returnDate: 'return',
-    passengers: { key: 'passengers', value: '1' },
-    cabin: {
-      key: 'cabin',
-      map: { economy: 'economy', premium_economy: 'premium-economy', business: 'business', first: 'first' },
+    customBuilder: (p, oneWay) => {
+      assertValidIataCode(p.origin, 'origin');
+      assertValidIataCode(p.destination, 'destination');
+      const url = new URL(`https://www.united.com/en-us/flights-from-${p.origin}-to-${p.destination}`);
+      url.searchParams.set('departure', isoDate(p.dateFrom));
+      if (!oneWay) url.searchParams.set('return', isoDate(p.dateTo));
+      url.searchParams.set('passengers', '1');
+      const cabinMapper: Record<string, string> = {
+        economy: 'economy',
+        premium_economy: 'premium-economy',
+        business: 'business',
+        first: 'first',
+      };
+      url.searchParams.set('cabin', cabinMapper[p.cabinClass ?? 'economy'] ?? 'economy');
+      return url;
     },
   },
 

--- a/apps/web/src/lib/scraper/airline-urls.ts
+++ b/apps/web/src/lib/scraper/airline-urls.ts
@@ -1,129 +1,396 @@
-import type { FlightSearchParams } from './navigate';
+import { assertValidIataCode, isoDate, type FlightSearchParams } from './navigate';
 
-type UrlBuilder = (params: FlightSearchParams) => string;
-
-function fmt(date: Date): string {
-  return date.toISOString().split('T')[0]!;
-}
-
-function cabinMap(cabinClass: string | undefined, mapping: Record<string, string>): string {
-  return mapping[cabinClass ?? 'economy'] ?? mapping['economy'] ?? '';
-}
-
-// Known airline URL patterns — avoids an LLM call when we can construct the URL directly
-const AIRLINE_URL_BUILDERS: Record<string, UrlBuilder> = {
-  // Americas
-  'southwest': (p) =>
-    `https://www.southwest.com/air/booking/select.html?originationAirportCode=${p.origin}&destinationAirportCode=${p.destination}&departureDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&adultPassengersCount=1&tripType=roundtrip`,
-
-  'jetblue': (p) =>
-    `https://www.jetblue.com/booking/flights?from=${p.origin}&to=${p.destination}&depart=${fmt(p.dateFrom)}&return=${fmt(p.dateTo)}&pax=1&fare=lowest`,
-
-  'delta': (p) =>
-    `https://www.delta.com/flight-search/search?cacheKeySuffix=a&action=findFlights&tripType=ROUND_TRIP&departureDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&paxCount=1&from=${p.origin}&to=${p.destination}&cabinClass=${cabinMap(p.cabinClass, { economy: 'MAIN', premium_economy: 'PREMIUM_ECONOMY', business: 'BUSINESS', first: 'FIRST' })}`,
-
-  'united': (p) =>
-    `https://www.united.com/en-us/flights-from-${p.origin}-to-${p.destination}?departure=${fmt(p.dateFrom)}&return=${fmt(p.dateTo)}&passengers=1&cabin=${cabinMap(p.cabinClass, { economy: 'economy', premium_economy: 'premium-economy', business: 'business', first: 'first' })}`,
-
-  'american': (p) =>
-    `https://www.aa.com/booking/find-flights?type=roundTrip&origin=${p.origin}&destination=${p.destination}&departDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&pax=1&cabin=${cabinMap(p.cabinClass, { economy: 'ECONOMY', premium_economy: 'PREMIUM_ECONOMY', business: 'BUSINESS', first: 'FIRST' })}`,
-
-  'avianca': (p) =>
-    `https://www.avianca.com/en/booking/select-flights/?origin1=${p.origin}&destination1=${p.destination}&departure1=${fmt(p.dateFrom)}&origin2=${p.destination}&destination2=${p.origin}&departure2=${fmt(p.dateTo)}&adt=1&tng=0&chd=0&inf=0&currency=${p.currency ?? 'USD'}`,
-
-  'latam': (p) =>
-    `https://www.latamairlines.com/us/en/booking?origin=${p.origin}&destination=${p.destination}&outbound=${fmt(p.dateFrom)}&inbound=${fmt(p.dateTo)}&adt=1&cabin=Y`,
-
-  'copa': (p) =>
-    `https://www.copaair.com/en-us/flight-offers/?origin=${p.origin}&destination=${p.destination}&departureDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&adults=1`,
-
-  'aeromexico': (p) =>
-    `https://www.aeromexico.com/en-us/booking?origin=${p.origin}&destination=${p.destination}&departure=${fmt(p.dateFrom)}&return=${fmt(p.dateTo)}&passengers=1`,
-
-  // Europe
-  'ryanair': (p) =>
-    `https://www.ryanair.com/gb/en/trip/flights/select?adults=1&dateOut=${fmt(p.dateFrom)}&dateIn=${fmt(p.dateTo)}&origin=${p.origin}&destination=${p.destination}`,
-
-  'easyjet': (p) =>
-    `https://www.easyjet.com/en/booking/select-flight?origin=${p.origin}&destination=${p.destination}&outboundDate=${fmt(p.dateFrom)}&inboundDate=${fmt(p.dateTo)}&adults=1`,
-
-  'vueling': (p) =>
-    `https://www.vueling.com/en/booking/select?origin=${p.origin}&destination=${p.destination}&outbound=${fmt(p.dateFrom)}&inbound=${fmt(p.dateTo)}&adults=1`,
-
-  'lufthansa': (p) =>
-    `https://www.lufthansa.com/us/en/flight-search?origin=${p.origin}&destination=${p.destination}&outbound=${fmt(p.dateFrom)}&inbound=${fmt(p.dateTo)}&pax=1&cabin=${cabinMap(p.cabinClass, { economy: 'eco', premium_economy: 'pre', business: 'bus', first: 'fir' })}`,
-
-  'british airways': (p) =>
-    `https://www.britishairways.com/travel/book/public/en_us?origin=${p.origin}&destination=${p.destination}&departureDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&adults=1&cabin=${cabinMap(p.cabinClass, { economy: 'M', premium_economy: 'W', business: 'C', first: 'F' })}`,
-
-  'air france': (p) =>
-    `https://www.airfrance.us/search/offer?origin=${p.origin}&destination=${p.destination}&outboundDate=${fmt(p.dateFrom)}&inboundDate=${fmt(p.dateTo)}&pax=1&cabinClass=${cabinMap(p.cabinClass, { economy: 'ECONOMY', premium_economy: 'PREMIUM', business: 'BUSINESS', first: 'FIRST' })}`,
-
-  'klm': (p) =>
-    `https://www.klm.us/search/offer?origin=${p.origin}&destination=${p.destination}&outboundDate=${fmt(p.dateFrom)}&inboundDate=${fmt(p.dateTo)}&pax=1`,
-
-  'iberia': (p) =>
-    `https://www.iberia.com/us/flights/?market=US&language=en&origin=${p.origin}&destination=${p.destination}&departure=${fmt(p.dateFrom)}&return=${fmt(p.dateTo)}&adults=1`,
-
-  'turkish airlines': (p) =>
-    `https://www.turkishairlines.com/en-us/flights/?origin=${p.origin}&destination=${p.destination}&departureDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&adult=1`,
-
-  // Middle East & Asia
-  'emirates': (p) =>
-    `https://www.emirates.com/us/english/book/flight-search/?origin=${p.origin}&destination=${p.destination}&departDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&pax=1&cabin=${cabinMap(p.cabinClass, { economy: 'economy', premium_economy: 'economy', business: 'business', first: 'first' })}`,
-
-  'qatar airways': (p) =>
-    `https://www.qatarairways.com/en/booking/book-a-flight.html?origin=${p.origin}&destination=${p.destination}&departDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&adults=1`,
-
-  'etihad': (p) =>
-    `https://www.etihad.com/en-us/fly-etihad/book-a-flight?origin=${p.origin}&destination=${p.destination}&departureDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&pax=1`,
-
-  'singapore airlines': (p) =>
-    `https://www.singaporeair.com/en_UK/plan-and-book/official-site-background/?origin=${p.origin}&destination=${p.destination}&departureDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&cabinClass=${cabinMap(p.cabinClass, { economy: 'Y', premium_economy: 'S', business: 'J', first: 'F' })}&adult=1`,
-
-  'cathay pacific': (p) =>
-    `https://www.cathaypacific.com/cx/en_US/book-a-trip/flight-search.html?origin=${p.origin}&destination=${p.destination}&departDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&adults=1`,
-
-  // Oceania
-  'qantas': (p) =>
-    `https://www.qantas.com/au/en/booking/flight-search.html?origin=${p.origin}&destination=${p.destination}&departureDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&adults=1`,
-
-  // Africa
-  'ethiopian airlines': (p) =>
-    `https://www.ethiopianairlines.com/booking/book-a-flight?origin=${p.origin}&destination=${p.destination}&departureDate=${fmt(p.dateFrom)}&returnDate=${fmt(p.dateTo)}&adults=1`,
+type TripTypeEnc = {
+  oneWayKey?: string;
+  oneWayValue?: string;
+  roundTripKey?: string;
+  roundTripValue?: string;
 };
 
-// Normalize airline name for lookup (lowercase, trim, common aliases)
+type AirlineSpec = {
+  base: string;
+  origin: string;
+  destination: string;
+  departureDate: string;
+  returnDate?: string;
+  passengers?: { key: string; value: string };
+  cabin?: { key: string; map: Record<string, string> };
+  currency?: string;
+  tripType?: TripTypeEnc;
+  extra?: Record<string, string>;
+  customBuilder?: (p: FlightSearchParams, oneWay: boolean) => URL;
+};
+
+function cabinValue(p: FlightSearchParams, map: Record<string, string>): string {
+  return map[p.cabinClass ?? 'economy'] ?? map.economy ?? '';
+}
+
+function buildFromSpec(spec: AirlineSpec, p: FlightSearchParams): string {
+  assertValidIataCode(p.origin, 'origin');
+  assertValidIataCode(p.destination, 'destination');
+
+  const oneWay = p.tripType === 'one_way';
+
+  if (spec.customBuilder) {
+    return spec.customBuilder(p, oneWay).toString();
+  }
+
+  const url = new URL(spec.base);
+  url.searchParams.set(spec.origin, p.origin);
+  url.searchParams.set(spec.destination, p.destination);
+  url.searchParams.set(spec.departureDate, isoDate(p.dateFrom));
+  if (spec.passengers) url.searchParams.set(spec.passengers.key, spec.passengers.value);
+  if (spec.cabin) url.searchParams.set(spec.cabin.key, cabinValue(p, spec.cabin.map));
+  if (spec.currency) url.searchParams.set(spec.currency, p.currency ?? 'USD');
+  if (spec.extra) {
+    for (const [k, v] of Object.entries(spec.extra)) url.searchParams.set(k, v);
+  }
+  if (oneWay) {
+    if (spec.tripType?.oneWayKey && spec.tripType.oneWayValue !== undefined) {
+      url.searchParams.set(spec.tripType.oneWayKey, spec.tripType.oneWayValue);
+    }
+  } else {
+    if (spec.returnDate) url.searchParams.set(spec.returnDate, isoDate(p.dateTo));
+    if (spec.tripType?.roundTripKey && spec.tripType.roundTripValue !== undefined) {
+      url.searchParams.set(spec.tripType.roundTripKey, spec.tripType.roundTripValue);
+    }
+  }
+  return url.toString();
+}
+
+const AIRLINE_URL_SPECS: Record<string, AirlineSpec> = {
+  // Americas
+  southwest: {
+    base: 'https://www.southwest.com/air/booking/select.html',
+    origin: 'originationAirportCode',
+    destination: 'destinationAirportCode',
+    departureDate: 'departureDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'adultPassengersCount', value: '1' },
+    tripType: {
+      oneWayKey: 'tripType',
+      oneWayValue: 'oneway',
+      roundTripKey: 'tripType',
+      roundTripValue: 'roundtrip',
+    },
+  },
+
+  jetblue: {
+    base: 'https://www.jetblue.com/booking/flights',
+    origin: 'from',
+    destination: 'to',
+    departureDate: 'depart',
+    returnDate: 'return',
+    passengers: { key: 'pax', value: '1' },
+    extra: { fare: 'lowest' },
+  },
+
+  delta: {
+    base: 'https://www.delta.com/flight-search/search',
+    origin: 'from',
+    destination: 'to',
+    departureDate: 'departureDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'paxCount', value: '1' },
+    cabin: {
+      key: 'cabinClass',
+      map: { economy: 'MAIN', premium_economy: 'PREMIUM_ECONOMY', business: 'BUSINESS', first: 'FIRST' },
+    },
+    extra: { cacheKeySuffix: 'a', action: 'findFlights' },
+    tripType: {
+      oneWayKey: 'tripType',
+      oneWayValue: 'ONE_WAY',
+      roundTripKey: 'tripType',
+      roundTripValue: 'ROUND_TRIP',
+    },
+  },
+
+  united: {
+    base: 'https://www.united.com/en-us/flight-search',
+    origin: 'from',
+    destination: 'to',
+    departureDate: 'departure',
+    returnDate: 'return',
+    passengers: { key: 'passengers', value: '1' },
+    cabin: {
+      key: 'cabin',
+      map: { economy: 'economy', premium_economy: 'premium-economy', business: 'business', first: 'first' },
+    },
+  },
+
+  american: {
+    base: 'https://www.aa.com/booking/find-flights',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'pax', value: '1' },
+    cabin: {
+      key: 'cabin',
+      map: { economy: 'ECONOMY', premium_economy: 'PREMIUM_ECONOMY', business: 'BUSINESS', first: 'FIRST' },
+    },
+    tripType: {
+      oneWayKey: 'type',
+      oneWayValue: 'oneWay',
+      roundTripKey: 'type',
+      roundTripValue: 'roundTrip',
+    },
+  },
+
+  avianca: {
+    base: 'https://www.avianca.com/en/booking/select-flights/',
+    origin: 'origin1',
+    destination: 'destination1',
+    departureDate: 'departure1',
+    customBuilder: (p, oneWay) => {
+      assertValidIataCode(p.origin, 'origin');
+      assertValidIataCode(p.destination, 'destination');
+      const url = new URL('https://www.avianca.com/en/booking/select-flights/');
+      url.searchParams.set('origin1', p.origin);
+      url.searchParams.set('destination1', p.destination);
+      url.searchParams.set('departure1', isoDate(p.dateFrom));
+      if (!oneWay) {
+        url.searchParams.set('origin2', p.destination);
+        url.searchParams.set('destination2', p.origin);
+        url.searchParams.set('departure2', isoDate(p.dateTo));
+      }
+      url.searchParams.set('adt', '1');
+      url.searchParams.set('tng', '0');
+      url.searchParams.set('chd', '0');
+      url.searchParams.set('inf', '0');
+      url.searchParams.set('currency', p.currency ?? 'USD');
+      return url;
+    },
+  },
+
+  latam: {
+    base: 'https://www.latamairlines.com/us/en/booking',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'outbound',
+    returnDate: 'inbound',
+    passengers: { key: 'adt', value: '1' },
+    extra: { cabin: 'Y' },
+  },
+
+  copa: {
+    base: 'https://www.copaair.com/en-us/flight-offers/',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departureDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'adults', value: '1' },
+  },
+
+  aeromexico: {
+    base: 'https://www.aeromexico.com/en-us/booking',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departure',
+    returnDate: 'return',
+    passengers: { key: 'passengers', value: '1' },
+  },
+
+  // Europe
+  ryanair: {
+    base: 'https://www.ryanair.com/gb/en/trip/flights/select',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'dateOut',
+    returnDate: 'dateIn',
+    passengers: { key: 'adults', value: '1' },
+  },
+
+  easyjet: {
+    base: 'https://www.easyjet.com/en/booking/select-flight',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'outboundDate',
+    returnDate: 'inboundDate',
+    passengers: { key: 'adults', value: '1' },
+  },
+
+  vueling: {
+    base: 'https://www.vueling.com/en/booking/select',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'outbound',
+    returnDate: 'inbound',
+    passengers: { key: 'adults', value: '1' },
+  },
+
+  lufthansa: {
+    base: 'https://www.lufthansa.com/us/en/flight-search',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'outbound',
+    returnDate: 'inbound',
+    passengers: { key: 'pax', value: '1' },
+    cabin: {
+      key: 'cabin',
+      map: { economy: 'eco', premium_economy: 'pre', business: 'bus', first: 'fir' },
+    },
+  },
+
+  'british airways': {
+    base: 'https://www.britishairways.com/travel/book/public/en_us',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departureDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'adults', value: '1' },
+    cabin: {
+      key: 'cabin',
+      map: { economy: 'M', premium_economy: 'W', business: 'C', first: 'F' },
+    },
+  },
+
+  'air france': {
+    base: 'https://www.airfrance.us/search/offer',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'outboundDate',
+    returnDate: 'inboundDate',
+    passengers: { key: 'pax', value: '1' },
+    cabin: {
+      key: 'cabinClass',
+      map: { economy: 'ECONOMY', premium_economy: 'PREMIUM', business: 'BUSINESS', first: 'FIRST' },
+    },
+  },
+
+  klm: {
+    base: 'https://www.klm.us/search/offer',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'outboundDate',
+    returnDate: 'inboundDate',
+    passengers: { key: 'pax', value: '1' },
+  },
+
+  iberia: {
+    base: 'https://www.iberia.com/us/flights/',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departure',
+    returnDate: 'return',
+    passengers: { key: 'adults', value: '1' },
+    extra: { market: 'US', language: 'en' },
+  },
+
+  'turkish airlines': {
+    base: 'https://www.turkishairlines.com/en-us/flights/',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departureDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'adult', value: '1' },
+  },
+
+  // Middle East and Asia
+  emirates: {
+    base: 'https://www.emirates.com/us/english/book/flight-search/',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'pax', value: '1' },
+    cabin: {
+      key: 'cabin',
+      map: { economy: 'economy', premium_economy: 'economy', business: 'business', first: 'first' },
+    },
+  },
+
+  'qatar airways': {
+    base: 'https://www.qatarairways.com/en/booking/book-a-flight.html',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'adults', value: '1' },
+  },
+
+  etihad: {
+    base: 'https://www.etihad.com/en-us/fly-etihad/book-a-flight',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departureDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'pax', value: '1' },
+  },
+
+  'singapore airlines': {
+    base: 'https://www.singaporeair.com/en_UK/plan-and-book/official-site-background/',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departureDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'adult', value: '1' },
+    cabin: {
+      key: 'cabinClass',
+      map: { economy: 'Y', premium_economy: 'S', business: 'J', first: 'F' },
+    },
+  },
+
+  'cathay pacific': {
+    base: 'https://www.cathaypacific.com/cx/en_US/book-a-trip/flight-search.html',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'adults', value: '1' },
+  },
+
+  // Oceania
+  qantas: {
+    base: 'https://www.qantas.com/au/en/booking/flight-search.html',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departureDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'adults', value: '1' },
+  },
+
+  // Africa
+  'ethiopian airlines': {
+    base: 'https://www.ethiopianairlines.com/booking/book-a-flight',
+    origin: 'origin',
+    destination: 'destination',
+    departureDate: 'departureDate',
+    returnDate: 'returnDate',
+    passengers: { key: 'adults', value: '1' },
+  },
+};
+
 const ALIASES: Record<string, string> = {
-  'aa': 'american',
+  aa: 'american',
   'american airlines': 'american',
-  'ua': 'united',
+  ua: 'united',
   'united airlines': 'united',
-  'dl': 'delta',
+  dl: 'delta',
   'delta air lines': 'delta',
-  'b6': 'jetblue',
-  'wn': 'southwest',
+  b6: 'jetblue',
+  wn: 'southwest',
   'southwest airlines': 'southwest',
-  'ba': 'british airways',
-  'af': 'air france',
-  'lh': 'lufthansa',
-  'ek': 'emirates',
-  'qr': 'qatar airways',
-  'sq': 'singapore airlines',
-  'cx': 'cathay pacific',
-  'qf': 'qantas',
-  'ey': 'etihad',
-  'tk': 'turkish airlines',
-  'av': 'avianca',
-  'la': 'latam',
-  'cm': 'copa',
-  'am': 'aeromexico',
-  'fr': 'ryanair',
-  'u2': 'easyjet',
-  'vy': 'vueling',
-  'ib': 'iberia',
-  'et': 'ethiopian airlines',
-  'ethiopian': 'ethiopian airlines',
+  ba: 'british airways',
+  af: 'air france',
+  lh: 'lufthansa',
+  ek: 'emirates',
+  qr: 'qatar airways',
+  sq: 'singapore airlines',
+  cx: 'cathay pacific',
+  qf: 'qantas',
+  ey: 'etihad',
+  tk: 'turkish airlines',
+  av: 'avianca',
+  la: 'latam',
+  cm: 'copa',
+  am: 'aeromexico',
+  fr: 'ryanair',
+  u2: 'easyjet',
+  vy: 'vueling',
+  ib: 'iberia',
+  et: 'ethiopian airlines',
+  ethiopian: 'ethiopian airlines',
 };
 
 function normalizeAirline(name: string): string {
@@ -133,14 +400,14 @@ function normalizeAirline(name: string): string {
 
 export function getAirlineUrl(airlineName: string, params: FlightSearchParams): string | null {
   const normalized = normalizeAirline(airlineName);
-  const builder = AIRLINE_URL_BUILDERS[normalized];
-  return builder ? builder(params) : null;
+  const spec = AIRLINE_URL_SPECS[normalized];
+  return spec ? buildFromSpec(spec, params) : null;
 }
 
 export function isKnownAirline(airlineName: string): boolean {
-  return normalizeAirline(airlineName) in AIRLINE_URL_BUILDERS;
+  return normalizeAirline(airlineName) in AIRLINE_URL_SPECS;
 }
 
 export function getKnownAirlines(): string[] {
-  return Object.keys(AIRLINE_URL_BUILDERS);
+  return Object.keys(AIRLINE_URL_SPECS);
 }

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -289,4 +289,57 @@ describe('extractPrices', () => {
       process.env.ANTHROPIC_API_KEY = origKey;
     }
   });
+
+  // Issue #65: previously, if the LLM rejected (timeout, rate limit, etc.)
+  // the error propagated up and was swallowed by runScrapeForQuery's silent
+  // catch. Now extractPrices returns a structured llm_error and logs.
+  it('returns llm_error when provider extract throws', async () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExtract.mockRejectedValue(new Error('rate limited'));
+
+    const result = await extractPrices('page content', 'https://flights.google.com', '2026-06-15');
+
+    expect(result.prices).toEqual([]);
+    expect(result.failureReason).toBe('llm_error');
+    expect(consoleErr).toHaveBeenCalledWith(
+      expect.stringContaining('FAIL llm_error'),
+    );
+    consoleErr.mockRestore();
+  });
+
+  it('returns llm_error when provider extract is aborted by AbortSignal timeout', async () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const abortErr = new Error('Request was aborted');
+    abortErr.name = 'AbortError';
+    mockExtract.mockRejectedValue(abortErr);
+
+    const result = await extractPrices('page content', 'https://flights.google.com', '2026-06-15');
+
+    expect(result.failureReason).toBe('llm_error');
+    consoleErr.mockRestore();
+  });
+
+  it('returns json_parse_error when LLM output has malformed JSON inside the bracket match', async () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // The regex /\[[\s\S]*\]/ matches; JSON.parse fails on truncated content.
+    mockExtract.mockResolvedValue({
+      content: '[{ "travelDate": "2026-06-15", "price": 6',  // truncated; closing ] is missing
+      usage: { inputTokens: 200, outputTokens: 50 },
+    });
+
+    // Force the regex to match by giving it a closing bracket that breaks JSON.
+    mockExtract.mockResolvedValue({
+      content: '[{ "travelDate": "2026-06-15", "price": invalid }]',
+      usage: { inputTokens: 200, outputTokens: 50 },
+    });
+
+    const result = await extractPrices('page content', 'https://flights.google.com', '2026-06-15');
+
+    expect(result.prices).toEqual([]);
+    expect(result.failureReason).toBe('json_parse_error');
+    expect(consoleErr).toHaveBeenCalledWith(
+      expect.stringContaining('FAIL json_parse_error'),
+    );
+    consoleErr.mockRestore();
+  });
 });

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -111,7 +111,9 @@ export type ExtractionFailureReason =
   | 'page_not_loaded'
   | 'no_json_in_response'
   | 'empty_extraction'
-  | 'all_filtered_out';
+  | 'all_filtered_out'
+  | 'llm_error'
+  | 'json_parse_error';
 
 export interface ExtractionResult {
   prices: PriceData[];
@@ -165,9 +167,16 @@ Page content:
 ${html}`;
 
   const systemPrompt = buildSystemPrompt(filters, maxResults, source, currency);
-  const result = await providerConfig.extract(apiKey, model, systemPrompt, userPrompt, {
-    baseUrl: config?.customBaseUrl ?? undefined,
-  });
+  let result;
+  try {
+    result = await providerConfig.extract(apiKey, model, systemPrompt, userPrompt, {
+      baseUrl: config?.customBaseUrl ?? undefined,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[extract] FAIL llm_error provider=${provider} model=${model} err=${msg}`);
+    return { prices: [], usage: { inputTokens: 0, outputTokens: 0 }, failureReason: 'llm_error' };
+  }
 
   const jsonMatch = result.content.match(/\[[\s\S]*\]/);
   if (!jsonMatch) {
@@ -175,7 +184,15 @@ ${html}`;
     return { prices: [], usage: result.usage, failureReason: 'no_json_in_response' };
   }
 
-  const raw = JSON.parse(jsonMatch[0]) as PriceData[];
+  let raw: PriceData[];
+  try {
+    raw = JSON.parse(jsonMatch[0]) as PriceData[];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const preview = jsonMatch[0].slice(0, 200);
+    console.error(`[extract] FAIL json_parse_error length=${jsonMatch[0].length} err=${msg} preview=${preview}`);
+    return { prices: [], usage: result.usage, failureReason: 'json_parse_error' };
+  }
 
   if (raw.length === 0) {
     console.log(`[extract] FAIL empty_extraction — LLM returned [] (${result.usage.inputTokens} input tokens)`);

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -58,13 +58,13 @@ export interface NavigationResult {
 // and would otherwise corrupt the URL via raw interpolation.
 const IATA_CODE = /^[A-Z]{3}$/;
 
-function assertValidIataCode(code: string, role: 'origin' | 'destination'): void {
+export function assertValidIataCode(code: string, role: 'origin' | 'destination'): void {
   if (!IATA_CODE.test(code)) {
     throw new Error(`Invalid IATA ${role} code: ${JSON.stringify(code)}`);
   }
 }
 
-function isoDate(d: Date): string {
+export function isoDate(d: Date): string {
   // toISOString().split('T')[0] returns the UTC calendar day. Callers that
   // construct dates in non-UTC timezones can see a day shift here; that risk
   // predates this file and is tracked separately.

--- a/apps/web/src/lib/scraper/run-scrape.test.ts
+++ b/apps/web/src/lib/scraper/run-scrape.test.ts
@@ -70,9 +70,12 @@ const BASE_QUERY = {
   preferredAirlines: [],
   maxPrice: null,
   maxStops: null,
+  maxDurationHours: null,
   timePreference: 'any',
+  flexibility: 0,
   lookAheadDays: 14,
   expiresAt: new Date('2027-01-01'),
+  vpnCountries: [],
 };
 
 describe('runScrapeForQuery', () => {
@@ -301,6 +304,210 @@ describe('runScrapeForQuery', () => {
         expect.objectContaining({ bookingUrl: null }),
       ]),
     });
+  });
+});
+
+describe('runScrapeForQuery multi-pair date expansion (issue #65)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.fetchRun.create.mockResolvedValue({ id: 'run1' });
+    mockPrisma.fetchRun.update.mockResolvedValue({});
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+    });
+    mockPrisma.priceSnapshot.findMany.mockResolvedValue([]);
+    mockPrisma.priceSnapshot.createMany.mockResolvedValue({ count: 1 });
+    mockPrisma.apiUsageLog.create.mockResolvedValue({});
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html>flights</html>',
+      url: 'https://flights.google.com',
+      resultsFound: true,
+      source: 'google_flights',
+    });
+    mockExtractPrices.mockResolvedValue({
+      prices: [{
+        travelDate: '2026-11-07',
+        price: 350,
+        currency: 'USD',
+        airline: 'Delta',
+        bookingUrl: '',
+        stops: 0,
+        duration: '5h',
+        departureTime: null,
+        arrivalTime: null,
+        seatsLeft: null,
+      }],
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+  });
+
+  it('one-way query with flex=2 calls navigate 5 times for the 5-day window', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      tripType: 'one_way',
+      dateFrom: new Date('2026-11-07'),
+      dateTo: new Date('2026-11-11'),
+      flexibility: 2,
+    });
+
+    await runScrapeForQuery('q1');
+
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(5);
+    const dates = mockNavigateGoogleFlights.mock.calls.map((call) => {
+      const params = call[0] as { dateFrom: Date };
+      return params.dateFrom.toISOString().slice(0, 10);
+    });
+    expect(dates).toEqual(['2026-11-07', '2026-11-08', '2026-11-09', '2026-11-10', '2026-11-11']);
+  });
+
+  it('round-trip query with flex=2 calls navigate 9 times for the 3x3 grid', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      tripType: 'round_trip',
+      dateFrom: new Date('2026-06-13'),
+      dateTo: new Date('2026-06-24'),
+      flexibility: 2,
+    });
+
+    await runScrapeForQuery('q1');
+
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(9);
+  });
+
+  it('creates a single FetchRun for a multi-pair scrape', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      tripType: 'one_way',
+      dateFrom: new Date('2026-11-07'),
+      dateTo: new Date('2026-11-09'),
+      flexibility: 1,
+    });
+
+    await runScrapeForQuery('q1');
+
+    expect(mockPrisma.fetchRun.create).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.fetchRun.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('flex=0 keeps single-pair behavior (no regression for non-flex queries)', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      tripType: 'one_way',
+      dateFrom: new Date('2026-06-15'),
+      dateTo: new Date('2026-06-15'),
+      flexibility: 0,
+    });
+
+    await runScrapeForQuery('q1');
+
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runScrapeForQuery sold-out scoping (issue #65)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.fetchRun.create.mockResolvedValue({ id: 'run1' });
+    mockPrisma.fetchRun.update.mockResolvedValue({});
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+    });
+    mockPrisma.priceSnapshot.createMany.mockResolvedValue({ count: 1 });
+    mockPrisma.apiUsageLog.create.mockResolvedValue({});
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html>flights</html>',
+      url: 'https://flights.google.com',
+      resultsFound: true,
+      source: 'google_flights',
+    });
+  });
+
+  it('does not flag sold-out for prior dates outside the scraped pair set', async () => {
+    // Query covers Nov 7..Nov 9 (one-way flex=1, 3-day window).
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      tripType: 'one_way',
+      dateFrom: new Date('2026-11-07'),
+      dateTo: new Date('2026-11-09'),
+      flexibility: 1,
+    });
+
+    // Prior snapshots include Nov 5 (out of range) and Nov 7 (in range).
+    // Both have status=available. Nov 7 has a flight that disappears in the
+    // current scrape; Nov 5 is from a previous wider-window scrape.
+    mockPrisma.priceSnapshot.findMany.mockResolvedValue([
+      {
+        flightId: 'Delta-1025-JFK-LAX-2026-11-05',
+        flightNumber: null,
+        price: 300,
+        airline: 'Delta',
+        travelDate: new Date('2026-11-05'),
+        currency: 'USD',
+        bookingUrl: 'https://example.com',
+        stops: 0,
+        duration: '5h',
+        departureTime: '10:25 AM',
+        arrivalTime: '3:25 PM',
+        status: 'available',
+      },
+      {
+        flightId: 'Delta-1025-JFK-LAX-2026-11-07',
+        flightNumber: null,
+        price: 350,
+        airline: 'Delta',
+        travelDate: new Date('2026-11-07'),
+        currency: 'USD',
+        bookingUrl: 'https://example.com',
+        stops: 0,
+        duration: '5h',
+        departureTime: '10:25 AM',
+        arrivalTime: '3:25 PM',
+        status: 'available',
+      },
+    ]);
+
+    // The current scrape returns United (different from the existing Delta flights).
+    mockExtractPrices.mockResolvedValue({
+      prices: [{
+        travelDate: '2026-11-07',
+        price: 400,
+        currency: 'USD',
+        airline: 'United',
+        bookingUrl: '',
+        stops: 1,
+        duration: '7h',
+        departureTime: '2:00 PM',
+        arrivalTime: '5:30 PM',
+        seatsLeft: null,
+      }],
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+
+    await runScrapeForQuery('q1');
+
+    // createMany is called for each pair's available rows (3 pairs x 1 flight = 3 calls)
+    // plus once for sold-out. Verify that the sold-out call only marks Nov 7 (in range),
+    // never Nov 5 (out of range).
+    const soldOutCall = mockPrisma.priceSnapshot.createMany.mock.calls.find((call) =>
+      Array.isArray(call[0]?.data) && call[0].data.some((row: { status?: string }) => row.status === 'sold_out')
+    );
+    expect(soldOutCall).toBeDefined();
+    const soldOutRows = soldOutCall![0].data as Array<{ flightId: string; status: string; travelDate: Date }>;
+    const soldOutDates = soldOutRows.map((r) => r.travelDate.toISOString().slice(0, 10));
+    expect(soldOutDates).toContain('2026-11-07');
+    expect(soldOutDates).not.toContain('2026-11-05');
   });
 });
 

--- a/apps/web/src/lib/scraper/run-scrape.test.ts
+++ b/apps/web/src/lib/scraper/run-scrape.test.ts
@@ -366,7 +366,8 @@ describe('runScrapeForQuery multi-pair date expansion (issue #65)', () => {
     expect(dates).toEqual(['2026-11-07', '2026-11-08', '2026-11-09', '2026-11-10', '2026-11-11']);
   });
 
-  it('round-trip query with flex=2 calls navigate 9 times for the 3x3 grid', async () => {
+  it('round-trip flex>0 still calls navigate once (single (dateFrom, dateTo) pair)', async () => {
+    // RT iteration is deferred until flightId/dedupe gain return-date awareness.
     mockPrisma.query.findUnique.mockResolvedValue({
       ...BASE_QUERY,
       tripType: 'round_trip',
@@ -377,7 +378,7 @@ describe('runScrapeForQuery multi-pair date expansion (issue #65)', () => {
 
     await runScrapeForQuery('q1');
 
-    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(9);
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(1);
   });
 
   it('creates a single FetchRun for a multi-pair scrape', async () => {
@@ -433,6 +434,50 @@ describe('runScrapeForQuery sold-out scoping (issue #65)', () => {
       source: 'google_flights',
     });
   });
+
+  it('does not flag sold-out when the pair scrape itself failed (audit blocker)', async () => {
+    // A failed pair (page_not_loaded, llm_error, etc.) must not mark prior
+    // snapshots for that date as sold_out, because we did not actually
+    // verify availability.
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      tripType: 'one_way',
+      dateFrom: new Date('2026-11-07'),
+      dateTo: new Date('2026-11-07'),
+      flexibility: 0,
+    });
+
+    mockPrisma.priceSnapshot.findMany.mockResolvedValue([{
+      flightId: 'Delta-1025-JFK-LAX-2026-11-07',
+      flightNumber: null,
+      price: 350,
+      airline: 'Delta',
+      travelDate: new Date('2026-11-07'),
+      currency: 'USD',
+      bookingUrl: 'https://example.com',
+      stops: 0,
+      duration: '5h',
+      departureTime: '10:25 AM',
+      arrivalTime: '3:25 PM',
+      status: 'available',
+    }]);
+
+    // Pair scrape returns failureReason on every attempt (no prices).
+    mockExtractPrices.mockResolvedValue({
+      prices: [],
+      usage: { inputTokens: 100, outputTokens: 20 },
+      failureReason: 'page_not_loaded',
+    });
+
+    await runScrapeForQuery('q1');
+
+    // No createMany call should mark the prior Delta flight as sold_out
+    // because the pair did not produce any prices.
+    const soldOutCall = mockPrisma.priceSnapshot.createMany.mock.calls.find((call) =>
+      Array.isArray(call[0]?.data) && call[0].data.some((row: { status?: string }) => row.status === 'sold_out')
+    );
+    expect(soldOutCall).toBeUndefined();
+  }, 15_000);
 
   it('does not flag sold-out for prior dates outside the scraped pair set', async () => {
     // Query covers Nov 7..Nov 9 (one-way flex=1, 3-day window).
@@ -531,16 +576,95 @@ describe('runScrapeForQuery extraction failure surfacing (issue #65)', () => {
     mockPrisma.apiUsageLog.create.mockResolvedValue({});
   });
 
-  it('logs to console.error when scrapeQueryForCountry throws (silent-catch fix)', async () => {
+  it('logs to console.error at the pair boundary when navigate throws (silent-catch fix)', async () => {
     const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockNavigateGoogleFlights.mockRejectedValue(new Error('browser crashed'));
 
     const result = await runScrapeForQuery('q1');
 
     expect(result.status).toBe('failed');
-    expect(result.error).toContain('browser crashed');
+    expect(consoleErr).toHaveBeenCalledWith(
+      expect.stringMatching(/pair=\S+ threw err=.*browser crashed/),
+    );
+    consoleErr.mockRestore();
+  });
+
+  it('logs to console.error in the outer runScrapeForQuery catch when scrapeQueryForCountry itself throws', async () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html>flights</html>',
+      url: 'https://flights.google.com',
+      resultsFound: true,
+      source: 'google_flights',
+    });
+    mockExtractPrices.mockResolvedValue({
+      prices: [{
+        travelDate: '2026-06-15',
+        price: 350,
+        currency: 'USD',
+        airline: 'Delta',
+        bookingUrl: '',
+        stops: 0,
+        duration: '5h',
+        departureTime: null,
+        arrivalTime: null,
+        seatsLeft: null,
+      }],
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+    // priceSnapshot.findMany runs after the pair loop inside
+    // scrapeQueryForCountry, so its throw lands in the outer catch.
+    mockPrisma.priceSnapshot.findMany.mockRejectedValueOnce(new Error('db connection lost'));
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('db connection lost');
     expect(consoleErr).toHaveBeenCalledWith(
       expect.stringContaining('runScrapeForQuery failed'),
+    );
+    consoleErr.mockRestore();
+  });
+
+  it('continues with remaining pairs when a single pair throws (issue #65 audit)', async () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      tripType: 'one_way',
+      dateFrom: new Date('2026-11-07'),
+      dateTo: new Date('2026-11-09'),
+      flexibility: 1,
+    });
+    // First pair throws, second succeeds, third succeeds.
+    mockNavigateGoogleFlights
+      .mockRejectedValueOnce(new Error('browser crashed'))
+      .mockResolvedValue({
+        html: '<html>flights</html>',
+        url: 'https://flights.google.com',
+        resultsFound: true,
+        source: 'google_flights',
+      });
+    mockExtractPrices.mockResolvedValue({
+      prices: [{
+        travelDate: '2026-11-08',
+        price: 350,
+        currency: 'USD',
+        airline: 'Delta',
+        bookingUrl: '',
+        stops: 0,
+        duration: '5h',
+        departureTime: null,
+        arrivalTime: null,
+        seatsLeft: null,
+      }],
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('success');
+    expect(consoleErr).toHaveBeenCalledWith(
+      expect.stringMatching(/pair=2026-11-07 threw/),
     );
     consoleErr.mockRestore();
   });

--- a/apps/web/src/lib/scraper/run-scrape.test.ts
+++ b/apps/web/src/lib/scraper/run-scrape.test.ts
@@ -511,6 +511,130 @@ describe('runScrapeForQuery sold-out scoping (issue #65)', () => {
   });
 });
 
+describe('runScrapeForQuery extraction failure surfacing (issue #65)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.query.findUnique.mockResolvedValue(BASE_QUERY);
+    mockPrisma.fetchRun.create.mockResolvedValue({ id: 'run1' });
+    mockPrisma.fetchRun.update.mockResolvedValue({});
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+    });
+    mockPrisma.priceSnapshot.findMany.mockResolvedValue([]);
+    mockPrisma.priceSnapshot.createMany.mockResolvedValue({ count: 0 });
+    mockPrisma.apiUsageLog.create.mockResolvedValue({});
+  });
+
+  it('logs to console.error when scrapeQueryForCountry throws (silent-catch fix)', async () => {
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockNavigateGoogleFlights.mockRejectedValue(new Error('browser crashed'));
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('browser crashed');
+    expect(consoleErr).toHaveBeenCalledWith(
+      expect.stringContaining('runScrapeForQuery failed'),
+    );
+    consoleErr.mockRestore();
+  });
+
+  it('retries when first attempt returns llm_error then succeeds', async () => {
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html>flights</html>',
+      url: 'https://flights.google.com',
+      resultsFound: true,
+      source: 'google_flights',
+    });
+    mockExtractPrices
+      .mockResolvedValueOnce({
+        prices: [],
+        usage: { inputTokens: 0, outputTokens: 0 },
+        failureReason: 'llm_error',
+      })
+      .mockResolvedValueOnce({
+        prices: [{
+          travelDate: '2026-06-15',
+          price: 350,
+          currency: 'USD',
+          airline: 'Delta',
+          bookingUrl: '',
+          stops: 0,
+          duration: '5h',
+          departureTime: null,
+          arrivalTime: null,
+          seatsLeft: null,
+        }],
+        usage: { inputTokens: 100, outputTokens: 20 },
+      });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('success');
+    expect(mockExtractPrices).toHaveBeenCalledTimes(2);
+  }, 15_000);
+
+  it('retries when first attempt returns json_parse_error then succeeds', async () => {
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html>flights</html>',
+      url: 'https://flights.google.com',
+      resultsFound: true,
+      source: 'google_flights',
+    });
+    mockExtractPrices
+      .mockResolvedValueOnce({
+        prices: [],
+        usage: { inputTokens: 100, outputTokens: 20 },
+        failureReason: 'json_parse_error',
+      })
+      .mockResolvedValueOnce({
+        prices: [{
+          travelDate: '2026-06-15',
+          price: 350,
+          currency: 'USD',
+          airline: 'Delta',
+          bookingUrl: '',
+          stops: 0,
+          duration: '5h',
+          departureTime: null,
+          arrivalTime: null,
+          seatsLeft: null,
+        }],
+        usage: { inputTokens: 100, outputTokens: 20 },
+      });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('success');
+    expect(mockExtractPrices).toHaveBeenCalledTimes(2);
+  }, 15_000);
+
+  it('writes human-readable llm_error message to FetchRun', async () => {
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html>flights</html>',
+      url: 'https://flights.google.com',
+      resultsFound: true,
+      source: 'google_flights',
+    });
+    mockExtractPrices.mockResolvedValue({
+      prices: [],
+      usage: { inputTokens: 0, outputTokens: 0 },
+      failureReason: 'llm_error',
+    });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('LLM call failed');
+  }, 15_000);
+});
+
 describe('PriceSnapshot schema', () => {
   it('bookingUrl must be optional (String?) to accept LLM null values', () => {
     const schema = readFileSync(

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -6,6 +6,7 @@ import { getModelCosts } from './ai-registry';
 import { isKnownAirline } from './airline-urls';
 import { getCountryProfile } from './country-profiles';
 import { createVpnProvider, type VpnProviderType } from './vpn';
+import { expandQueryDates } from './scrape-dates';
 
 const RETRYABLE_FAILURES: ExtractionFailureReason[] = ['empty_extraction', 'page_not_loaded', 'no_json_in_response'];
 const MAX_EXTRACT_ATTEMPTS = 2;
@@ -32,23 +33,103 @@ interface ScrapeResult {
   error?: string;
 }
 
+interface PairScrapeResult {
+  prices: import('./extract-prices').PriceData[];
+  inputTokens: number;
+  outputTokens: number;
+  sources: Set<string>;
+  lastFailureReason: string | undefined;
+}
+
+/** Scrape a single (outbound, return) date pair, with extract retries. */
+async function scrapeOneDatePair(
+  queryId: string,
+  pairParams: import('./navigate').FlightSearchParams,
+  filters: import('./extract-prices').QueryFilters,
+  directAirlines: string[],
+  useAirlineDirect: boolean,
+  countryProfile: ReturnType<typeof getCountryProfile> | undefined,
+  proxyUrl: string | undefined,
+  vpnCountry: string | null,
+): Promise<PairScrapeResult> {
+  const effectiveCurrency = pairParams.currency ?? null;
+  const travelDateFallback = pairParams.dateFrom.toISOString().split('T')[0]!;
+
+  const sources = new Set<string>();
+  let prices: import('./extract-prices').PriceData[] = [];
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let lastFailureReason: string | undefined;
+
+  async function navigateAll(): Promise<NavigationResult[]> {
+    if (useAirlineDirect) {
+      const results = await Promise.all(
+        directAirlines.map(async (airline) => {
+          try {
+            const result = await navigateAirlineDirect(pairParams, airline, countryProfile, proxyUrl);
+            if (!result.resultsFound) return null;
+            return result;
+          } catch {
+            return null;
+          }
+        })
+      );
+      const valid = results.filter((r): r is NavigationResult => r !== null);
+      if (valid.length === 0) {
+        return [await navigateGoogleFlights(pairParams, countryProfile, proxyUrl)];
+      }
+      return valid;
+    }
+    return [await navigateGoogleFlights(pairParams, countryProfile, proxyUrl)];
+  }
+
+  for (let attempt = 1; attempt <= MAX_EXTRACT_ATTEMPTS; attempt++) {
+    const vpnLabel = vpnCountry ? ` vpn=${vpnCountry}` : '';
+    console.log(`[scrape] query=${queryId}${vpnLabel} pair=${travelDateFallback} extract attempt ${attempt}/${MAX_EXTRACT_ATTEMPTS}`);
+
+    const navResults = await navigateAll();
+
+    for (const nav of navResults) {
+      sources.add(nav.source);
+      const result = await extractPrices(
+        nav.html, nav.url, travelDateFallback, filters, undefined, nav.resultsFound, nav.source, effectiveCurrency,
+      );
+      prices = prices.concat(result.prices);
+      inputTokens += result.usage.inputTokens;
+      outputTokens += result.usage.outputTokens;
+      if (result.failureReason) {
+        lastFailureReason = result.failureReason;
+        await saveDebugHtml(queryId, nav.html, attempt);
+      }
+    }
+
+    if (prices.length > 0) break;
+
+    if (attempt < MAX_EXTRACT_ATTEMPTS && lastFailureReason && RETRYABLE_FAILURES.includes(lastFailureReason as ExtractionFailureReason)) {
+      const delay = 5000 + Math.random() * 5000;
+      console.log(`[scrape] query=${queryId} pair=${travelDateFallback} retrying after ${Math.round(delay)}ms (reason: ${lastFailureReason})`);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+
+  return { prices, inputTokens, outputTokens, sources, lastFailureReason };
+}
+
 /** Scrape a single query for a single country pass (local or VPN). */
 async function scrapeQueryForCountry(
   queryId: string,
-  query: { origin: string; destination: string; preferredAirlines: string[]; maxPrice: number | null; maxStops: number | null; maxDurationHours: number | null; timePreference: string; cabinClass: string },
+  query: { origin: string; destination: string; preferredAirlines: string[]; maxPrice: number | null; maxStops: number | null; maxDurationHours: number | null; timePreference: string; cabinClass: string; flexibility: number },
   searchParams: import('./navigate').FlightSearchParams,
   config: { provider?: string; model?: string } | null,
   vpnCountry: string | null,
   proxyUrl: string | undefined,
   fetchRunId: string,
 ): Promise<ScrapeResult> {
-  const effectiveCurrency = searchParams.currency ?? null;
   const countryProfile = vpnCountry ? getCountryProfile(vpnCountry) : undefined;
 
   const directAirlines = query.preferredAirlines.filter(isKnownAirline);
   const useAirlineDirect = directAirlines.length > 0;
 
-  const travelDateFallback = searchParams.dateFrom.toISOString().split('T')[0]!;
   const filters = {
     maxPrice: query.maxPrice,
     maxStops: query.maxStops,
@@ -61,61 +142,45 @@ async function scrapeQueryForCountry(
   const model = config?.model ?? 'claude-haiku-4-5-20251001';
   const costs = getModelCosts(provider, model);
 
+  // Expand the date window into per-pair scrapes. One-way iterates every day
+  // in [dateFrom, dateTo] capped at 7; round-trip with flex emits a 3x3
+  // outbound/return grid; flex=0 collapses to a single pair.
+  const pairs = expandQueryDates(
+    {
+      dateFrom: searchParams.dateFrom,
+      dateTo: searchParams.dateTo,
+      flexibility: query.flexibility ?? 0,
+      tripType: searchParams.tripType ?? 'round_trip',
+    },
+    { oneWayCap: 7, roundTripGrid: 3 },
+  );
+  console.log(`[scrape] query=${queryId} expanded into ${pairs.length} date pair(s)`);
+
   let allPrices: import('./extract-prices').PriceData[] = [];
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
   let lastFailureReason: string | undefined;
   const sources = new Set<string>();
+  const scrapedTravelDates = new Set<string>();
 
-  async function navigateAll(): Promise<NavigationResult[]> {
-    if (useAirlineDirect) {
-      const results = await Promise.all(
-        directAirlines.map(async (airline) => {
-          try {
-            const result = await navigateAirlineDirect(searchParams, airline, countryProfile, proxyUrl);
-            if (!result.resultsFound) return null; // airline site blocked/empty
-            return result;
-          } catch {
-            return null;
-          }
-        })
-      );
-      const valid = results.filter((r): r is NavigationResult => r !== null);
-      // If all airline-direct attempts failed, fall back to Google Flights
-      if (valid.length === 0) {
-        return [await navigateGoogleFlights(searchParams, countryProfile, proxyUrl)];
-      }
-      return valid;
-    }
-    return [await navigateGoogleFlights(searchParams, countryProfile, proxyUrl)];
-  }
+  for (const pair of pairs) {
+    scrapedTravelDates.add(pair.outbound.toISOString().slice(0, 10));
+    const pairParams: import('./navigate').FlightSearchParams = {
+      ...searchParams,
+      dateFrom: pair.outbound,
+      dateTo: pair.return_,
+    };
 
-  for (let attempt = 1; attempt <= MAX_EXTRACT_ATTEMPTS; attempt++) {
-    const vpnLabel = vpnCountry ? ` vpn=${vpnCountry}` : '';
-    console.log(`[scrape] query=${queryId}${vpnLabel} extract attempt ${attempt}/${MAX_EXTRACT_ATTEMPTS}`);
+    const pairResult = await scrapeOneDatePair(
+      queryId, pairParams, filters, directAirlines, useAirlineDirect, countryProfile, proxyUrl, vpnCountry,
+    );
 
-    const navResults = await navigateAll();
-
-    for (const nav of navResults) {
-      sources.add(nav.source);
-      const { prices, usage, failureReason } = await extractPrices(
-        nav.html, nav.url, travelDateFallback, filters, undefined, nav.resultsFound, nav.source, effectiveCurrency
-      );
-      allPrices = allPrices.concat(prices);
-      totalInputTokens += usage.inputTokens;
-      totalOutputTokens += usage.outputTokens;
-      if (failureReason) {
-        lastFailureReason = failureReason;
-        await saveDebugHtml(queryId, nav.html, attempt);
-      }
-    }
-
-    if (allPrices.length > 0) break;
-
-    if (attempt < MAX_EXTRACT_ATTEMPTS && lastFailureReason && RETRYABLE_FAILURES.includes(lastFailureReason as ExtractionFailureReason)) {
-      const delay = 5000 + Math.random() * 5000;
-      console.log(`[scrape] query=${queryId} retrying after ${Math.round(delay)}ms (reason: ${lastFailureReason})`);
-      await new Promise((r) => setTimeout(r, delay));
+    allPrices = allPrices.concat(pairResult.prices);
+    totalInputTokens += pairResult.inputTokens;
+    totalOutputTokens += pairResult.outputTokens;
+    for (const s of pairResult.sources) sources.add(s);
+    if (pairResult.lastFailureReason) {
+      lastFailureReason = pairResult.lastFailureReason;
     }
   }
 
@@ -176,11 +241,18 @@ async function scrapeQueryForCountry(
   // Match prior rows against BOTH the new and the legacy id forms so the
   // rollout does not flag every existing flight as sold out when scraping
   // resumes.
+  //
+  // Scope sold-out detection to dates we actually scraped this run. With
+  // multi-pair scraping (issue #65 fix), the date pairs sampled per cron run
+  // can change, and snapshots for dates outside the current pair set must
+  // not be flagged sold-out just because we did not look at them.
   const currentFlightIds = new Set(withFlightIds.map((p) => p.flightId));
   const currentLegacyIds = new Set(withFlightIds.map((p) => p.flightIdLegacy));
   const soldOutSnapshots = previousSnapshots
     .filter((prev) => {
       if (!prev.flightId || prev.status !== 'available') return false;
+      const prevTravelIso = prev.travelDate.toISOString().slice(0, 10);
+      if (!scrapedTravelDates.has(prevTravelIso)) return false;
       return !currentFlightIds.has(prev.flightId) && !currentLegacyIds.has(prev.flightId);
     })
     .map((prev) => ({

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -8,7 +8,13 @@ import { getCountryProfile } from './country-profiles';
 import { createVpnProvider, type VpnProviderType } from './vpn';
 import { expandQueryDates } from './scrape-dates';
 
-const RETRYABLE_FAILURES: ExtractionFailureReason[] = ['empty_extraction', 'page_not_loaded', 'no_json_in_response'];
+const RETRYABLE_FAILURES: ExtractionFailureReason[] = [
+  'empty_extraction',
+  'page_not_loaded',
+  'no_json_in_response',
+  'llm_error',
+  'json_parse_error',
+];
 const MAX_EXTRACT_ATTEMPTS = 2;
 const DEBUG_DIR = '/tmp/fairtrail-debug';
 const VPN_INTER_COUNTRY_DELAY_MS = 12000;
@@ -310,6 +316,8 @@ async function scrapeQueryForCountry(
     no_json_in_response: 'LLM response contained no parseable JSON array. Page HTML may be a consent wall, error page, or empty shell.',
     empty_extraction: 'LLM parsed the page but returned 0 flights. Page likely loaded without flight content (rate-limited or empty response).',
     all_filtered_out: 'Flights were extracted but all removed by query filters (price/stops/airline).',
+    llm_error: 'LLM call failed (timeout, rate limit, or provider error). The provider may be temporarily unavailable.',
+    json_parse_error: 'LLM returned invalid JSON. Provider output was malformed or truncated.',
   };
   const errorMsg = failureReason ? failureMessages[failureReason] : undefined;
 
@@ -374,6 +382,10 @@ export async function runScrapeForQuery(
     );
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
+    // Log before updating the DB row so cron operators can diagnose silent
+    // failures from logs alone (issue #65). Without this, the only signal
+    // was the cron summary line "0 ok, N failed".
+    console.error(`[scrape] runScrapeForQuery failed query=${queryId} err=${errorMsg}`);
     await prisma.fetchRun.update({
       where: { id: fetchRun.id },
       data: { status: 'failed', error: errorMsg, completedAt: new Date() },

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -149,8 +149,10 @@ async function scrapeQueryForCountry(
   const costs = getModelCosts(provider, model);
 
   // Expand the date window into per-pair scrapes. One-way iterates every day
-  // in [dateFrom, dateTo] capped at 7; round-trip with flex emits a 3x3
-  // outbound/return grid; flex=0 collapses to a single pair.
+  // in [dateFrom, dateTo] capped at 7. Round-trip emits a single (dateFrom,
+  // dateTo) pair regardless of flexibility; iterating multiple pairs would
+  // collapse same-outbound flights with different returns at the
+  // flightId/dedupe layer.
   const pairs = expandQueryDates(
     {
       dateFrom: searchParams.dateFrom,
@@ -158,7 +160,7 @@ async function scrapeQueryForCountry(
       flexibility: query.flexibility ?? 0,
       tripType: searchParams.tripType ?? 'round_trip',
     },
-    { oneWayCap: 7, roundTripGrid: 3 },
+    { oneWayCap: 7 },
   );
   console.log(`[scrape] query=${queryId} expanded into ${pairs.length} date pair(s)`);
 
@@ -170,16 +172,26 @@ async function scrapeQueryForCountry(
   const scrapedTravelDates = new Set<string>();
 
   for (const pair of pairs) {
-    scrapedTravelDates.add(pair.outbound.toISOString().slice(0, 10));
+    const pairTravelDate = pair.outbound.toISOString().slice(0, 10);
     const pairParams: import('./navigate').FlightSearchParams = {
       ...searchParams,
       dateFrom: pair.outbound,
       dateTo: pair.return_,
     };
 
-    const pairResult = await scrapeOneDatePair(
-      queryId, pairParams, filters, directAirlines, useAirlineDirect, countryProfile, proxyUrl, vpnCountry,
-    );
+    // Per-pair try/catch isolates failures: a thrown pair (browser crash,
+    // VPN hiccup) must not discard prices already gathered from prior pairs.
+    let pairResult: PairScrapeResult;
+    try {
+      pairResult = await scrapeOneDatePair(
+        queryId, pairParams, filters, directAirlines, useAirlineDirect, countryProfile, proxyUrl, vpnCountry,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[scrape] query=${queryId} pair=${pairTravelDate} threw err=${msg}`);
+      lastFailureReason = lastFailureReason ?? 'page_not_loaded';
+      continue;
+    }
 
     allPrices = allPrices.concat(pairResult.prices);
     totalInputTokens += pairResult.inputTokens;
@@ -187,6 +199,13 @@ async function scrapeQueryForCountry(
     for (const s of pairResult.sources) sources.add(s);
     if (pairResult.lastFailureReason) {
       lastFailureReason = pairResult.lastFailureReason;
+    }
+    // Only mark this travelDate as authoritatively scraped if the pair
+    // produced prices. Without this gate, a pair that hit page_not_loaded
+    // or llm_error would still flag prior snapshots for that date as
+    // sold_out, even though we did not actually verify availability.
+    if (pairResult.prices.length > 0) {
+      scrapedTravelDates.add(pairTravelDate);
     }
   }
 

--- a/apps/web/src/lib/scraper/scrape-dates.test.ts
+++ b/apps/web/src/lib/scraper/scrape-dates.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
   expandQueryDates,
   expandContinuousRangeToDates,
-  previewRoundTripGridForCombos,
 } from './scrape-dates';
 
 const D = (s: string) => new Date(s + 'T00:00:00Z');
@@ -76,6 +75,10 @@ describe('expandQueryDates one-way', () => {
 });
 
 describe('expandQueryDates round-trip', () => {
+  // Round-trip always emits a single (dateFrom, dateTo) pair. Iterating per
+  // pair would collapse same-outbound flights with different returns at the
+  // flightId/dedupe layer; that requires a returnTravelDate column on
+  // PriceSnapshot which is out of scope for this fix.
   it('flex=0 emits a single (dateFrom, dateTo) pair', () => {
     const pairs = expandQueryDates({
       dateFrom: D('2026-06-15'),
@@ -88,57 +91,16 @@ describe('expandQueryDates round-trip', () => {
     expect(iso(pairs[0]!.return_)).toBe('2026-06-22');
   });
 
-  it('flex=2 over an 11-day trip emits 9 pairs (3x3 grid)', () => {
-    // Intent: outbound around Jun 15 +/- 2, return around Jun 22 +/- 2.
-    // Storage: dateFrom=Jun 13, dateTo=Jun 24 (= 22+2).
+  it('flex>0 still emits a single (dateFrom, dateTo) pair (RT iteration deferred)', () => {
     const pairs = expandQueryDates({
       dateFrom: D('2026-06-13'),
       dateTo: D('2026-06-24'),
       flexibility: 2,
       tripType: 'round_trip',
     });
-    expect(pairs).toHaveLength(9);
-
-    const outboundDays = new Set(pairs.map((p) => iso(p.outbound)));
-    const returnDays = new Set(pairs.map((p) => iso(p.return_)));
-    expect(outboundDays).toEqual(new Set(['2026-06-13', '2026-06-15', '2026-06-17']));
-    expect(returnDays).toEqual(new Set(['2026-06-20', '2026-06-22', '2026-06-24']));
-
-    // Every pair must have outbound <= return.
-    for (const p of pairs) {
-      expect(p.outbound.getTime()).toBeLessThanOrEqual(p.return_.getTime());
-    }
-  });
-
-  it('tight window (flex > gap) clamps and produces valid pairs', () => {
-    const pairs = expandQueryDates({
-      dateFrom: D('2026-06-15'),
-      dateTo: D('2026-06-16'),
-      flexibility: 5,
-      tripType: 'round_trip',
-    });
-    expect(pairs.length).toBeGreaterThanOrEqual(1);
-    for (const p of pairs) {
-      const o = iso(p.outbound);
-      const r = iso(p.return_);
-      expect(o >= '2026-06-15' && o <= '2026-06-16').toBe(true);
-      expect(r >= '2026-06-15' && r <= '2026-06-16').toBe(true);
-      expect(p.outbound.getTime()).toBeLessThanOrEqual(p.return_.getTime());
-    }
-  });
-
-  it('dedupes when grid cells coincide', () => {
-    // flex=1 on a tight window where outbound and return windows overlap
-    // entirely: every outbound choice equals every return choice (after
-    // outbound <= return filter, only the diagonal pairs survive).
-    const pairs = expandQueryDates({
-      dateFrom: D('2026-06-15'),
-      dateTo: D('2026-06-15'),
-      flexibility: 1,
-      tripType: 'round_trip',
-    });
-    const keys = pairs.map((p) => `${iso(p.outbound)}|${iso(p.return_)}`);
-    expect(new Set(keys).size).toBe(keys.length);
+    expect(pairs).toHaveLength(1);
+    expect(iso(pairs[0]!.outbound)).toBe('2026-06-13');
+    expect(iso(pairs[0]!.return_)).toBe('2026-06-24');
   });
 });
 
@@ -176,20 +138,3 @@ describe('expandContinuousRangeToDates', () => {
   });
 });
 
-describe('previewRoundTripGridForCombos', () => {
-  it('1 combo allows 4x4 grid', () => {
-    expect(previewRoundTripGridForCombos(1)).toBe(4);
-  });
-
-  it('6 combos allows 2x2 grid (4 pairs, 24 tasks)', () => {
-    expect(previewRoundTripGridForCombos(6)).toBe(2);
-  });
-
-  it('25 combos clamps to 1', () => {
-    expect(previewRoundTripGridForCombos(25)).toBe(1);
-  });
-
-  it('0 combos defaults to 1 (defensive)', () => {
-    expect(previewRoundTripGridForCombos(0)).toBe(1);
-  });
-});

--- a/apps/web/src/lib/scraper/scrape-dates.test.ts
+++ b/apps/web/src/lib/scraper/scrape-dates.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import {
+  expandQueryDates,
+  expandContinuousRangeToDates,
+  previewRoundTripGridForCombos,
+} from './scrape-dates';
+
+const D = (s: string) => new Date(s + 'T00:00:00Z');
+const iso = (d: Date) => d.toISOString().slice(0, 10);
+
+describe('expandQueryDates one-way', () => {
+  it('single-day query (flex=0) emits one pair', () => {
+    const pairs = expandQueryDates({
+      dateFrom: D('2026-06-15'),
+      dateTo: D('2026-06-15'),
+      flexibility: 0,
+      tripType: 'one_way',
+    });
+    expect(pairs).toHaveLength(1);
+    expect(iso(pairs[0]!.outbound)).toBe('2026-06-15');
+    expect(iso(pairs[0]!.return_)).toBe('2026-06-15');
+  });
+
+  it('5-day window (flex=2) emits 5 pairs covering every day', () => {
+    const pairs = expandQueryDates({
+      dateFrom: D('2026-11-07'),
+      dateTo: D('2026-11-11'),
+      flexibility: 2,
+      tripType: 'one_way',
+    });
+    expect(pairs.map((p) => iso(p.outbound))).toEqual([
+      '2026-11-07',
+      '2026-11-08',
+      '2026-11-09',
+      '2026-11-10',
+      '2026-11-11',
+    ]);
+    for (const p of pairs) {
+      expect(iso(p.outbound)).toBe(iso(p.return_));
+    }
+  });
+
+  it('large window (flex=15, 31 days) is capped at 7 evenly-spaced pairs', () => {
+    const pairs = expandQueryDates({
+      dateFrom: D('2026-06-15'),
+      dateTo: D('2026-07-15'),
+      flexibility: 15,
+      tripType: 'one_way',
+    });
+    expect(pairs).toHaveLength(7);
+    expect(iso(pairs[0]!.outbound)).toBe('2026-06-15');
+    expect(iso(pairs[6]!.outbound)).toBe('2026-07-15');
+    // Roughly evenly spaced (5-day stride for a 30-day span across 6 gaps).
+    const gaps = pairs.slice(1).map((p, i) => {
+      const prev = pairs[i]!.outbound;
+      return Math.round((p.outbound.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24));
+    });
+    for (const g of gaps) {
+      expect(g).toBeGreaterThanOrEqual(4);
+      expect(g).toBeLessThanOrEqual(6);
+    }
+  });
+
+  it('respects custom oneWayCap', () => {
+    const pairs = expandQueryDates(
+      {
+        dateFrom: D('2026-06-15'),
+        dateTo: D('2026-07-15'),
+        flexibility: 15,
+        tripType: 'one_way',
+      },
+      { oneWayCap: 3 },
+    );
+    expect(pairs).toHaveLength(3);
+  });
+});
+
+describe('expandQueryDates round-trip', () => {
+  it('flex=0 emits a single (dateFrom, dateTo) pair', () => {
+    const pairs = expandQueryDates({
+      dateFrom: D('2026-06-15'),
+      dateTo: D('2026-06-22'),
+      flexibility: 0,
+      tripType: 'round_trip',
+    });
+    expect(pairs).toHaveLength(1);
+    expect(iso(pairs[0]!.outbound)).toBe('2026-06-15');
+    expect(iso(pairs[0]!.return_)).toBe('2026-06-22');
+  });
+
+  it('flex=2 over an 11-day trip emits 9 pairs (3x3 grid)', () => {
+    // Intent: outbound around Jun 15 +/- 2, return around Jun 22 +/- 2.
+    // Storage: dateFrom=Jun 13, dateTo=Jun 24 (= 22+2).
+    const pairs = expandQueryDates({
+      dateFrom: D('2026-06-13'),
+      dateTo: D('2026-06-24'),
+      flexibility: 2,
+      tripType: 'round_trip',
+    });
+    expect(pairs).toHaveLength(9);
+
+    const outboundDays = new Set(pairs.map((p) => iso(p.outbound)));
+    const returnDays = new Set(pairs.map((p) => iso(p.return_)));
+    expect(outboundDays).toEqual(new Set(['2026-06-13', '2026-06-15', '2026-06-17']));
+    expect(returnDays).toEqual(new Set(['2026-06-20', '2026-06-22', '2026-06-24']));
+
+    // Every pair must have outbound <= return.
+    for (const p of pairs) {
+      expect(p.outbound.getTime()).toBeLessThanOrEqual(p.return_.getTime());
+    }
+  });
+
+  it('tight window (flex > gap) clamps and produces valid pairs', () => {
+    const pairs = expandQueryDates({
+      dateFrom: D('2026-06-15'),
+      dateTo: D('2026-06-16'),
+      flexibility: 5,
+      tripType: 'round_trip',
+    });
+    expect(pairs.length).toBeGreaterThanOrEqual(1);
+    for (const p of pairs) {
+      const o = iso(p.outbound);
+      const r = iso(p.return_);
+      expect(o >= '2026-06-15' && o <= '2026-06-16').toBe(true);
+      expect(r >= '2026-06-15' && r <= '2026-06-16').toBe(true);
+      expect(p.outbound.getTime()).toBeLessThanOrEqual(p.return_.getTime());
+    }
+  });
+
+  it('dedupes when grid cells coincide', () => {
+    // flex=1 on a tight window where outbound and return windows overlap
+    // entirely: every outbound choice equals every return choice (after
+    // outbound <= return filter, only the diagonal pairs survive).
+    const pairs = expandQueryDates({
+      dateFrom: D('2026-06-15'),
+      dateTo: D('2026-06-15'),
+      flexibility: 1,
+      tripType: 'round_trip',
+    });
+    const keys = pairs.map((p) => `${iso(p.outbound)}|${iso(p.return_)}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe('expandContinuousRangeToDates', () => {
+  it('returns every day for short ranges', () => {
+    expect(expandContinuousRangeToDates('2026-06-15', '2026-06-19')).toEqual([
+      '2026-06-15',
+      '2026-06-16',
+      '2026-06-17',
+      '2026-06-18',
+      '2026-06-19',
+    ]);
+  });
+
+  it('caps at 7 evenly-spaced dates for wide ranges', () => {
+    const dates = expandContinuousRangeToDates('2026-06-15', '2026-07-15');
+    expect(dates).toHaveLength(7);
+    expect(dates[0]).toBe('2026-06-15');
+    expect(dates[6]).toBe('2026-07-15');
+  });
+
+  it('respects custom cap', () => {
+    const dates = expandContinuousRangeToDates('2026-06-15', '2026-07-15', 3);
+    expect(dates).toHaveLength(3);
+    expect(dates[0]).toBe('2026-06-15');
+    expect(dates[2]).toBe('2026-07-15');
+  });
+
+  it('returns single date when dateFrom == dateTo', () => {
+    expect(expandContinuousRangeToDates('2026-06-15', '2026-06-15')).toEqual(['2026-06-15']);
+  });
+
+  it('returns single date for inverted range (defensive)', () => {
+    expect(expandContinuousRangeToDates('2026-06-19', '2026-06-15')).toEqual(['2026-06-19']);
+  });
+});
+
+describe('previewRoundTripGridForCombos', () => {
+  it('1 combo allows 4x4 grid', () => {
+    expect(previewRoundTripGridForCombos(1)).toBe(4);
+  });
+
+  it('6 combos allows 2x2 grid (4 pairs, 24 tasks)', () => {
+    expect(previewRoundTripGridForCombos(6)).toBe(2);
+  });
+
+  it('25 combos clamps to 1', () => {
+    expect(previewRoundTripGridForCombos(25)).toBe(1);
+  });
+
+  it('0 combos defaults to 1 (defensive)', () => {
+    expect(previewRoundTripGridForCombos(0)).toBe(1);
+  });
+});

--- a/apps/web/src/lib/scraper/scrape-dates.ts
+++ b/apps/web/src/lib/scraper/scrape-dates.ts
@@ -24,8 +24,6 @@ export interface ScrapeDatePair {
 export interface ExpandQueryDatesOptions {
   /** Max one-way pairs across the [dateFrom, dateTo] window. */
   oneWayCap?: number;
-  /** Round-trip grid side length (N x N pairs after dedupe). */
-  roundTripGrid?: number;
 }
 
 /** Convert a Date to an ISO calendar day (UTC). */
@@ -70,25 +68,23 @@ function evenIndices(length: number, count: number): number[] {
  *   - If the range is wider than `oneWayCap`, samples evenly-spaced days,
  *     always including dateFrom and dateTo.
  *
- * Round-trip with flexibility > 0:
- *   - Outbound dates: `roundTripGrid` evenly-spaced from
- *     [dateFrom, min(dateFrom + 2*flex, dateTo)].
- *   - Return dates: `roundTripGrid` evenly-spaced from
- *     [max(dateTo - 2*flex, dateFrom), dateTo].
- *   - Cartesian product, deduped by (outboundISO, returnISO), then filtered
- *     to keep only pairs where outbound <= return.
- *
- * Round-trip flexibility = 0 and one-way dateFrom == dateTo collapse to a
- * single pair (no behavior change for current single-day queries).
+ * Round-trip:
+ *   - Always emits a single (dateFrom, dateTo) pair regardless of
+ *     flexibility. PriceSnapshot.flightId is keyed by airline + outbound
+ *     travelDate only, so iterating multiple (outbound, return) pairs would
+ *     collapse same-outbound flights with different returns. Google
+ *     Flights' calendar grid already surfaces nearby return dates within a
+ *     single search, so the loss is small. Adding RT pair iteration would
+ *     require a returnTravelDate column on PriceSnapshot and changes to
+ *     flightId; that is a future migration, not part of this fix.
  */
 export function expandQueryDates(
   query: { dateFrom: Date; dateTo: Date; flexibility: number; tripType: string },
   options: ExpandQueryDatesOptions = {},
 ): ScrapeDatePair[] {
   const oneWayCap = options.oneWayCap ?? 7;
-  const roundTripGrid = options.roundTripGrid ?? 3;
 
-  const { dateFrom, dateTo, flexibility, tripType } = query;
+  const { dateFrom, dateTo, tripType } = query;
   const isOneWay = tripType === 'one_way';
 
   if (isOneWay) {
@@ -104,45 +100,8 @@ export function expandQueryDates(
     });
   }
 
-  // Round-trip
-  if (flexibility <= 0) {
-    return [{ outbound: dateFrom, return_: dateTo }];
-  }
-
-  // Outbound flex window: [dateFrom, dateFrom + 2*flex] clamped to dateTo.
-  const outboundEnd = new Date(
-    Math.min(addDaysUtc(dateFrom, 2 * flexibility).getTime(), dateTo.getTime()),
-  );
-  const outboundSpan = Math.max(0, dayDiff(dateFrom, outboundEnd));
-  const outboundDays = outboundSpan + 1;
-  const outboundIndices = evenIndices(outboundDays, Math.min(outboundDays, roundTripGrid));
-  const outboundDates = outboundIndices.map((i) => addDaysUtc(dateFrom, i));
-
-  // Return flex window: [dateTo - 2*flex, dateTo] clamped to dateFrom.
-  const returnStart = new Date(
-    Math.max(addDaysUtc(dateTo, -2 * flexibility).getTime(), dateFrom.getTime()),
-  );
-  const returnSpan = Math.max(0, dayDiff(returnStart, dateTo));
-  const returnDays = returnSpan + 1;
-  const returnIndices = evenIndices(returnDays, Math.min(returnDays, roundTripGrid));
-  const returnDates = returnIndices.map((i) => addDaysUtc(returnStart, i));
-
-  // Cartesian product, dedupe, drop outbound > return.
-  const seen = new Set<string>();
-  const pairs: ScrapeDatePair[] = [];
-  for (const outbound of outboundDates) {
-    for (const ret of returnDates) {
-      if (outbound.getTime() > ret.getTime()) continue;
-      const key = `${toIsoDay(outbound)}|${toIsoDay(ret)}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      pairs.push({ outbound, return_: ret });
-    }
-  }
-  if (pairs.length === 0) {
-    return [{ outbound: dateFrom, return_: dateTo }];
-  }
-  return pairs;
+  // Round-trip: single pair until flightId/dedupe gain return-date awareness.
+  return [{ outbound: dateFrom, return_: dateTo }];
 }
 
 /**
@@ -167,14 +126,4 @@ export function expandContinuousRangeToDates(
   const totalDays = span + 1;
   const indices = evenIndices(totalDays, Math.min(totalDays, cap));
   return indices.map((i) => toIsoDay(addDaysUtc(from, i)));
-}
-
-/**
- * For the preview path: the round-trip pair count must respect the
- * combos x dates <= 24 cap in validatePreviewPayload. Return the largest
- * grid side that fits. Always >= 1.
- */
-export function previewRoundTripGridForCombos(combos: number): number {
-  if (combos <= 0) return 1;
-  return Math.max(1, Math.floor(Math.sqrt(24 / combos)));
 }

--- a/apps/web/src/lib/scraper/scrape-dates.ts
+++ b/apps/web/src/lib/scraper/scrape-dates.ts
@@ -1,0 +1,180 @@
+/**
+ * Date-pair expansion for the scrape pipeline.
+ *
+ * Issue #65: queries with a flexibility window (e.g. "Nov 9 +/- 2 days") store
+ * dateFrom=Nov 7, dateTo=Nov 11, flexibility=2. The scrape orchestrator must
+ * expand this into per-day searches for one-way and a sampled grid for
+ * round-trip; otherwise only dateFrom is ever queried and the rest of the
+ * window is silently skipped.
+ *
+ * Invariant from parse-query.ts: continuous range queries store
+ * `dateTo - dateFrom = 2 * flexibility`. Round-trip stores
+ * dateFrom = (intended outbound) - flex and dateTo = (intended return) + flex,
+ * so outbound flex window is [dateFrom, dateFrom + 2*flex] and return flex
+ * window is [dateTo - 2*flex, dateTo].
+ */
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export interface ScrapeDatePair {
+  outbound: Date;
+  return_: Date;
+}
+
+export interface ExpandQueryDatesOptions {
+  /** Max one-way pairs across the [dateFrom, dateTo] window. */
+  oneWayCap?: number;
+  /** Round-trip grid side length (N x N pairs after dedupe). */
+  roundTripGrid?: number;
+}
+
+/** Convert a Date to an ISO calendar day (UTC). */
+function toIsoDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function dayDiff(a: Date, b: Date): number {
+  return Math.round((b.getTime() - a.getTime()) / MS_PER_DAY);
+}
+
+function addDaysUtc(d: Date, n: number): Date {
+  return new Date(d.getTime() + n * MS_PER_DAY);
+}
+
+/**
+ * Pick `count` evenly-spaced indices from [0, length-1] inclusive. Always
+ * returns the endpoints when count >= 2 and length >= 2. count == 1 returns
+ * [0]. count == 0 returns [].
+ */
+function evenIndices(length: number, count: number): number[] {
+  if (length <= 0 || count <= 0) return [];
+  if (count === 1) return [0];
+  if (length <= count) return Array.from({ length }, (_, i) => i);
+  const result: number[] = [];
+  for (let i = 0; i < count; i++) {
+    result.push(Math.round((i * (length - 1)) / (count - 1)));
+  }
+  // Defensive dedupe in case rounding produced duplicates at the seam of a
+  // very small range; preserves insertion order.
+  return Array.from(new Set(result));
+}
+
+/**
+ * Expand a query's stored date window into the (outbound, return) pairs the
+ * scraper actually iterates.
+ *
+ * One-way:
+ *   - Emits one pair per day in [dateFrom, dateTo] inclusive.
+ *   - Each pair has outbound == return (matches the upstream invariant for
+ *     one-way: only dateFrom is sent to the upstream URL).
+ *   - If the range is wider than `oneWayCap`, samples evenly-spaced days,
+ *     always including dateFrom and dateTo.
+ *
+ * Round-trip with flexibility > 0:
+ *   - Outbound dates: `roundTripGrid` evenly-spaced from
+ *     [dateFrom, min(dateFrom + 2*flex, dateTo)].
+ *   - Return dates: `roundTripGrid` evenly-spaced from
+ *     [max(dateTo - 2*flex, dateFrom), dateTo].
+ *   - Cartesian product, deduped by (outboundISO, returnISO), then filtered
+ *     to keep only pairs where outbound <= return.
+ *
+ * Round-trip flexibility = 0 and one-way dateFrom == dateTo collapse to a
+ * single pair (no behavior change for current single-day queries).
+ */
+export function expandQueryDates(
+  query: { dateFrom: Date; dateTo: Date; flexibility: number; tripType: string },
+  options: ExpandQueryDatesOptions = {},
+): ScrapeDatePair[] {
+  const oneWayCap = options.oneWayCap ?? 7;
+  const roundTripGrid = options.roundTripGrid ?? 3;
+
+  const { dateFrom, dateTo, flexibility, tripType } = query;
+  const isOneWay = tripType === 'one_way';
+
+  if (isOneWay) {
+    const span = dayDiff(dateFrom, dateTo);
+    if (span <= 0) {
+      return [{ outbound: dateFrom, return_: dateFrom }];
+    }
+    const totalDays = span + 1;
+    const indices = evenIndices(totalDays, Math.min(totalDays, oneWayCap));
+    return indices.map((i) => {
+      const day = addDaysUtc(dateFrom, i);
+      return { outbound: day, return_: day };
+    });
+  }
+
+  // Round-trip
+  if (flexibility <= 0) {
+    return [{ outbound: dateFrom, return_: dateTo }];
+  }
+
+  // Outbound flex window: [dateFrom, dateFrom + 2*flex] clamped to dateTo.
+  const outboundEnd = new Date(
+    Math.min(addDaysUtc(dateFrom, 2 * flexibility).getTime(), dateTo.getTime()),
+  );
+  const outboundSpan = Math.max(0, dayDiff(dateFrom, outboundEnd));
+  const outboundDays = outboundSpan + 1;
+  const outboundIndices = evenIndices(outboundDays, Math.min(outboundDays, roundTripGrid));
+  const outboundDates = outboundIndices.map((i) => addDaysUtc(dateFrom, i));
+
+  // Return flex window: [dateTo - 2*flex, dateTo] clamped to dateFrom.
+  const returnStart = new Date(
+    Math.max(addDaysUtc(dateTo, -2 * flexibility).getTime(), dateFrom.getTime()),
+  );
+  const returnSpan = Math.max(0, dayDiff(returnStart, dateTo));
+  const returnDays = returnSpan + 1;
+  const returnIndices = evenIndices(returnDays, Math.min(returnDays, roundTripGrid));
+  const returnDates = returnIndices.map((i) => addDaysUtc(returnStart, i));
+
+  // Cartesian product, dedupe, drop outbound > return.
+  const seen = new Set<string>();
+  const pairs: ScrapeDatePair[] = [];
+  for (const outbound of outboundDates) {
+    for (const ret of returnDates) {
+      if (outbound.getTime() > ret.getTime()) continue;
+      const key = `${toIsoDay(outbound)}|${toIsoDay(ret)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      pairs.push({ outbound, return_: ret });
+    }
+  }
+  if (pairs.length === 0) {
+    return [{ outbound: dateFrom, return_: dateTo }];
+  }
+  return pairs;
+}
+
+/**
+ * Expand a continuous [dateFrom, dateTo] ISO range into evenly-spaced ISO
+ * date strings, capped at `cap`. Used by the preview path which deals in
+ * string dates rather than Date objects.
+ */
+export function expandContinuousRangeToDates(
+  dateFrom: string,
+  dateTo: string,
+  cap = 7,
+): string[] {
+  const from = new Date(dateFrom + 'T00:00:00Z');
+  const to = new Date(dateTo + 'T00:00:00Z');
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+    return [dateFrom];
+  }
+  if (to.getTime() <= from.getTime()) {
+    return [dateFrom];
+  }
+  const span = dayDiff(from, to);
+  const totalDays = span + 1;
+  const indices = evenIndices(totalDays, Math.min(totalDays, cap));
+  return indices.map((i) => toIsoDay(addDaysUtc(from, i)));
+}
+
+/**
+ * For the preview path: the round-trip pair count must respect the
+ * combos x dates <= 24 cap in validatePreviewPayload. Return the largest
+ * grid side that fits. Always >= 1.
+ */
+export function previewRoundTripGridForCombos(combos: number): number {
+  if (combos <= 0) return 1;
+  return Math.max(1, Math.floor(Math.sqrt(24 / combos)));
+}


### PR DESCRIPTION
## Summary

Three followup bugs reported by @antoniods97 against the deployed PR #68 fix.

- **Airline URL builder ignored `tripType`** — every of the 24 builders injected `returnDate=dateTo` even for one-way trips (where `dateTo === dateFrom`). Carrier sites rendered an invalid-date error and Gemini extracted zero flights.
- **Flexible date ranges only scraped `dateFrom`** — for "around Nov 9 +/- 2 days" (`dateFrom=Nov 7, dateTo=Nov 11, flexibility=2`), the cron path passed a single `searchParams` to navigate; for one-way the URL only emits `on dateFrom`, so Nov 8-11 were silently skipped.
- **Silent extraction failures** — `runScrapeForQuery`'s catch wrote to `FetchRun.error` but never `console.error`, and Gemini's SDK had no default request timeout, so hung calls sat forever with no diagnostic in the cron logs.

A pre-merge codex audit surfaced 3 blockers in the initial implementation; commit 4 addresses them.

## Changes

| Phase | Files | What |
|-------|-------|------|
| 1 (`f3d8518`) | `airline-urls.ts`, `airline-urls.test.ts`, `navigate.ts` | Refactored airline URL builders from template strings to a declarative `AirlineSpec` map + `URLSearchParams`. One-way trips drop the return-date key. Three carriers (southwest/delta/american) flip explicit one-way tokens. Avianca uses a `customBuilder`. Reused `assertValidIataCode` and `isoDate` from `navigate.ts`. |
| 2 (`7643a89`) | `scrape-dates.ts` (new), `run-scrape.ts`, `preview/route.ts` | New `expandQueryDates` helper. One-way iterates every day in `[dateFrom, dateTo]` capped at 7 evenly-spaced pairs. `scrapeQueryForCountry` loops per pair into a single shared `FetchRun`. Sold-out detection scoped to dates actually scraped. |
| 3 (`ec534ef`) | `ai-registry.ts`, `extract-prices.ts`, `run-scrape.ts`, `preview/route.ts` | New `EXTRACT_TIMEOUT_MS=90000` env-overridable. Native `AbortSignal.timeout` per provider (Anthropic/OpenAI/Ollama/llamacpp/vllm). Gemini uses native `SingleRequestOptions { signal, timeout }`. Two new `ExtractionFailureReason`s (`llm_error`, `json_parse_error`) with `console.error` at every boundary. Outer catch in `runScrapeForQuery` now logs before the DB write. New reasons added to `RETRYABLE_FAILURES` and `failureMessages`. |
| 4 (`102989f`) | audit fixes | (1) Round-trip flex grid reverted to single pair: `PriceSnapshot` has no `returnTravelDate` and `flightId` keys by outbound only, so iterating RT pairs would collapse same-flight rows with different returns. (2) Sold-out scoping now gated on `prices.length > 0` so failed pairs do not flag siblings. (3) Per-pair `try/catch` so one pair throw does not discard prior successful pair results. (4) United URL reverted to original path-based form via `customBuilder`. (5) Preview cap error message clarified. |

Test coverage: 24-airline behavioral matrix asserting no `returnDate`-shaped param leaks for one-way; `scrape-dates.test.ts` covers single-day, full-range, capped-range, and round-trip single-pair behavior; `run-scrape.test.ts` covers multi-pair scraping (5 navigate calls for one-way flex=2), sold-out scoping (Nov 5 outside scraped set is left untouched, failed pair does not flag siblings), per-pair throw isolation, silent-catch logging at both pair and outer-catch boundaries, retry on `llm_error`/`json_parse_error`; `ai-registry.test.ts` covers `EXTRACT_TIMEOUT_MS` env parsing including malformed values.

## Out of scope (future work)

Round-trip flex pair iteration. The codex audit established that doing this cleanly requires a `returnTravelDate` column on `PriceSnapshot` and corresponding changes to `flightId` and dedupe keys. Today round-trip flex queries still rely on Google Flights' calendar grid surfacing nearby return dates within a single search. If real-world usage shows a need, the schema migration is straightforward.

## Verification

- [x] `npm run ci` clean (27 test files passed)
- [x] `./scripts/install-flow-test.sh` 14/14 passed
- [x] `./scripts/docker-smoke-test.sh` all checks passed (database, chromium, extraction, db_write_read)
- [x] Pre-merge audit by `codex exec` — 3 blockers + 4 improvements + 2 nits, all addressed in commit 4
- [ ] Manual smoke from VPS: BRI to JFK +/- 2 days, Turkish Airlines preferred. Confirm 5 navigate attempts spanning Nov 7-11, no `returnDate` in airline URL, forced Gemini failure surfaces in logs.

## Test plan

- [ ] Cron picks up a one-way query with `flexibility>0` and produces snapshots for every day in the window.
- [ ] Sold-out detection does not mass-flag prior snapshots whose `travelDate` is outside the current scrape's pair set, AND does not flag any when the pair scrape itself failed.
- [ ] When Gemini hangs or rate-limits, cron log shows `[extract] FAIL llm_error provider=google` and the FetchRun row carries a human-readable message.
- [ ] Turkish Airlines URL has no `returnDate` for one-way queries.
- [ ] One pair throwing (browser crash) does not discard prices from prior successful pairs in the same query.
