### PR TITLE
fix(cli): force-recreate web container in fairtrail update (#72)

### DIFF
--- a/apps/web/public/fairtrail-cli
+++ b/apps/web/public/fairtrail-cli
@@ -252,8 +252,17 @@ cmd_update() {
     done
   fi
 
+  # Ensure db/redis are running but do not touch them.
+  dc up -d --no-recreate db redis 2>&1 | while IFS= read -r line; do
+    printf "  ${DIM}%s${RESET}\n" "$line"
+  done
 
-  dc up -d 2>&1 | while IFS= read -r line; do
+  # Force-recreate the web container so the freshly-pulled (or rebuilt)
+  # image actually replaces the running one. Without --force-recreate,
+  # podman-compose does not always detect that :latest now points to a
+  # different digest and skips the recreate, leaving the user on the old
+  # image even though the pull succeeded (issue #72).
+  dc up -d --force-recreate --no-deps --remove-orphans web 2>&1 | while IFS= read -r line; do
     printf "  ${DIM}%s${RESET}\n" "$line"
   done
 

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -43,6 +43,26 @@ test_update_shows_curl_errors() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: fairtrail update force-recreates the web container after pull (#72)
+# ---------------------------------------------------------------------------
+# Without --force-recreate, podman-compose does not always detect a digest
+# change on :latest after `dc pull web` and skips the recreate, leaving the
+# user running the old image even though the pull succeeded.
+test_update_force_recreates_web() {
+  local cli="apps/web/public/fairtrail-cli"
+  local block
+  block=$(sed -n '/^cmd_update/,/^cmd_/p' "$cli")
+
+  # The cmd_update block must contain a `dc up -d` line that includes both
+  # --force-recreate and --no-deps targeting the `web` service.
+  if echo "$block" | grep -E 'dc up -d.*--force-recreate.*--no-deps.*web|dc up -d.*--no-deps.*--force-recreate.*web' >/dev/null; then
+    pass "fairtrail update force-recreates web after pull (#72)"
+  else
+    fail "fairtrail update should run 'dc up -d --force-recreate --no-deps web' after pull/build (#72)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Test: install.sh patches both .bashrc and .profile
 # ---------------------------------------------------------------------------
 test_path_patches_both_files() {
@@ -238,6 +258,7 @@ echo ""
 
 test_update_self_path
 test_update_shows_curl_errors
+test_update_force_recreates_web
 test_path_patches_both_files
 test_old_dir_migration
 test_env_host_port


### PR DESCRIPTION
## Summary

@backslashV in #72 reported that `fairtrail update` runs successfully (image pulled, containers restarted) but `fairtrail version` still reports the old version. Verified locally: `cmd_update` calls `dc up -d` after `dc pull web`, but on podman-compose `up -d` does not always detect that `:latest` now points to a different digest. The user keeps running the old image even though the pull succeeded.

## Fix

In `cmd_update`:

1. Ensure db/redis are up but do not touch them: `dc up -d --no-recreate db redis`.
2. Force-recreate the web container with the freshly-pulled (or rebuilt) image: `dc up -d --force-recreate --no-deps --remove-orphans web`.

Same pattern the production deploy script already uses, which is why direct deploys work but the CLI's own update path did not.

## Regression test

`scripts/install-flow-test.sh` gains `test_update_force_recreates_web` which asserts that the `cmd_update` block contains a `dc up -d` line carrying both `--force-recreate` and `--no-deps` targeting `web`. 15/15 install-flow tests pass.

## Test plan
- [ ] `./scripts/install-flow-test.sh` 15 passed.
- [ ] `npm run ci` clean (27 test files).
- [ ] After merge + release, ask @backslashV to retry `fairtrail update` then `fairtrail version` and confirm the version actually advances.
