### PR TITLE
fix(cli): runtime-aware exec flags + behavioral test harness (#72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         working-directory: apps/web
       - run: npm run build
       - run: bash scripts/install-flow-test.sh
+      - run: bash scripts/cli-runtime-test.sh
 
   install-smoke:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,14 +130,20 @@ Departure board / atmospheric aviation aesthetic — deep navy, amber glow, prec
 
 ## Pre-Release Gate (MANDATORY before `/create-release`)
 
-Both tests must pass before tagging a release:
+All three tests must pass before tagging a release:
 
 ```bash
 ./scripts/docker-smoke-test.sh    # Docker infra: build, health, chromium, extraction, DB
-./scripts/install-flow-test.sh    # User flow: install.sh, CLI commands, search
+./scripts/install-flow-test.sh    # Static + grep regression checks on install.sh / fairtrail-cli
+./scripts/cli-runtime-test.sh     # Behavioral CLI runtime matrix (docker v1/v2, podman compose, podman-compose)
 ```
 
-If either fails, fix the issue and re-run. Do NOT tag without both passing.
+If any fails, fix the issue and re-run. Do NOT tag without all three passing.
+
+The runtime-matrix harness (`cli-runtime-test.sh`) is what catches the
+"works on docker, broken on podman" class of bug (issues #62, #72). It
+shims `docker`/`podman`/`*compose`/`curl` and asserts the recorded
+invocations — every CLI command across every compose flavor.
 
 ## DON'T
 

--- a/apps/web/public/fairtrail-cli
+++ b/apps/web/public/fairtrail-cli
@@ -25,6 +25,19 @@ FAIRTRAIL_DIR="$HOME/.fairtrail"
 PORT="${HOST_PORT:-${PORT:-3003}}"
 BASE_URL="${FAIRTRAIL_URL:-https://fairtrail.org}"
 
+# Compose-flavor flag helpers (issue #72). Lives next to this script so
+# `command -v fairtrail` and dev-mode (bin/fairtrail → apps/web/public/) both
+# resolve it via dirname "$0". Required, not optional — a missing helper on
+# podman would silently break `fairtrail --headless` again.
+_FLAGS_LIB="$(dirname "$0")/fairtrail-cli-flags.sh"
+if [ ! -f "$_FLAGS_LIB" ]; then
+  printf "\033[0;31m\033[1m✗\033[0m Missing %s — re-run installer:\n  curl -fsSL %s/install.sh | bash\n" \
+    "$_FLAGS_LIB" "${FAIRTRAIL_URL:-https://fairtrail.org}" >&2
+  exit 1
+fi
+# shellcheck source=fairtrail-cli-flags.sh
+. "$_FLAGS_LIB"
+
 if [ ! -f "$FAIRTRAIL_DIR/docker-compose.yml" ]; then
   printf "${RED}${BOLD}✗${RESET} Fairtrail not found. Run the installer first:\n"
   printf "  curl -fsSL https://fairtrail.org/install.sh | bash\n"
@@ -234,6 +247,18 @@ cmd_update() {
   else
     rm -f "${CLI_PATH}.tmp"
     printf "${YELLOW}${BOLD}!${RESET} CLI update skipped (couldn't reach %s)\n" "$BASE_URL"
+  fi
+
+  # Refresh the compose-flavor flag helper alongside the CLI (issue #72).
+  # If the CLI updated but the helper didn't, podman-compose users would
+  # fall through to undefined `_compose_exec_flags`. Treat as best-effort:
+  # the source guard at the top of the CLI errors out clearly if missing.
+  FLAGS_PATH="${CLI_DIR}/fairtrail-cli-flags.sh"
+  if curl -fsSL "$BASE_URL/fairtrail-cli-flags.sh" -o "${FLAGS_PATH}.tmp"; then
+    mv -f "${FLAGS_PATH}.tmp" "$FLAGS_PATH"
+  else
+    rm -f "${FLAGS_PATH}.tmp"
+    printf "${YELLOW}${BOLD}!${RESET} Flag helper update skipped (couldn't reach %s)\n" "$BASE_URL"
   fi
 
   # Try pulling pre-built image; fall back to local build if unavailable
@@ -480,14 +505,16 @@ cmd_tui() {
     exit 1
   fi
 
-  local exec_flags
-  if [ -t 0 ] && [ -t 1 ]; then
-    exec_flags="-it"
-  else
-    exec_flags="-i"
-  fi
+  # Compose flavors disagree on exec flags (issue #72). _compose_exec_flags
+  # picks -it/-i for docker-style, empty/-T for podman-compose standalone.
+  local stdin_tty stdout_tty exec_flags
+  [ -t 0 ] && stdin_tty=1 || stdin_tty=0
+  [ -t 1 ] && stdout_tty=1 || stdout_tty=0
+  exec_flags=$(_compose_exec_flags "$_DC" "$stdin_tty" "$stdout_tty")
 
   # `exec` cannot run shell functions, so call $_DC directly instead of dc().
+  # $exec_flags is intentionally unquoted: empty string must word-split to
+  # nothing, otherwise podman-compose receives an empty arg and rejects it.
   exec $_DC $COMPOSE_FILES exec $exec_flags web fairtrail-tui "$@"
 }
 

--- a/apps/web/public/fairtrail-cli
+++ b/apps/web/public/fairtrail-cli
@@ -59,8 +59,12 @@ fi
 # Resolve override files
 COMPOSE_FILES="-f docker-compose.yml"
 [ -f "docker-compose.override.yml" ] && COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.override.yml"
-# Auto-include VPN sidecar if activation code is configured
-if [ -f "docker-compose.vpn.yml" ] && grep -q "EXPRESSVPN_CODE" .env 2>/dev/null; then
+# Auto-include VPN sidecar only if EXPRESSVPN_CODE is set to a non-empty
+# value at the start of a line (commented-out or unset entries don't count).
+# Previous form `grep -q "EXPRESSVPN_CODE"` matched `# EXPRESSVPN_CODE=` too,
+# silently enabling the VPN sidecar from a disabled-by-comment placeholder.
+if [ -f "docker-compose.vpn.yml" ] \
+  && grep -Eq '^[[:space:]]*EXPRESSVPN_CODE=.+' .env 2>/dev/null; then
   COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.vpn.yml"
 fi
 

--- a/apps/web/public/fairtrail-cli-flags.sh
+++ b/apps/web/public/fairtrail-cli-flags.sh
@@ -1,0 +1,57 @@
+# shellcheck shell=bash
+# Compose-flavor flag helpers, sourced by fairtrail-cli and the test suite.
+#
+# Why this file is separate: the four compose flavors fairtrail-cli detects
+# (`docker compose`, `docker-compose`, `podman compose`, `podman-compose`)
+# do NOT share a flag surface for `exec`. Specifically, `podman-compose`
+# (the standalone Python tool from containers/podman-compose) accepts only
+# `-T` to disable TTY allocation — `-i`, `-t`, and `-it` raise
+# "unrecognized arguments" and abort the command (issue #72 follow-up,
+# verified against podman_compose.py:4636-4683).
+#
+# The other three flavors (docker compose v2, docker-compose v1,
+# podman compose native v5+) implement Docker's flag surface, so `-it`/`-i`
+# work as expected.
+#
+# Branch on `$_DC` (the resolved compose invocation string), not on
+# `$CONTAINER_CMD` — `podman compose` and `podman-compose` share
+# CONTAINER_CMD=podman but require different flags.
+
+# _compose_exec_flags <dc> <stdin_tty> <stdout_tty>
+#
+# <dc>          Exact `$_DC` string: "docker compose" | "docker-compose"
+#               | "podman compose" | "podman-compose".
+# <stdin_tty>   "1" if caller's stdin is a TTY, "0" otherwise.
+# <stdout_tty>  "1" if caller's stdout is a TTY, "0" otherwise.
+#
+# Prints the flag(s) that should appear between `exec` and the service name
+# in `$_DC $COMPOSE_FILES exec <flags> <service> <command>`. May print an
+# empty string — the caller MUST leave `$exec_flags` unquoted at the call
+# site so word-splitting collapses it to nothing.
+_compose_exec_flags() {
+  local dc="$1" stdin_tty="${2:-0}" stdout_tty="${3:-0}" interactive=0
+  if [ "$stdin_tty" = "1" ] && [ "$stdout_tty" = "1" ]; then
+    interactive=1
+  fi
+  case "$dc" in
+    "podman-compose")
+      # Standalone podman-compose: --interactive is implicit (always passed
+      # to `podman exec`); a TTY is allocated by default. -T disables the
+      # TTY when stdin/stdout are not terminals. -i / -it are rejected.
+      if [ "$interactive" = "1" ]; then
+        printf ''
+      else
+        printf '%s' '-T'
+      fi
+      ;;
+    *)
+      # Docker-compatible flag surface (docker compose v2, docker-compose v1,
+      # podman compose native v5+).
+      if [ "$interactive" = "1" ]; then
+        printf '%s' '-it'
+      else
+        printf '%s' '-i'
+      fi
+      ;;
+  esac
+}

--- a/apps/web/public/fairtrail-cli-flags.sh
+++ b/apps/web/public/fairtrail-cli-flags.sh
@@ -44,14 +44,23 @@ _compose_exec_flags() {
         printf '%s' '-T'
       fi
       ;;
-    *)
-      # Docker-compatible flag surface (docker compose v2, docker-compose v1,
-      # podman compose native v5+).
+    "docker compose"|"docker-compose"|"podman compose")
+      # Docker-compatible flag surface: docker compose v2 native,
+      # docker-compose v1 standalone, podman compose v5+ native subcommand.
       if [ "$interactive" = "1" ]; then
         printf '%s' '-it'
       else
         printf '%s' '-i'
       fi
+      ;;
+    *)
+      # Hard-fail on unknown compose flavors (nerdctl, finch, lima
+      # nerdctl wrappers, etc.). Falling through to docker-compatible
+      # would silently assume the new tool accepts -i/-it — exactly the
+      # mistake that produced issue #72. Anyone wiring up a new flavor
+      # MUST add an explicit case here and a test in cli-runtime-test.sh.
+      printf '_compose_exec_flags: unsupported compose flavor "%s" — add explicit support in fairtrail-cli-flags.sh\n' "$dc" >&2
+      return 2
       ;;
   esac
 }

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -366,6 +366,13 @@ mkdir -p "$INSTALL_BIN"
 if [ -n "${FAIRTRAIL_CLI_SOURCE:-}" ] && [ -f "$FAIRTRAIL_CLI_SOURCE" ]; then
   cp "$FAIRTRAIL_CLI_SOURCE" "$INSTALL_BIN/fairtrail"
   chmod +x "$INSTALL_BIN/fairtrail"
+  # Helper sits next to the CLI source; copy it too (issue #72).
+  _flags_src="$(dirname "$FAIRTRAIL_CLI_SOURCE")/fairtrail-cli-flags.sh"
+  if [ -f "$_flags_src" ]; then
+    cp "$_flags_src" "$INSTALL_BIN/fairtrail-cli-flags.sh"
+  else
+    fail "Missing $_flags_src — required helper for compose-flavor flag handling"
+  fi
   ok "Installed fairtrail CLI from local source"
 else
   info "Downloading CLI..."
@@ -376,6 +383,13 @@ else
   else
     rm -f "$INSTALL_BIN/fairtrail.tmp"
     fail "Failed to download CLI from $BASE_URL/fairtrail-cli"
+  fi
+  # Compose-flavor flag helper (issue #72). Hard requirement on podman.
+  if curl -fsSL "$BASE_URL/fairtrail-cli-flags.sh" -o "$INSTALL_BIN/fairtrail-cli-flags.sh.tmp" 2>/dev/null; then
+    mv -f "$INSTALL_BIN/fairtrail-cli-flags.sh.tmp" "$INSTALL_BIN/fairtrail-cli-flags.sh"
+  else
+    rm -f "$INSTALL_BIN/fairtrail-cli-flags.sh.tmp"
+    fail "Failed to download flag helper from $BASE_URL/fairtrail-cli-flags.sh"
   fi
 fi
 

--- a/scripts/Dockerfile.install-test
+++ b/scripts/Dockerfile.install-test
@@ -19,6 +19,7 @@ WORKDIR /home/testuser
 # Copy only the scripts we're testing
 COPY --chown=testuser:testuser apps/web/public/install.sh /home/testuser/install.sh
 COPY --chown=testuser:testuser apps/web/public/fairtrail-cli /home/testuser/fairtrail-cli
+COPY --chown=testuser:testuser apps/web/public/fairtrail-cli-flags.sh /home/testuser/fairtrail-cli-flags.sh
 COPY --chown=testuser:testuser scripts/debian-install-smoke.sh /home/testuser/run-tests.sh
 
 RUN chmod +x /home/testuser/install.sh /home/testuser/fairtrail-cli /home/testuser/run-tests.sh

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -261,18 +261,52 @@ setup_runtime() {
   write_python3_passthrough
 }
 
-# Run the CLI under the sandbox. Replaces stdin with /dev/null so [ -t 0 ]
-# is false (covers the non-TTY branch — the TTY branch is unit-tested).
+# Run the CLI under the sandbox. stdin is a single newline (not /dev/null)
+# so that interactive `read -rp` prompts (cmd_stop, cmd_uninstall) get an
+# empty answer and take the cancel path, not crash from EOF under set -e.
+# To answer "y", use run_cli_with_input "y\n" <cmd>.
+# Captures exit code into LAST_EXIT for assertions; default expectation is
+# 0 unless the test sets EXPECT_NONZERO=1 before calling.
+LAST_EXIT=0
 run_cli() {
   LAST_CMD="$1"
   shift
   : > "$RECORD_FILE"
-  HOME="$SANDBOX" \
-  PATH="$SANDBOX/bin:/usr/bin:/bin" \
-  RECORD_FILE="$RECORD_FILE" \
-  FAIRTRAIL_URL="http://test.invalid" \
-  HOST_PORT=3003 \
-  bash "$CLI" "$LAST_CMD" "$@" </dev/null >/dev/null 2>&1 || true
+  set +e
+  printf '\n' \
+    | HOME="$SANDBOX" \
+      PATH="$SANDBOX/bin:/usr/bin:/bin" \
+      RECORD_FILE="$RECORD_FILE" \
+      FAIRTRAIL_URL="http://test.invalid" \
+      HOST_PORT=3003 \
+      bash "$CLI" "$LAST_CMD" "$@" >/dev/null 2>&1
+  LAST_EXIT=$?
+  set -e
+  if [ "${EXPECT_NONZERO:-0}" != "1" ] && [ $LAST_EXIT -ne 0 ]; then
+    fail "CLI exited $LAST_EXIT — assertions on its recorded calls are unreliable"
+  fi
+}
+
+# Same as run_cli, but pipes a string into stdin so confirm prompts get
+# answered. Use for stop/uninstall confirm=Y tests.
+run_cli_with_input() {
+  local input="$1"
+  LAST_CMD="$2"
+  shift 2
+  : > "$RECORD_FILE"
+  set +e
+  printf '%s' "$input" \
+    | HOME="$SANDBOX" \
+      PATH="$SANDBOX/bin:/usr/bin:/bin" \
+      RECORD_FILE="$RECORD_FILE" \
+      FAIRTRAIL_URL="http://test.invalid" \
+      HOST_PORT=3003 \
+      bash "$CLI" "$LAST_CMD" "$@" >/dev/null 2>&1
+  LAST_EXIT=$?
+  set -e
+  if [ "${EXPECT_NONZERO:-0}" != "1" ] && [ $LAST_EXIT -ne 0 ]; then
+    fail "CLI exited $LAST_EXIT — assertions on its recorded calls are unreliable"
+  fi
 }
 
 # Match a regex against the recorded invocations (one per line).
@@ -437,6 +471,30 @@ test_missing_helper_fails_loudly() {
   fi
 }
 
+# Negative-control: a CLI that crashes during dispatch must NOT silently
+# pass tests like "status never invokes compose". Rewrite the CLI's
+# `status` dispatcher to exit 7, run via run_cli with EXPECT_NONZERO=1 to
+# bypass fail(), and assert LAST_EXIT was captured.
+test_run_cli_captures_exit() {
+  setup_runtime docker_v2
+  LAST_RUNTIME="harness"; LAST_CMD="self-check"
+  local crashy_cli="$SANDBOX/bin/fairtrail-crashy"
+  sed 's#status)    cmd_status ;;#status)    exit 7 ;;#' "$CLI" > "$crashy_cli"
+  chmod +x "$crashy_cli"
+  # The helper must sit next to the CLI for the source guard to pass.
+  cp "$HELPER" "$SANDBOX/bin/fairtrail-cli-flags.sh"
+  local prev_cli="$CLI"
+  CLI="$crashy_cli"
+  EXPECT_NONZERO=1 run_cli status
+  CLI="$prev_cli"
+  unset EXPECT_NONZERO
+  if [ "$LAST_EXIT" = "7" ]; then
+    pass "run_cli captures CLI exit code (LAST_EXIT=7)"
+  else
+    fail "run_cli should capture exit code 7, got $LAST_EXIT"
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
@@ -459,6 +517,7 @@ test_uninstall_aborts_without_confirmation
 test_status_only_calls_curl
 test_version_only_calls_curl
 test_missing_helper_fails_loudly
+test_run_cli_captures_exit
 
 echo ""
 printf "${BOLD}Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}\n" "$PASS" "$FAIL"

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -247,7 +247,7 @@ SHIM
 
 setup_sandbox() {
   SANDBOX=$(mktemp -d -t fairtrail-cli-test-XXXXXX)
-  mkdir -p "$SANDBOX/bin" "$SANDBOX/.fairtrail"
+  mkdir -p "$SANDBOX/bin" "$SANDBOX/sysbin" "$SANDBOX/.fairtrail"
   cat > "$SANDBOX/.fairtrail/docker-compose.yml" <<'YAML'
 services:
   web:
@@ -256,6 +256,23 @@ YAML
   RECORD_FILE="$SANDBOX/record.log"
   : > "$RECORD_FILE"
   export RECORD_FILE
+
+  # Curated sysbin: symlinks only to the system tools the CLI actually uses.
+  # Hermetic so `command -v docker` cannot find /usr/bin/docker on Ubuntu CI
+  # (where it would otherwise short-circuit every podman_* test).
+  local tool real
+  for tool in bash sh env mktemp \
+              printf echo cat sed grep head tail cut tr sort uniq awk \
+              mkdir rmdir rm cp mv ln chmod basename dirname \
+              date sleep uname id whoami tput tee pwd ls find \
+              xargs which true false stat touch \
+              python3 git ; do
+    real=""
+    for d in /usr/bin /bin /usr/local/bin; do
+      if [ -x "$d/$tool" ]; then real="$d/$tool"; break; fi
+    done
+    [ -n "$real" ] && ln -sf "$real" "$SANDBOX/sysbin/$tool"
+  done
 }
 
 teardown_sandbox() {
@@ -300,7 +317,7 @@ run_cli() {
   set +e
   printf '\n' \
     | HOME="$SANDBOX" \
-      PATH="$SANDBOX/bin:/usr/bin:/bin" \
+      PATH="$SANDBOX/bin:$SANDBOX/sysbin" \
       RECORD_FILE="$RECORD_FILE" \
       FAIRTRAIL_URL="http://test.invalid" \
       HOST_PORT=3003 \
@@ -322,7 +339,7 @@ run_cli_with_input() {
   set +e
   printf '%s' "$input" \
     | HOME="$SANDBOX" \
-      PATH="$SANDBOX/bin:/usr/bin:/bin" \
+      PATH="$SANDBOX/bin:$SANDBOX/sysbin" \
       RECORD_FILE="$RECORD_FILE" \
       FAIRTRAIL_URL="http://test.invalid" \
       HOST_PORT=3003 \
@@ -686,7 +703,7 @@ test_missing_helper_fails_loudly() {
   # No helper sibling — should fail with non-zero and print to stderr.
   local exit_code stderr_out
   set +e
-  stderr_out=$(HOME="$SANDBOX" PATH="$SANDBOX/bin:/usr/bin:/bin" \
+  stderr_out=$(HOME="$SANDBOX" PATH="$SANDBOX/bin:$SANDBOX/sysbin" \
     bash "$cli_copy" --headless </dev/null 2>&1 >/dev/null)
   exit_code=$?
   set -e

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+# Behavioral test harness for apps/web/public/fairtrail-cli.
+#
+# Why this exists: every previous CLI bug in this repo (issue #72 v1 — silent
+# `up -d` on podman; #72 v2 — -it rejected by podman-compose; #62 — Arch
+# detection; #62 — docker permission-denied vs daemon-down) shared a shape:
+# shell CLI behavior that diverges by container runtime or compose flavor.
+# The pre-existing install-flow-test.sh is grep-only and would pass on every
+# one of those bugs. This file runs the actual CLI against shimmed compose
+# binaries and asserts the recorded invocations.
+#
+# Coverage per command, per runtime:
+#   docker_v2       docker + `docker compose` (v2 native)
+#   docker_v1       docker + `docker-compose` (v1 standalone)
+#   podman_native   podman + `podman compose` (v5+ native subcommand)
+#   podman_pc       podman + `podman-compose` (standalone Python tool)
+#
+# Non-TTY only (stdin redirected from /dev/null). The TTY branch of
+# `cmd_tui` is covered by the helper unit test in install-flow-test.sh.
+
+set -euo pipefail
+
+BOLD='\033[1m'
+DIM='\033[2m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+RESET='\033[0m'
+
+PASS=0
+FAIL=0
+LAST_RUNTIME=""
+LAST_CMD=""
+
+pass() { PASS=$((PASS + 1)); printf "${GREEN}PASS${RESET} [%s] %s\n" "${LAST_RUNTIME}/${LAST_CMD}" "$1"; }
+fail() {
+  FAIL=$((FAIL + 1))
+  printf "${RED}FAIL${RESET} [%s] %s\n" "${LAST_RUNTIME}/${LAST_CMD}" "$1"
+  if [ -n "${RECORD_FILE:-}" ] && [ -f "$RECORD_FILE" ]; then
+    printf "${DIM}     recorded:${RESET}\n"
+    sed 's/^/       /' "$RECORD_FILE"
+  fi
+}
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+CLI="$REPO_ROOT/apps/web/public/fairtrail-cli"
+HELPER="$REPO_ROOT/apps/web/public/fairtrail-cli-flags.sh"
+
+[ -x "$CLI" ] || { printf "${RED}missing $CLI${RESET}\n"; exit 1; }
+[ -f "$HELPER" ] || { printf "${RED}missing $HELPER${RESET}\n"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Shim writers. Each test invokes setup_runtime <name> which populates
+# $SANDBOX/bin with exactly the binaries that runtime should expose.
+# Probes (info, compose version) return the right exit codes; everything
+# else appends "<binary> <args>" to $RECORD_FILE.
+# ---------------------------------------------------------------------------
+
+write_docker_shim() {
+  # $1: 0 if `docker compose` v2 available, 1 if not (forces docker-compose v1)
+  local has_v2="$1"
+  cat > "$SANDBOX/bin/docker" <<SHIM
+#!/usr/bin/env bash
+case "\$1" in
+  info) exit 0 ;;
+  compose)
+    case "\${2:-}" in
+      version) exit $has_v2 ;;
+      *)
+        if [ $has_v2 -eq 0 ]; then
+          printf 'docker %s\n' "\$*" >> "\$RECORD_FILE"
+          exit 0
+        fi
+        # If v2 isn't available we shouldn't be reaching here
+        printf 'docker %s\n' "\$*" >> "\$RECORD_FILE"
+        exit 1 ;;
+    esac ;;
+  *)
+    printf 'docker %s\n' "\$*" >> "\$RECORD_FILE"
+    exit 0 ;;
+esac
+SHIM
+  chmod +x "$SANDBOX/bin/docker"
+}
+
+write_docker_compose_v1_shim() {
+  cat > "$SANDBOX/bin/docker-compose" <<'SHIM'
+#!/usr/bin/env bash
+printf 'docker-compose %s\n' "$*" >> "$RECORD_FILE"
+exit 0
+SHIM
+  chmod +x "$SANDBOX/bin/docker-compose"
+}
+
+write_podman_shim() {
+  # $1: 0 if `podman compose` native subcommand available, 1 if not
+  local has_native="$1"
+  cat > "$SANDBOX/bin/podman" <<SHIM
+#!/usr/bin/env bash
+case "\$1" in
+  compose)
+    case "\${2:-}" in
+      version) exit $has_native ;;
+      *)
+        if [ $has_native -eq 0 ]; then
+          printf 'podman %s\n' "\$*" >> "\$RECORD_FILE"
+          exit 0
+        fi
+        exit 1 ;;
+    esac ;;
+  *)
+    printf 'podman %s\n' "\$*" >> "\$RECORD_FILE"
+    exit 0 ;;
+esac
+SHIM
+  chmod +x "$SANDBOX/bin/podman"
+}
+
+write_podman_compose_shim() {
+  cat > "$SANDBOX/bin/podman-compose" <<'SHIM'
+#!/usr/bin/env bash
+printf 'podman-compose %s\n' "$*" >> "$RECORD_FILE"
+exit 0
+SHIM
+  chmod +x "$SANDBOX/bin/podman-compose"
+}
+
+write_curl_shim() {
+  # Responds to /api/health, /api/version, /api/parse, /api/preview,
+  # /api/queries, and BASE_URL self-update fetches. Anything else exits 0
+  # silently — the CLI generally tolerates a no-op curl.
+  cat > "$SANDBOX/bin/curl" <<'SHIM'
+#!/usr/bin/env bash
+url=""
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -*) shift ;;
+    http*|*://*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "$url" in
+  *"/api/health"*)
+    printf '{"activeQueries":1,"intervalHours":3,"nextScrape":"2026-05-10T12:00:00"}' ;;
+  *"/api/version"*)
+    printf '{"ok":true,"data":{"current":"0.5.4","commit":"3153f98abcdef"}}' ;;
+  *"/api/parse"*)
+    printf '{"ok":true,"data":{"confidence":"high","parsed":{"origin":"NYC","destination":"LAX","originName":"New York","destinationName":"Los Angeles","dateFrom":"2026-06-01","dateTo":"2026-06-15","origins":[{"code":"NYC"}],"destinations":[{"code":"LAX"}]}}}' ;;
+  *"/api/preview"*)
+    printf '{"data":{"flights":[],"routes":[]}}' ;;
+  *"/api/queries"*)
+    printf '{"ok":true,"data":{"queries":[{"id":"abc123"}]}}' ;;
+  *"/fairtrail-cli-flags.sh"*)
+    [ -n "$out" ] && printf '# stub helper\n_compose_exec_flags(){ printf %%s ""; }\n' > "$out" ;;
+  *"/fairtrail-cli"*)
+    [ -n "$out" ] && {
+      printf '#!/usr/bin/env bash\necho stub-cli\n' > "$out"
+      chmod +x "$out" 2>/dev/null || true
+    } ;;
+esac
+exit 0
+SHIM
+  chmod +x "$SANDBOX/bin/curl"
+}
+
+write_python3_passthrough() {
+  # Some cmd_search code paths call python3. Real python3 is fine if it's on
+  # PATH outside the sandbox — symlink it through.
+  if real_py=$(/usr/bin/env -i PATH=/usr/bin:/bin command -v python3 2>/dev/null); then
+    ln -sf "$real_py" "$SANDBOX/bin/python3"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Sandbox / runtime setup
+# ---------------------------------------------------------------------------
+
+setup_sandbox() {
+  SANDBOX=$(mktemp -d -t fairtrail-cli-test-XXXXXX)
+  mkdir -p "$SANDBOX/bin" "$SANDBOX/.fairtrail"
+  cat > "$SANDBOX/.fairtrail/docker-compose.yml" <<'YAML'
+services:
+  web:
+    image: ghcr.io/affromero/fairtrail:latest
+YAML
+  RECORD_FILE="$SANDBOX/record.log"
+  : > "$RECORD_FILE"
+  export RECORD_FILE
+}
+
+teardown_sandbox() {
+  [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"
+  SANDBOX=""
+  RECORD_FILE=""
+}
+
+setup_runtime() {
+  LAST_RUNTIME="$1"
+  rm -f "$SANDBOX"/bin/docker "$SANDBOX"/bin/docker-compose \
+        "$SANDBOX"/bin/podman "$SANDBOX"/bin/podman-compose
+  case "$1" in
+    docker_v2)
+      write_docker_shim 0 ;;
+    docker_v1)
+      write_docker_shim 1
+      write_docker_compose_v1_shim ;;
+    podman_native)
+      write_podman_shim 0 ;;
+    podman_pc)
+      write_podman_shim 1
+      write_podman_compose_shim ;;
+    *) printf "${RED}unknown runtime: $1${RESET}\n"; exit 1 ;;
+  esac
+  write_curl_shim
+  write_python3_passthrough
+}
+
+# Run the CLI under the sandbox. Replaces stdin with /dev/null so [ -t 0 ]
+# is false (covers the non-TTY branch — the TTY branch is unit-tested).
+run_cli() {
+  LAST_CMD="$1"
+  shift
+  : > "$RECORD_FILE"
+  HOME="$SANDBOX" \
+  PATH="$SANDBOX/bin:/usr/bin:/bin" \
+  RECORD_FILE="$RECORD_FILE" \
+  FAIRTRAIL_URL="http://test.invalid" \
+  HOST_PORT=3003 \
+  bash "$CLI" "$LAST_CMD" "$@" </dev/null >/dev/null 2>&1 || true
+}
+
+# Match a regex against the recorded invocations (one per line).
+assert_recorded() {
+  local label="$1" pattern="$2"
+  if grep -qE "$pattern" "$RECORD_FILE"; then
+    pass "$label"
+  else
+    fail "$label — no line matched: $pattern"
+  fi
+}
+
+# Inverse: assert no recorded line matches.
+assert_not_recorded() {
+  local label="$1" pattern="$2"
+  if ! grep -qE "$pattern" "$RECORD_FILE"; then
+    pass "$label"
+  else
+    fail "$label — unexpected line matched: $pattern"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test cases — cmd_tui (the bug we shipped a fix for)
+# ---------------------------------------------------------------------------
+
+test_tui_headless_docker_v2() {
+  setup_runtime docker_v2
+  run_cli --headless
+  assert_recorded "tui sends docker compose exec -i web fairtrail-tui --headless" \
+    'docker compose -f docker-compose.yml exec -i web fairtrail-tui --headless'
+}
+
+test_tui_headless_docker_v1() {
+  setup_runtime docker_v1
+  run_cli --headless
+  assert_recorded "tui sends docker-compose exec -i web fairtrail-tui --headless" \
+    'docker-compose -f docker-compose.yml exec -i web fairtrail-tui --headless'
+}
+
+test_tui_headless_podman_native() {
+  setup_runtime podman_native
+  run_cli --headless
+  assert_recorded "tui sends podman compose exec -i web fairtrail-tui --headless" \
+    'podman compose -f docker-compose.yml exec -i web fairtrail-tui --headless'
+}
+
+test_tui_headless_podman_pc() {
+  # The bug from issue #72 — must NOT pass -i or -it; podman-compose only
+  # accepts -T to disable TTY.
+  setup_runtime podman_pc
+  run_cli --headless
+  assert_recorded "tui sends podman-compose exec -T web fairtrail-tui --headless (#72)" \
+    'podman-compose -f docker-compose.yml exec -T web fairtrail-tui --headless'
+  assert_not_recorded "tui never sends -it/-i to podman-compose (#72)" \
+    'podman-compose .* exec [^ ]*(-it|-i ) '
+}
+
+test_tui_list_podman_pc() {
+  setup_runtime podman_pc
+  run_cli --list
+  assert_recorded "tui --list sends podman-compose exec -T web fairtrail-tui --list" \
+    'podman-compose -f docker-compose.yml exec -T web fairtrail-tui --list'
+}
+
+# ---------------------------------------------------------------------------
+# Test cases — cmd_update (issue #72 v1)
+# ---------------------------------------------------------------------------
+
+test_update_pulls_then_force_recreates_web() {
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli update
+    LAST_RUNTIME="$rt"; LAST_CMD="update"
+    assert_recorded "update pulls web" \
+      ' pull web'
+    assert_recorded "update brings up db/redis with --no-recreate" \
+      ' up -d --no-recreate db redis'
+    assert_recorded "update force-recreates web (#72 v1)" \
+      ' up -d --force-recreate --no-deps --remove-orphans web'
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Test cases — cmd_start_background, cmd_stop, cmd_logs, cmd_status
+# ---------------------------------------------------------------------------
+
+test_start_calls_up_dash_d() {
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli start
+    LAST_RUNTIME="$rt"; LAST_CMD="start"
+    assert_recorded "start runs dc up -d" ' up -d( |$)'
+  done
+}
+
+test_stop_aborts_without_confirmation() {
+  # cmd_stop reads y/N from stdin. With stdin closed we get the cancel path,
+  # so dc stop is NOT called — verify that, since silently calling stop on a
+  # cancelled prompt would be a regression in itself.
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli stop
+    LAST_RUNTIME="$rt"; LAST_CMD="stop"
+    assert_not_recorded "stop respects N answer (no dc stop on cancel)" \
+      ' stop( |$)'
+  done
+}
+
+test_uninstall_aborts_without_confirmation() {
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli uninstall
+    LAST_RUNTIME="$rt"; LAST_CMD="uninstall"
+    assert_not_recorded "uninstall respects N answer (no dc down on cancel)" \
+      ' down -v( |$)'
+    [ -d "$SANDBOX/.fairtrail" ] && pass "uninstall did not remove ~/.fairtrail on cancel" \
+      || fail "uninstall removed ~/.fairtrail despite cancel"
+  done
+}
+
+test_status_only_calls_curl() {
+  # status should not invoke compose at all — pure /api/health probe.
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli status
+    LAST_RUNTIME="$rt"; LAST_CMD="status"
+    assert_not_recorded "status never invokes compose" '\b(up|down|stop|exec|pull) '
+  done
+}
+
+test_version_only_calls_curl() {
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli version
+    LAST_RUNTIME="$rt"; LAST_CMD="version"
+    assert_not_recorded "version never invokes compose" '\b(up|down|stop|exec|pull) '
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Helper missing → CLI must exit non-zero (loud failure)
+# ---------------------------------------------------------------------------
+
+test_missing_helper_fails_loudly() {
+  setup_runtime docker_v2
+  LAST_RUNTIME="missing-helper"; LAST_CMD="--headless"
+  # Run a copy of the CLI without the helper next to it.
+  local cli_copy="$SANDBOX/bin/fairtrail-orphan"
+  cp "$CLI" "$cli_copy"
+  # No helper sibling — should fail with non-zero and print to stderr.
+  local exit_code stderr_out
+  set +e
+  stderr_out=$(HOME="$SANDBOX" PATH="$SANDBOX/bin:/usr/bin:/bin" \
+    bash "$cli_copy" --headless </dev/null 2>&1 >/dev/null)
+  exit_code=$?
+  set -e
+  if [ "$exit_code" -ne 0 ] && echo "$stderr_out" | grep -q "fairtrail-cli-flags.sh"; then
+    pass "CLI exits non-zero with helpful message when helper is missing"
+  else
+    fail "CLI must exit non-zero and mention fairtrail-cli-flags.sh — got exit=$exit_code, stderr=$stderr_out"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+echo ""
+printf "${BOLD}Fairtrail CLI behavioral tests (runtime matrix)${RESET}\n"
+echo ""
+
+trap 'teardown_sandbox' EXIT
+setup_sandbox
+
+test_tui_headless_docker_v2
+test_tui_headless_docker_v1
+test_tui_headless_podman_native
+test_tui_headless_podman_pc
+test_tui_list_podman_pc
+test_update_pulls_then_force_recreates_web
+test_start_calls_up_dash_d
+test_stop_aborts_without_confirmation
+test_uninstall_aborts_without_confirmation
+test_status_only_calls_curl
+test_version_only_calls_curl
+test_missing_helper_fails_loudly
+
+echo ""
+printf "${BOLD}Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -212,9 +212,24 @@ SHIM
 write_python3_passthrough() {
   # Some cmd_search code paths call python3. Real python3 is fine if it's on
   # PATH outside the sandbox — symlink it through.
-  if real_py=$(/usr/bin/env -i PATH=/usr/bin:/bin command -v python3 2>/dev/null); then
+  if real_py=$(PATH=/usr/bin:/bin bash -c 'command -v python3' 2>/dev/null); then
     ln -sf "$real_py" "$SANDBOX/bin/python3"
   fi
+}
+
+write_browser_stubs() {
+  # cmd_search/cmd_start_* call `open` (macOS) or `xdg-open` (Linux) on
+  # success. Without stubs, every test run pops a real browser tab on the
+  # developer's machine. Record but don't actually open anything.
+  cat > "$SANDBOX/bin/open" <<'SHIM'
+#!/usr/bin/env bash
+printf 'open %s\n' "$*" >> "$RECORD_FILE"
+SHIM
+  cat > "$SANDBOX/bin/xdg-open" <<'SHIM'
+#!/usr/bin/env bash
+printf 'xdg-open %s\n' "$*" >> "$RECORD_FILE"
+SHIM
+  chmod +x "$SANDBOX/bin/open" "$SANDBOX/bin/xdg-open"
 }
 
 # ---------------------------------------------------------------------------
@@ -259,6 +274,7 @@ setup_runtime() {
   esac
   write_curl_shim
   write_python3_passthrough
+  write_browser_stubs
 }
 
 # Run the CLI under the sandbox. stdin is a single newline (not /dev/null)
@@ -468,6 +484,51 @@ YAML
   done
 }
 
+# ---------------------------------------------------------------------------
+# Test cases — cmd_search (POSTs to /api/parse, /api/preview, /api/queries)
+# ---------------------------------------------------------------------------
+
+test_search_hits_all_three_endpoints() {
+  # cmd_search must POST query→/api/parse, then POST parsed→/api/preview,
+  # then POST tracker body→/api/queries. Runtime-independent (no compose).
+  for rt in docker_v2 podman_pc; do
+    setup_runtime "$rt"
+    run_cli search "NYC to LAX next month"
+    LAST_RUNTIME="$rt"; LAST_CMD="search"
+    assert_recorded "search POSTs /api/parse with query body" \
+      '^curl POST http://localhost:3003/api/parse body=\{.*"query":[[:space:]]*"NYC to LAX next month".*\}$'
+    assert_recorded "search POSTs /api/preview with parsed origin/destination" \
+      '^curl POST http://localhost:3003/api/preview body=\{.*"origin":[[:space:]]*"NYC".*"destination":[[:space:]]*"LAX".*\}$'
+    assert_recorded "search POSTs /api/queries with rawInput tracker body" \
+      '^curl POST http://localhost:3003/api/queries body=\{.*"rawInput":[[:space:]]*"NYC to LAX next month".*\}$'
+    assert_not_recorded "search never invokes compose" \
+      '\b(up|down|stop|exec|pull|logs) '
+  done
+}
+
+test_search_aborts_when_health_fails() {
+  # If /api/health returns nothing, cmd_search must NOT proceed to /api/parse.
+  setup_runtime docker_v2
+  # Replace curl shim with one that returns empty for /api/health.
+  cat > "$SANDBOX/bin/curl" <<'SHIM'
+#!/usr/bin/env bash
+url=""; for arg in "$@"; do case "$arg" in http*) url="$arg" ;; esac; done
+printf 'curl GET %s\n' "$url" >> "$RECORD_FILE"
+exit 0
+SHIM
+  chmod +x "$SANDBOX/bin/curl"
+  EXPECT_NONZERO=1 run_cli search "NYC to LAX"
+  unset EXPECT_NONZERO
+  LAST_RUNTIME="docker_v2"; LAST_CMD="search"
+  if [ "$LAST_EXIT" -ne 0 ]; then
+    pass "search exits non-zero when /api/health is unreachable"
+  else
+    fail "search should exit non-zero when /api/health is unreachable"
+  fi
+  assert_not_recorded "search does not POST /api/parse when health fails" \
+    '/api/parse'
+}
+
 test_status_only_calls_curl() {
   # status should not invoke compose at all — pure /api/health probe.
   for rt in docker_v2 docker_v1 podman_native podman_pc; do
@@ -556,6 +617,8 @@ test_stop_aborts_without_confirmation
 test_stop_invokes_compose_on_y
 test_uninstall_aborts_without_confirmation
 test_uninstall_invokes_compose_and_removes_dir_on_y
+test_search_hits_all_three_endpoints
+test_search_aborts_when_health_fails
 test_status_only_calls_curl
 test_version_only_calls_curl
 test_missing_helper_fails_loudly

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -419,6 +419,39 @@ test_start_calls_up_dash_d() {
   done
 }
 
+test_logs_calls_dc_logs_f_web() {
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli logs
+    LAST_RUNTIME="$rt"; LAST_CMD="logs"
+    case "$rt" in
+      docker_v2)     assert_recorded "logs -> docker compose logs -f web"   '^docker compose -f docker-compose.yml logs -f web$' ;;
+      docker_v1)     assert_recorded "logs -> docker-compose logs -f web"   '^docker-compose -f docker-compose.yml logs -f web$' ;;
+      podman_native) assert_recorded "logs -> podman compose logs -f web"   '^podman compose -f docker-compose.yml logs -f web$' ;;
+      podman_pc)     assert_recorded "logs -> podman-compose logs -f web"   '^podman-compose -f docker-compose.yml logs -f web$' ;;
+    esac
+  done
+}
+
+test_no_arg_runs_full_foreground_pipeline() {
+  # Bare `fairtrail` triggers cmd_start_foreground:
+  #   dc up -d -> poll /api/health -> dc logs -f web (shim returns 0).
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli ""
+    LAST_RUNTIME="$rt"; LAST_CMD="(no-arg)"
+    assert_recorded "no-arg runs dc up -d before logs"  ' up -d( |$)'
+    assert_recorded "no-arg polls /api/health" \
+      '^curl GET http://localhost:3003/api/health$'
+    case "$rt" in
+      docker_v2)     assert_recorded "no-arg tails docker compose logs -f web"   '^docker compose -f docker-compose.yml logs -f web$' ;;
+      docker_v1)     assert_recorded "no-arg tails docker-compose logs -f web"   '^docker-compose -f docker-compose.yml logs -f web$' ;;
+      podman_native) assert_recorded "no-arg tails podman compose logs -f web"   '^podman compose -f docker-compose.yml logs -f web$' ;;
+      podman_pc)     assert_recorded "no-arg tails podman-compose logs -f web"   '^podman-compose -f docker-compose.yml logs -f web$' ;;
+    esac
+  done
+}
+
 test_stop_aborts_without_confirmation() {
   # Empty answer (just hitting Enter) → cancel branch. dc stop must NOT run.
   for rt in docker_v2 docker_v1 podman_native podman_pc; do
@@ -613,6 +646,8 @@ test_tui_headless_podman_pc
 test_tui_list_podman_pc
 test_update_pulls_then_force_recreates_web
 test_start_calls_up_dash_d
+test_logs_calls_dc_logs_f_web
+test_no_arg_runs_full_foreground_pipeline
 test_stop_aborts_without_confirmation
 test_stop_invokes_compose_on_y
 test_uninstall_aborts_without_confirmation

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -56,27 +56,37 @@ HELPER="$REPO_ROOT/apps/web/public/fairtrail-cli-flags.sh"
 # else appends "<binary> <args>" to $RECORD_FILE.
 # ---------------------------------------------------------------------------
 
+# Common preamble injected into every shim. record_call <bin> <argv...>
+# uses `printf '%q '` per-arg so multi-word args ("--model 'gpt 5'") are
+# preserved with explicit boundaries instead of collapsing into "gpt 5".
+SHIM_PREAMBLE='record_call() {
+  local bin="$1"; shift
+  local args_str
+  if [ $# -gt 0 ]; then
+    args_str=$(printf "%q " "$@")
+    printf "%s %s\n" "$bin" "${args_str% }" >> "$RECORD_FILE"
+  else
+    printf "%s\n" "$bin" >> "$RECORD_FILE"
+  fi
+}'
+
 write_docker_shim() {
   # $1: 0 if `docker compose` v2 available, 1 if not (forces docker-compose v1)
   local has_v2="$1"
   cat > "$SANDBOX/bin/docker" <<SHIM
 #!/usr/bin/env bash
+$SHIM_PREAMBLE
 case "\$1" in
   info) exit 0 ;;
   compose)
     case "\${2:-}" in
       version) exit $has_v2 ;;
       *)
-        if [ $has_v2 -eq 0 ]; then
-          printf 'docker %s\n' "\$*" >> "\$RECORD_FILE"
-          exit 0
-        fi
-        # If v2 isn't available we shouldn't be reaching here
-        printf 'docker %s\n' "\$*" >> "\$RECORD_FILE"
-        exit 1 ;;
+        record_call docker "\$@"
+        exit $has_v2 ;;
     esac ;;
   *)
-    printf 'docker %s\n' "\$*" >> "\$RECORD_FILE"
+    record_call docker "\$@"
     exit 0 ;;
 esac
 SHIM
@@ -84,9 +94,10 @@ SHIM
 }
 
 write_docker_compose_v1_shim() {
-  cat > "$SANDBOX/bin/docker-compose" <<'SHIM'
+  cat > "$SANDBOX/bin/docker-compose" <<SHIM
 #!/usr/bin/env bash
-printf 'docker-compose %s\n' "$*" >> "$RECORD_FILE"
+$SHIM_PREAMBLE
+record_call docker-compose "\$@"
 exit 0
 SHIM
   chmod +x "$SANDBOX/bin/docker-compose"
@@ -97,19 +108,17 @@ write_podman_shim() {
   local has_native="$1"
   cat > "$SANDBOX/bin/podman" <<SHIM
 #!/usr/bin/env bash
+$SHIM_PREAMBLE
 case "\$1" in
   compose)
     case "\${2:-}" in
       version) exit $has_native ;;
       *)
-        if [ $has_native -eq 0 ]; then
-          printf 'podman %s\n' "\$*" >> "\$RECORD_FILE"
-          exit 0
-        fi
-        exit 1 ;;
+        record_call podman "\$@"
+        exit $has_native ;;
     esac ;;
   *)
-    printf 'podman %s\n' "\$*" >> "\$RECORD_FILE"
+    record_call podman "\$@"
     exit 0 ;;
 esac
 SHIM
@@ -124,32 +133,32 @@ write_podman_compose_shim() {
   # -i, -t, -it, --interactive, --tty) must abort with the same usage error
   # the real binary produces. Without this, a buggy CLI passing -it would
   # quietly record success and the test would lie.
-  cat > "$SANDBOX/bin/podman-compose" <<'SHIM'
+  cat > "$SANDBOX/bin/podman-compose" <<SHIM
 #!/usr/bin/env bash
-printf 'podman-compose %s\n' "$*" >> "$RECORD_FILE"
+$SHIM_PREAMBLE
+record_call podman-compose "\$@"
 saw_exec=0
 i=0
-args=("$@")
-while [ $i -lt ${#args[@]} ]; do
-  a="${args[$i]}"
-  if [ $saw_exec -eq 0 ]; then
-    case "$a" in
+args=("\$@")
+while [ \$i -lt \${#args[@]} ]; do
+  a="\${args[\$i]}"
+  if [ \$saw_exec -eq 0 ]; then
+    case "\$a" in
       exec) saw_exec=1 ;;
-      -f|--file) i=$((i + 1)) ;;  # pre-exec file flags consume the next arg
+      -f|--file) i=\$((i + 1)) ;;
       *) ;;
     esac
-    i=$((i + 1)); continue
+    i=\$((i + 1)); continue
   fi
-  # In exec args. Stop validating once we hit a non-flag (the service name).
-  case "$a" in
+  case "\$a" in
     -d|--detach|--privileged|-T) ;;
-    -u|--user|--index|-e|--env|-w|--workdir) i=$((i + 1)) ;;
+    -u|--user|--index|-e|--env|-w|--workdir) i=\$((i + 1)) ;;
     -*)
-      printf 'podman-compose: error: unrecognized arguments: %s\n' "$a" >&2
+      printf 'podman-compose: error: unrecognized arguments: %s\n' "\$a" >&2
       exit 2 ;;
-    *) break ;;  # service name reached — REMAINDER follows, never validate
+    *) break ;;
   esac
-  i=$((i + 1))
+  i=\$((i + 1))
 done
 exit 0
 SHIM
@@ -386,6 +395,25 @@ test_tui_list_podman_pc() {
   run_cli --list
   assert_recorded "tui --list sends podman-compose exec -T web fairtrail-tui --list" \
     'podman-compose -f docker-compose.yml exec -T web fairtrail-tui --list'
+}
+
+# Codex audit gap 10: argv boundaries must survive recording so a
+# multi-word arg ("--model 'gpt 5 turbo'") is distinguishable from three
+# separate words. The shims use printf %q per arg, which backslash-
+# escapes spaces in multi-word tokens.
+test_tui_preserves_multi_word_arg_boundaries() {
+  setup_runtime podman_pc
+  run_cli --headless --model "gpt 5 turbo"
+  LAST_RUNTIME="podman_pc"; LAST_CMD="--headless"
+  # The %q quoting renders 'gpt 5 turbo' as gpt\ 5\ turbo. The pattern
+  # below matches the escaped form on the same line as fairtrail-tui.
+  assert_recorded "multi-word --model arg recorded with boundaries intact (#72)" \
+    'fairtrail-tui --headless --model gpt\\ 5\\ turbo'
+  # Negative control: the unsplit form 'gpt 5 turbo' (three plain tokens)
+  # must NOT appear, otherwise we would not be able to tell argv-3 from
+  # argv-1-with-spaces.
+  assert_not_recorded "multi-word arg is not recorded as three plain tokens" \
+    'fairtrail-tui --headless --model gpt 5 turbo$'
 }
 
 # ---------------------------------------------------------------------------
@@ -708,6 +736,7 @@ test_tui_headless_docker_v1
 test_tui_headless_podman_native
 test_tui_headless_podman_pc
 test_tui_list_podman_pc
+test_tui_preserves_multi_word_arg_boundaries
 test_update_pulls_then_force_recreates_web
 test_start_calls_up_dash_d
 test_logs_calls_dc_logs_f_web

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -404,15 +404,28 @@ test_start_calls_up_dash_d() {
 }
 
 test_stop_aborts_without_confirmation() {
-  # cmd_stop reads y/N from stdin. With stdin closed we get the cancel path,
-  # so dc stop is NOT called — verify that, since silently calling stop on a
-  # cancelled prompt would be a regression in itself.
+  # Empty answer (just hitting Enter) → cancel branch. dc stop must NOT run.
   for rt in docker_v2 docker_v1 podman_native podman_pc; do
     setup_runtime "$rt"
     run_cli stop
     LAST_RUNTIME="$rt"; LAST_CMD="stop"
-    assert_not_recorded "stop respects N answer (no dc stop on cancel)" \
+    assert_not_recorded "stop respects empty answer (no dc stop on cancel)" \
       ' stop( |$)'
+  done
+}
+
+test_stop_invokes_compose_on_y() {
+  # Answer "y" → dc stop must run with the runtime-correct prefix.
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli_with_input $'y\n' stop
+    LAST_RUNTIME="$rt"; LAST_CMD="stop"
+    case "$rt" in
+      docker_v2)     assert_recorded "stop -> docker compose stop"   '^docker compose -f docker-compose.yml stop$' ;;
+      docker_v1)     assert_recorded "stop -> docker-compose stop"   '^docker-compose -f docker-compose.yml stop$' ;;
+      podman_native) assert_recorded "stop -> podman compose stop"   '^podman compose -f docker-compose.yml stop$' ;;
+      podman_pc)     assert_recorded "stop -> podman-compose stop"   '^podman-compose -f docker-compose.yml stop$' ;;
+    esac
   done
 }
 
@@ -421,10 +434,37 @@ test_uninstall_aborts_without_confirmation() {
     setup_runtime "$rt"
     run_cli uninstall
     LAST_RUNTIME="$rt"; LAST_CMD="uninstall"
-    assert_not_recorded "uninstall respects N answer (no dc down on cancel)" \
+    assert_not_recorded "uninstall respects empty answer (no dc down on cancel)" \
       ' down -v( |$)'
-    [ -d "$SANDBOX/.fairtrail" ] && pass "uninstall did not remove ~/.fairtrail on cancel" \
+    [ -d "$SANDBOX/.fairtrail" ] \
+      && pass "uninstall did not remove ~/.fairtrail on cancel" \
       || fail "uninstall removed ~/.fairtrail despite cancel"
+  done
+}
+
+test_uninstall_invokes_compose_and_removes_dir_on_y() {
+  for rt in docker_v2 docker_v1 podman_native podman_pc; do
+    setup_runtime "$rt"
+    run_cli_with_input $'y\n' uninstall
+    LAST_RUNTIME="$rt"; LAST_CMD="uninstall"
+    case "$rt" in
+      docker_v2)     assert_recorded "uninstall -> docker compose down -v"   '^docker compose -f docker-compose.yml down -v$' ;;
+      docker_v1)     assert_recorded "uninstall -> docker-compose down -v"   '^docker-compose -f docker-compose.yml down -v$' ;;
+      podman_native) assert_recorded "uninstall -> podman compose down -v"   '^podman compose -f docker-compose.yml down -v$' ;;
+      podman_pc)     assert_recorded "uninstall -> podman-compose down -v"   '^podman-compose -f docker-compose.yml down -v$' ;;
+    esac
+    if [ ! -d "$SANDBOX/.fairtrail" ]; then
+      pass "uninstall removed ~/.fairtrail on confirm=y"
+    else
+      fail "uninstall did not remove ~/.fairtrail on confirm=y"
+    fi
+    # Recreate sandbox state so subsequent tests still find docker-compose.yml.
+    mkdir -p "$SANDBOX/.fairtrail"
+    cat > "$SANDBOX/.fairtrail/docker-compose.yml" <<'YAML'
+services:
+  web:
+    image: ghcr.io/affromero/fairtrail:latest
+YAML
   done
 }
 
@@ -513,7 +553,9 @@ test_tui_list_podman_pc
 test_update_pulls_then_force_recreates_web
 test_start_calls_up_dash_d
 test_stop_aborts_without_confirmation
+test_stop_invokes_compose_on_y
 test_uninstall_aborts_without_confirmation
+test_uninstall_invokes_compose_and_removes_dir_on_y
 test_status_only_calls_curl
 test_version_only_calls_curl
 test_missing_helper_fails_loudly

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -117,30 +117,74 @@ SHIM
 }
 
 write_podman_compose_shim() {
+  # Mirror the real argparser at podman_compose.py:4636-4683. Walk the args,
+  # skipping any global -f flags before `exec`. Once we see `exec`, the only
+  # tokens valid before the service name are: -d, --detach, --privileged,
+  # -u/--user, -T, --index, -e/--env, -w/--workdir. Anything else (especially
+  # -i, -t, -it, --interactive, --tty) must abort with the same usage error
+  # the real binary produces. Without this, a buggy CLI passing -it would
+  # quietly record success and the test would lie.
   cat > "$SANDBOX/bin/podman-compose" <<'SHIM'
 #!/usr/bin/env bash
 printf 'podman-compose %s\n' "$*" >> "$RECORD_FILE"
+saw_exec=0
+i=0
+args=("$@")
+while [ $i -lt ${#args[@]} ]; do
+  a="${args[$i]}"
+  if [ $saw_exec -eq 0 ]; then
+    case "$a" in
+      exec) saw_exec=1 ;;
+      -f|--file) i=$((i + 1)) ;;  # pre-exec file flags consume the next arg
+      *) ;;
+    esac
+    i=$((i + 1)); continue
+  fi
+  # In exec args. Stop validating once we hit a non-flag (the service name).
+  case "$a" in
+    -d|--detach|--privileged|-T) ;;
+    -u|--user|--index|-e|--env|-w|--workdir) i=$((i + 1)) ;;
+    -*)
+      printf 'podman-compose: error: unrecognized arguments: %s\n' "$a" >&2
+      exit 2 ;;
+    *) break ;;  # service name reached — REMAINDER follows, never validate
+  esac
+  i=$((i + 1))
+done
 exit 0
 SHIM
   chmod +x "$SANDBOX/bin/podman-compose"
 }
 
 write_curl_shim() {
-  # Responds to /api/health, /api/version, /api/parse, /api/preview,
-  # /api/queries, and BASE_URL self-update fetches. Anything else exits 0
-  # silently — the CLI generally tolerates a no-op curl.
+  # Records each call as `curl <METHOD> <URL> [body=<BODY>]` to RECORD_FILE,
+  # then responds with a body shape matching the real /api/* contract.
+  # Anything not enumerated exits 0 silently (no-op).
   cat > "$SANDBOX/bin/curl" <<'SHIM'
 #!/usr/bin/env bash
 url=""
 out=""
+method="GET"
+body=""
 while [ $# -gt 0 ]; do
   case "$1" in
     -o) out="$2"; shift 2 ;;
+    -X|--request) method="$2"; shift 2 ;;
+    -d|--data|--data-binary|--data-raw)
+      method="POST"; body="$2"; shift 2 ;;
+    -H|--header) shift 2 ;;
+    --max-time|--connect-timeout|-w|--write-out|--retry|--retry-delay|--retry-max-time)
+      shift 2 ;;
     -*) shift ;;
     http*|*://*) url="$1"; shift ;;
     *) shift ;;
   esac
 done
+if [ -n "$body" ]; then
+  printf 'curl %s %s body=%s\n' "$method" "$url" "$body" >> "$RECORD_FILE"
+else
+  printf 'curl %s %s\n' "$method" "$url" >> "$RECORD_FILE"
+fi
 case "$url" in
   *"/api/health"*)
     printf '{"activeQueries":1,"intervalHours":3,"nextScrape":"2026-05-10T12:00:00"}' ;;

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -582,6 +582,70 @@ test_version_only_calls_curl() {
 }
 
 # ---------------------------------------------------------------------------
+# Test cases — compose file composition (override + VPN auto-inclusion)
+# ---------------------------------------------------------------------------
+
+test_compose_files_includes_override_when_present() {
+  setup_runtime docker_v2
+  echo "services: { web: { environment: { FOO: bar } } }" \
+    > "$SANDBOX/.fairtrail/docker-compose.override.yml"
+  run_cli start
+  LAST_RUNTIME="docker_v2"; LAST_CMD="start"
+  assert_recorded "override file appended to -f chain" \
+    '^docker compose -f docker-compose.yml -f docker-compose.override.yml up -d'
+  rm -f "$SANDBOX/.fairtrail/docker-compose.override.yml"
+}
+
+test_vpn_compose_excluded_without_env() {
+  # No .env file at all → VPN sidecar must NOT be included.
+  setup_runtime docker_v2
+  echo "services: { vpn: {} }" > "$SANDBOX/.fairtrail/docker-compose.vpn.yml"
+  rm -f "$SANDBOX/.fairtrail/.env"
+  run_cli start
+  LAST_RUNTIME="docker_v2"; LAST_CMD="start"
+  assert_not_recorded "no .env -> VPN sidecar omitted" 'docker-compose.vpn.yml'
+  rm -f "$SANDBOX/.fairtrail/docker-compose.vpn.yml"
+}
+
+test_vpn_compose_excluded_when_commented() {
+  # .env has the token only inside a comment → must be treated as disabled.
+  # This is the actual bug Codex audit found: `grep -q "EXPRESSVPN_CODE"`
+  # used to match commented lines and enable the VPN sidecar.
+  setup_runtime docker_v2
+  echo "services: { vpn: {} }" > "$SANDBOX/.fairtrail/docker-compose.vpn.yml"
+  printf '# EXPRESSVPN_CODE=placeholder\nDB_URL=postgres://x\n' \
+    > "$SANDBOX/.fairtrail/.env"
+  run_cli start
+  LAST_RUNTIME="docker_v2"; LAST_CMD="start"
+  assert_not_recorded "commented EXPRESSVPN_CODE -> VPN sidecar omitted" \
+    'docker-compose.vpn.yml'
+  rm -f "$SANDBOX/.fairtrail/docker-compose.vpn.yml" "$SANDBOX/.fairtrail/.env"
+}
+
+test_vpn_compose_excluded_when_empty_value() {
+  # EXPRESSVPN_CODE= (no value) is also disabled.
+  setup_runtime docker_v2
+  echo "services: { vpn: {} }" > "$SANDBOX/.fairtrail/docker-compose.vpn.yml"
+  printf 'EXPRESSVPN_CODE=\n' > "$SANDBOX/.fairtrail/.env"
+  run_cli start
+  LAST_RUNTIME="docker_v2"; LAST_CMD="start"
+  assert_not_recorded "empty EXPRESSVPN_CODE -> VPN sidecar omitted" \
+    'docker-compose.vpn.yml'
+  rm -f "$SANDBOX/.fairtrail/docker-compose.vpn.yml" "$SANDBOX/.fairtrail/.env"
+}
+
+test_vpn_compose_included_when_enabled() {
+  setup_runtime docker_v2
+  echo "services: { vpn: {} }" > "$SANDBOX/.fairtrail/docker-compose.vpn.yml"
+  printf 'EXPRESSVPN_CODE=ABC123XYZ\n' > "$SANDBOX/.fairtrail/.env"
+  run_cli start
+  LAST_RUNTIME="docker_v2"; LAST_CMD="start"
+  assert_recorded "EXPRESSVPN_CODE=value -> VPN sidecar appended" \
+    '^docker compose -f docker-compose.yml -f docker-compose.vpn.yml up -d'
+  rm -f "$SANDBOX/.fairtrail/docker-compose.vpn.yml" "$SANDBOX/.fairtrail/.env"
+}
+
+# ---------------------------------------------------------------------------
 # Helper missing → CLI must exit non-zero (loud failure)
 # ---------------------------------------------------------------------------
 
@@ -656,6 +720,11 @@ test_search_hits_all_three_endpoints
 test_search_aborts_when_health_fails
 test_status_only_calls_curl
 test_version_only_calls_curl
+test_compose_files_includes_override_when_present
+test_vpn_compose_excluded_without_env
+test_vpn_compose_excluded_when_commented
+test_vpn_compose_excluded_when_empty_value
+test_vpn_compose_included_when_enabled
 test_missing_helper_fails_loudly
 test_run_cli_captures_exit
 

--- a/scripts/debian-install-smoke.sh
+++ b/scripts/debian-install-smoke.sh
@@ -260,6 +260,9 @@ STUB
   # Create a fake "fairtrail-cli" download server using a local file
   mkdir -p "$HOME/fake-server"
   cp /home/testuser/fairtrail-cli "$HOME/fake-server/fairtrail-cli"
+  # The CLI requires fairtrail-cli-flags.sh next to it (issue #72); ship it
+  # in the fake-server so install.sh's parallel curl succeeds.
+  cp /home/testuser/fairtrail-cli-flags.sh "$HOME/fake-server/fairtrail-cli-flags.sh"
 
   # Run installer in non-interactive mode with stubbed Docker and local CLI.
   # Pipe empty stdin so the API key prompt gets "" (skip), and FAIRTRAIL_YES=1

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -294,6 +294,17 @@ EXPECTED
     fail "_compose_exec_flags matrix mismatch (#72)"
     diff <(printf '%s\n' "$expected") <(printf '%s\n' "$out") || true
   fi
+
+  # Unknown compose flavors must hard-fail (return non-zero) so a future
+  # `nerdctl compose` / `finch compose` doesn't silently inherit docker
+  # flags. Anyone adding a new flavor must register it explicitly.
+  local rc=0
+  bash -c "source $helper; _compose_exec_flags 'nerdctl compose' 0 0" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "_compose_exec_flags rejects unknown compose flavor (#72)"
+  else
+    fail "_compose_exec_flags must hard-fail on unknown compose flavor — got rc=$rc"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -250,6 +250,117 @@ test_entrypoint_pins_prisma_major() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: _compose_exec_flags emits the right flags for each compose flavor
+# (issue #72 follow-up). docker compose, docker-compose, and podman compose
+# accept Docker's -it/-i; podman-compose (standalone Python tool) rejects
+# them and uses -T to disable TTY.
+# ---------------------------------------------------------------------------
+test_compose_exec_flags_matrix() {
+  local helper="apps/web/public/fairtrail-cli-flags.sh"
+  if [ ! -f "$helper" ]; then
+    fail "missing helper file $helper"
+    return
+  fi
+
+  # Source in a subshell so set -u from the parent doesn't leak in.
+  local out
+  out=$(bash -c "source $helper
+    printf 'docker-compose +tty=[%s]\n'  \"\$(_compose_exec_flags 'docker-compose' 1 1)\"
+    printf 'docker-compose -tty=[%s]\n'  \"\$(_compose_exec_flags 'docker-compose' 0 0)\"
+    printf 'docker-compose-v2 +tty=[%s]\n' \"\$(_compose_exec_flags 'docker compose' 1 1)\"
+    printf 'docker-compose-v2 -tty=[%s]\n' \"\$(_compose_exec_flags 'docker compose' 0 0)\"
+    printf 'podman-native +tty=[%s]\n'  \"\$(_compose_exec_flags 'podman compose' 1 1)\"
+    printf 'podman-native -tty=[%s]\n'  \"\$(_compose_exec_flags 'podman compose' 0 0)\"
+    printf 'podman-compose +tty=[%s]\n' \"\$(_compose_exec_flags 'podman-compose' 1 1)\"
+    printf 'podman-compose -tty=[%s]\n' \"\$(_compose_exec_flags 'podman-compose' 0 0)\"
+  ")
+
+  local expected
+  expected=$(cat <<'EXPECTED'
+docker-compose +tty=[-it]
+docker-compose -tty=[-i]
+docker-compose-v2 +tty=[-it]
+docker-compose-v2 -tty=[-i]
+podman-native +tty=[-it]
+podman-native -tty=[-i]
+podman-compose +tty=[]
+podman-compose -tty=[-T]
+EXPECTED
+)
+
+  if [ "$out" = "$expected" ]; then
+    pass "_compose_exec_flags emits correct flags across the 4-flavor x 2-tty matrix (#72)"
+  else
+    fail "_compose_exec_flags matrix mismatch (#72)"
+    diff <(printf '%s\n' "$expected") <(printf '%s\n' "$out") || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test: cmd_tui delegates exec-flag selection to _compose_exec_flags
+# (so future rewrites can't bypass the helper and re-introduce hardcoded -it)
+# ---------------------------------------------------------------------------
+test_cmd_tui_uses_helper() {
+  local cli="apps/web/public/fairtrail-cli"
+  local code_only
+  # Strip comment lines (leading-whitespace-then-#) so a "see _compose_exec_flags"
+  # comment can't satisfy the assertion on its own.
+  code_only=$(sed -n '/^cmd_tui()/,/^}/p' "$cli" | grep -vE '^[[:space:]]*#')
+  if echo "$code_only" | grep -q '_compose_exec_flags'; then
+    pass "cmd_tui calls _compose_exec_flags (#72)"
+  else
+    fail "cmd_tui must call _compose_exec_flags to pick exec flags by compose flavor (#72)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test: no raw -it/-i flags survive in any \$_DC exec call site
+# (catches future commands that bypass the helper)
+# ---------------------------------------------------------------------------
+test_no_raw_it_flags_in_dc_exec() {
+  local cli="apps/web/public/fairtrail-cli"
+  # Strip comment-only lines first, then look for any literal -it / -i  flag
+  # passed to `$_DC ... exec` on the same line. The bug we're guarding against
+  # is hardcoded -it that survives the helper indirection — so also flag
+  # `exec_flags="-it"` style assignments that funnel into the same call.
+  local code_only hits
+  code_only=$(grep -vE '^[[:space:]]*#' "$cli")
+  hits=$(printf '%s\n' "$code_only" \
+    | grep -nE '(\$_DC[^#]*[[:space:]]exec[[:space:]]+(-it|-i[[:space:]]))|exec_flags=("|'"'"')-(it|i)("|'"'"')' \
+    || true)
+  if [ -z "$hits" ]; then
+    pass "no raw -it/-i flags in \$_DC exec call sites (#72)"
+  else
+    fail "found raw -it/-i flags in \$_DC exec — must use _compose_exec_flags helper:"
+    printf "%s\n" "$hits"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test: the helper file is shipped by install.sh and refreshed by cmd_update
+# (the CLI hard-fails on startup if the helper is missing, so install must
+# place it and update must refresh it)
+# ---------------------------------------------------------------------------
+test_helper_shipped_by_install_and_update() {
+  local installer="apps/web/public/install.sh"
+  local cli="apps/web/public/fairtrail-cli"
+
+  if grep -q 'fairtrail-cli-flags.sh' "$installer"; then
+    pass "install.sh ships fairtrail-cli-flags.sh"
+  else
+    fail "install.sh must download/copy fairtrail-cli-flags.sh next to fairtrail (#72)"
+  fi
+
+  local update_block
+  update_block=$(sed -n '/^cmd_update/,/^cmd_/p' "$cli")
+  if echo "$update_block" | grep -q 'fairtrail-cli-flags.sh'; then
+    pass "cmd_update refreshes fairtrail-cli-flags.sh"
+  else
+    fail "cmd_update must refresh fairtrail-cli-flags.sh alongside the CLI (#72)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 echo ""
@@ -271,6 +382,10 @@ test_install_supports_no_browser
 test_dockerfile_ships_cli
 test_install_supports_arch_family
 test_entrypoint_pins_prisma_major
+test_compose_exec_flags_matrix
+test_cmd_tui_uses_helper
+test_no_raw_it_flags_in_dc_exec
+test_helper_shipped_by_install_and_update
 
 echo ""
 printf "${BOLD}Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}\n" "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Closes the second half of #72. After v0.5.4 fixed silent `up -d` on podman-compose, reporter @backslashV reported `fairtrail --headless` aborting with `unrecognized arguments: -it`. This branch ships the fix and a behavioral test layer that would have caught both #72 sub-bugs.

The branch grew during review: original fix → Codex adversarial audit → 6 hardening commits closing every audit finding → 2 deferred-gap fixes (helper whitelist, argv boundaries) → 2 CI portability fixes (install-smoke fake-server, hermetic PATH for Ubuntu).

### Fix

- **`apps/web/public/fairtrail-cli-flags.sh`** (new) — `_compose_exec_flags(dc, stdin_tty, stdout_tty)` whitelists the four supported compose flavors and emits flags by flavor: `-it`/`-i` for docker compose v2, docker-compose v1, and podman compose native; empty/`-T` for podman-compose standalone (the actual bug). Hard-fails on unknown flavors so a future `nerdctl compose` / `finch compose` cannot silently inherit docker flags.
- **`apps/web/public/fairtrail-cli`** — `cmd_tui` calls the helper instead of hardcoding `-it`/`-i`. Source guard at the top fails loudly if the helper is missing post-install. `cmd_update` refreshes the helper alongside the CLI.
- **`apps/web/public/install.sh`** — ships the helper next to the CLI binary.
- **`apps/web/public/fairtrail-cli`** also fixes a real bug Codex audit surfaced: `grep -q "EXPRESSVPN_CODE" .env` matched commented placeholder lines, silently enabling the VPN sidecar from a disabled-by-comment `# EXPRESSVPN_CODE=` entry. Now requires `^[[:space:]]*EXPRESSVPN_CODE=.+`.

### Test infrastructure

| Suite | Purpose | Tests |
|---|---|---|
| `scripts/install-flow-test.sh` | Static + grep regression layer (fast-fail) | 21 |
| `scripts/cli-runtime-test.sh` | Behavioral harness — runs the actual CLI under shimmed `docker`/`podman`/`*compose`/`curl`/`open` binaries across 4 runtime configurations and asserts every recorded invocation | 89 |
| **Total** | | **110** |

The behavioral harness models real binary behavior:
- `podman-compose` shim mirrors the real argparser at `podman_compose.py:4636-4683` and rejects `-i`/`-t`/`-it`/`--interactive`/`--tty` with exit 2.
- `curl` shim records each call as `<METHOD> <URL> body=<BODY>` with proper argv boundaries (`printf '%q '`) so multi-word args don't collapse.
- Hermetic PATH (`$SANDBOX/bin:$SANDBOX/sysbin`, no `/usr/bin`) so `command -v docker` doesn't find Ubuntu CI's preinstalled docker and short-circuit podman tests.
- `run_cli` captures the CLI's exit code and fails the test if non-zero (with `EXPECT_NONZERO=1` opt-out for missing-helper test).

### What it catches

| Codex audit gap | Resolution | Phase |
|---|---|---|
| 1. `cmd_search` had zero coverage | 4 endpoint assertions (parse/preview/queries POST + health-fail abort) | 9 |
| 2. `stop`/`uninstall` confirm=Y paths untested | 8 runtime-prefixed assertions + `~/.fairtrail` removal check | 8 |
| 3. `cmd_logs` and bare `fairtrail` (foreground) untested | 12 runtime-prefixed log-tail and up-pipeline assertions | 10 |
| 4. `\|\| true` swallowed exit codes | `LAST_EXIT` capture + self-check; `read -rp` EOF crash exposed | 7 |
| 5+6. Permissive shims accepting any flag | Strict podman-compose argparser mirror; `-i`/`-it` rejected with exit 2 | 6 |
| 7. Override compose files untested | 5 assertions for `-f` chain composition | 11 |
| 8. **Real bug** — VPN grep matched commented placeholders | `^[[:space:]]*EXPRESSVPN_CODE=.+` + 4 regression tests | 11 |
| 9. Helper fell through on unknown `$_DC` | Whitelist + hard-fail + regression test | 12 |
| 10. Argv boundaries collapsed | `printf '%q'` per-arg recording + boundary preservation test | 13 |

### Verification

- 14/14 commits build clean. `npm run lint` green.
- All 110 assertions pass on macOS dev and Ubuntu CI.
- Reverting `cmd_tui` to hardcoded `exec_flags="-it"` trips 6 behavioral FAILs + 2 grep FAILs.
- Reverting `cmd_update`'s `--force-recreate` trips 4 behavioral FAILs.
- Reverting the VPN grep to the buggy form trips 2 FAILs.
- Reverting the argv recording to `$*` trips 2 FAILs.

CI: `ci` ✓, `install-smoke` ✓, `integration` ✓.

## Test plan

- [x] `bash scripts/install-flow-test.sh` — 21/21 pass
- [x] `bash scripts/cli-runtime-test.sh` — 89/89 pass
- [x] Sanity-revert of each fix trips the corresponding regression guard
- [x] CI `ci` job green (run 25635245509)
- [x] CI `install-smoke` job green
- [x] CI `integration` job green
- [ ] Manual on a real `podman-compose` machine: `fairtrail --headless` opens the Ink TUI without `unrecognized arguments: -it` (left for @backslashV to verify post-merge per the issue-reply convention)
