### PR TITLE
fix(scraper): diversify to Google when airline_direct yields stub (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Cron silently failed for queries whose picked flights were on a "known" airline** (#65 follow-up): when a user picked a flight in the preview picker (e.g. Turkish Airlines for BRI to JFK), `apps/web/src/app/api/queries/route.ts` and `packages/cli/src/lib/create-queries.ts` auto-derived `preferredAirlines` from the picked flights. The cron scraper then treated `preferredAirlines` as a navigation strategy (`useAirlineDirect = directAirlines.length > 0`) and routed every cycle to `https://www.turkishairlines.com/.../?origin=BRI&destination=JFK`. Turkish's site does not accept raw IATA codes, auto-resolves BRI to Lecce, and renders a 1964 char marketing stub. The stub satisfied `navigateAirlineDirect`'s loose `/€|EUR|USD/` regex so the existing Google Flights fallback never fired. Three-layer fix: (1) `queries/route.ts` and `create-queries.ts` no longer auto-derive `preferredAirlines` from `selectedFlights`; (2) new `hasFlightPriceSignal` helper in `navigate.ts` requires both currency density (3+ mentions) and a letter-bounded price token, rejecting stubs while accepting `EUR99` / `EUR 1,200` / `€431` / `EUR 1.299`; (3) `scrapeOneDatePair` now diversifies to Google Flights when `airline_direct` extracts zero prices with `empty_extraction`/`no_json_in_response`/`page_not_loaded`/`llm_error`, but never on `all_filtered_out` (real flights, filters worked). Once diversification fires, attempt-2 retry skips the broken airline launch. Composite source label (`airline_direct+google_flights`) on `FetchRun.source` for operators to grep. Existing rows with stale `preferredAirlines` recover via (3); no DB migration needed. 13 new behavioral tests across `route.test.ts`, `create-queries.test.ts` (new), `navigate.test.ts`, `run-scrape.test.ts`.
+
 ## [0.6.0] - 2026-05-12
 
 ### Added

--- a/apps/web/src/app/api/queries/route.test.ts
+++ b/apps/web/src/app/api/queries/route.test.ts
@@ -146,6 +146,42 @@ describe('POST /api/queries', () => {
     expect(mockSnapshotCreateMany).toHaveBeenCalled();
   });
 
+  // Issue 65: a picked Turkish flight used to silently flag the saved query as
+  // preferredAirlines=['Turkish'], which then routed cron through a broken
+  // turkishairlines.com URL forever. Picked flights now seed snapshots only and
+  // never poison the cron navigation strategy.
+  it('does NOT auto-derive preferredAirlines from selectedFlights when preferredAirlines is empty', async () => {
+    const bodyWithPickedTurkish = {
+      ...validBody,
+      preferredAirlines: [],
+      routes: [{
+        ...validBody.routes[0],
+        selectedFlights: [
+          { travelDate: '2026-06-15', price: 431, airline: 'Turkish Airlines', bookingUrl: 'https://turkishairlines.com' },
+        ],
+      }],
+    };
+    await POST(makeRequest(bodyWithPickedTurkish));
+    const createCall = mockQueryCreate.mock.calls[0]![0] as { data: { preferredAirlines: string[] } };
+    expect(createCall.data.preferredAirlines).toEqual([]);
+  });
+
+  it('preserves explicit preferredAirlines even when selectedFlights contain other airlines', async () => {
+    const bodyWithExplicitAirlines = {
+      ...validBody,
+      preferredAirlines: ['Lufthansa'],
+      routes: [{
+        ...validBody.routes[0],
+        selectedFlights: [
+          { travelDate: '2026-06-15', price: 431, airline: 'Turkish Airlines', bookingUrl: 'https://turkishairlines.com' },
+        ],
+      }],
+    };
+    await POST(makeRequest(bodyWithExplicitAirlines));
+    const createCall = mockQueryCreate.mock.calls[0]![0] as { data: { preferredAirlines: string[] } };
+    expect(createCall.data.preferredAirlines).toEqual(['Lufthansa']);
+  });
+
   it('supports multi-route format', async () => {
     const multiRoute = {
       ...validBody,

--- a/apps/web/src/app/api/queries/route.ts
+++ b/apps/web/src/app/api/queries/route.ts
@@ -119,12 +119,6 @@ export async function POST(request: NextRequest) {
   for (const route of routeInputs) {
     const flights = route.selectedFlights || [];
 
-    // Derive airlines from selected flights if not explicitly set
-    let routeAirlines = airlines;
-    if (routeAirlines.length === 0 && flights.length > 0) {
-      routeAirlines = [...new Set(flights.map((f) => f.airline))];
-    }
-
     const deleteToken = crypto.randomUUID();
 
     // Per-date pinning: when route has a specific date, pin dateFrom to outbound and dateTo to return
@@ -147,7 +141,7 @@ export async function POST(request: NextRequest) {
         maxPrice: maxPrice ? Number(maxPrice) : null,
         maxStops: maxStops !== undefined && maxStops !== null ? Number(maxStops) : null,
         maxDurationHours: maxDurationHoursValidated,
-        preferredAirlines: routeAirlines,
+        preferredAirlines: airlines,
         timePreference: timePreference || 'any',
         cabinClass: cabinClass || 'economy',
         tripType: tripType === 'one_way' ? 'one_way' : 'round_trip',

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildGoogleFlightsUrl,
   buildGoogleFlightsUrlCandidates,
+  hasFlightPriceSignal,
   pageHasRequestedRoute,
   pageRedirectedToHomepage,
 } from './navigate';
@@ -445,5 +446,61 @@ describe('pageRedirectedToHomepage (the #65 headline failure mode)', () => {
 
   it('returns false on malformed URL inputs (defensive)', () => {
     expect(pageRedirectedToHomepage('not a url', 'also not a url')).toBe(false);
+  });
+});
+
+// Issue 65: navigateAirlineDirect previously accepted any "currency symbol or
+// code + digit" page as having flight prices, including a Turkish stub at
+// 1964 chars that just mentioned "EUR pricing" in marketing copy. The
+// two-criterion signal requires both currency density (3+ mentions) and at
+// least one price-shaped token with letter-boundary protection.
+describe('hasFlightPriceSignal (two-criterion airline page heuristic, issue #65)', () => {
+  it('rejects a stub page with one EUR mention and no digits', () => {
+    expect(hasFlightPriceSignal('Discover EUR fares with flexible booking.')).toBe(false);
+  });
+
+  it('rejects a page with TRY embedded in INDUSTRY (lookbehind blocks the mid-word match)', () => {
+    expect(hasFlightPriceSignal('Aviation INDUSTRY 2026 entry pricing for the new industry')).toBe(false);
+  });
+
+  it('rejects EURO trip (lookahead blocks trailing letter)', () => {
+    expect(hasFlightPriceSignal('EURO trip planner 1990 - EURO destinations EURO regions')).toBe(false);
+  });
+
+  it('rejects 1-mention text even with a valid price token', () => {
+    expect(hasFlightPriceSignal('Get flights from EUR 431 today.')).toBe(false);
+  });
+
+  it('rejects 2-mention text', () => {
+    expect(hasFlightPriceSignal('Save with EUR pricing and book in EUR easily.')).toBe(false);
+  });
+
+  it('accepts a real-shaped airline results page (5+ EUR prices)', () => {
+    const text = [
+      'BRI to JFK Direct Flight Options',
+      'Turkish Airlines EUR 431 - 12h 30m - 1 stop',
+      'Lufthansa EUR 522 - 11h 45m - 1 stop',
+      'Air France EUR 480 - 13h 10m - 1 stop',
+      'KLM EUR 720 - 14h 05m - 2 stops',
+      'Alitalia EUR 1,200 - 9h 30m - nonstop',
+    ].join('\n');
+    expect(hasFlightPriceSignal(text)).toBe(true);
+  });
+
+  it('accepts symbol-form prices (€431, €99, €350)', () => {
+    expect(hasFlightPriceSignal('€431 / €99 / €350 / €480')).toBe(true);
+  });
+
+  it('accepts mixed currency tokens summing to >= 3 mentions', () => {
+    expect(hasFlightPriceSignal('USD 431 / EUR 99 / GBP 350')).toBe(true);
+  });
+
+  it('rejects a legitimate "no flights available" page with currency in chrome only (3 mentions, no token)', () => {
+    const text = 'Change currency: USD EUR GBP. No flights match your search. Try different dates.';
+    expect(hasFlightPriceSignal(text)).toBe(false);
+  });
+
+  it('accepts EUR99 (no space between code and digits)', () => {
+    expect(hasFlightPriceSignal('EUR99 EUR131 EUR205')).toBe(true);
   });
 });

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -71,6 +71,27 @@ export function isoDate(d: Date): string {
   return d.toISOString().split('T')[0]!;
 }
 
+// Issue 65: navigateAirlineDirect previously used a loose regex that accepted
+// any single currency symbol plus digit. A Turkish stub page (1964 chars,
+// "EUR" appearing in marketing copy) passed the gate, then extraction returned
+// zero prices and the cron silently saved nothing every cycle. Two-criterion
+// signal:
+//   1. Currency must be mentioned at least MIN_CURRENCY_MENTIONS times. Real
+//      airline result pages render many flight rows each with a price;
+//      marketing stubs typically mention currency 0 to 2 times in chrome.
+//   2. At least one price-shaped token (symbol or bounded code adjacent to a
+//      digit). Lookaround prevents matching "TRY" inside INDUSTRY or "EUR"
+//      inside EURO trip.
+export const CURRENCY_MENTION_PATTERN = '€|£|\\$|EUR|GBP|USD|TRY|JPY|CHF';
+export const PRICE_TOKEN_PATTERN = '(?:€|£|\\$)\\s?\\d|(?<![A-Za-z])(?:EUR|GBP|USD|TRY|JPY|CHF)(?![A-Za-z])\\s?\\d';
+export const MIN_CURRENCY_MENTIONS = 3;
+
+export function hasFlightPriceSignal(text: string): boolean {
+  const mentions = (text.match(new RegExp(CURRENCY_MENTION_PATTERN, 'g')) || []).length;
+  if (mentions < MIN_CURRENCY_MENTIONS) return false;
+  return new RegExp(PRICE_TOKEN_PATTERN).test(text);
+}
+
 function buildFlightsUrl(qPhrase: string, params: FlightSearchParams): string {
   const url = new URL('https://www.google.com/travel/flights');
   url.searchParams.set('q', qPhrase);
@@ -579,19 +600,22 @@ export async function navigateAirlineDirect(
       // No consent dialog — continue
     }
 
-    // Heuristic: check if any price-like content loaded (currency symbols or digits)
+    // Two-criterion price signal (see hasFlightPriceSignal at module top, issue 65).
     let resultsFound = false;
     try {
       await page.waitForFunction(
-        () => {
+        (params: { mention: string; token: string; min: number }) => {
           const text = document.body?.innerText ?? '';
-          return /\$\s?\d|€\s?\d|£\s?\d|USD|EUR|GBP|\d+\.\d{2}/.test(text);
+          const mentions = (text.match(new RegExp(params.mention, 'g')) || []).length;
+          if (mentions < params.min) return false;
+          return new RegExp(params.token).test(text);
         },
+        { mention: CURRENCY_MENTION_PATTERN, token: PRICE_TOKEN_PATTERN, min: MIN_CURRENCY_MENTIONS },
         { timeout: 15_000 }
       );
       resultsFound = true;
     } catch {
-      // No price content detected — page may be blocked or empty
+      // No price signal detected — page may be a stub, marketing redirect, or block.
     }
 
     const html = await page.evaluate(() => document.body.innerText);

--- a/apps/web/src/lib/scraper/run-scrape.test.ts
+++ b/apps/web/src/lib/scraper/run-scrape.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-const { mockPrisma, mockNavigateGoogleFlights, mockExtractPrices } = vi.hoisted(() => {
+const { mockPrisma, mockNavigateGoogleFlights, mockNavigateAirlineDirect, mockExtractPrices, mockIsKnownAirline } = vi.hoisted(() => {
   const mockPrisma = {
     query: { findUnique: vi.fn() },
     fetchRun: { create: vi.fn(), update: vi.fn() },
@@ -11,15 +11,17 @@ const { mockPrisma, mockNavigateGoogleFlights, mockExtractPrices } = vi.hoisted(
     apiUsageLog: { create: vi.fn() },
   };
   const mockNavigateGoogleFlights = vi.fn();
+  const mockNavigateAirlineDirect = vi.fn();
   const mockExtractPrices = vi.fn();
-  return { mockPrisma, mockNavigateGoogleFlights, mockExtractPrices };
+  const mockIsKnownAirline = vi.fn();
+  return { mockPrisma, mockNavigateGoogleFlights, mockNavigateAirlineDirect, mockExtractPrices, mockIsKnownAirline };
 });
 
 vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }));
 
 vi.mock('./navigate', () => ({
   navigateGoogleFlights: (...args: unknown[]) => mockNavigateGoogleFlights(...args),
-  navigateAirlineDirect: vi.fn(),
+  navigateAirlineDirect: (...args: unknown[]) => mockNavigateAirlineDirect(...args),
 }));
 
 vi.mock('./extract-prices', () => ({
@@ -31,7 +33,7 @@ vi.mock('./ai-registry', () => ({
 }));
 
 vi.mock('./airline-urls', () => ({
-  isKnownAirline: vi.fn().mockReturnValue(false),
+  isKnownAirline: (...args: unknown[]) => mockIsKnownAirline(...args),
 }));
 
 vi.mock('./country-profiles', () => ({
@@ -81,6 +83,7 @@ const BASE_QUERY = {
 describe('runScrapeForQuery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsKnownAirline.mockReturnValue(false);
     mockPrisma.query.findUnique.mockResolvedValue(BASE_QUERY);
     mockPrisma.fetchRun.create.mockResolvedValue({ id: 'run1' });
     mockPrisma.fetchRun.update.mockResolvedValue({});
@@ -757,6 +760,151 @@ describe('runScrapeForQuery extraction failure surfacing (issue #65)', () => {
     expect(result.status).toBe('failed');
     expect(result.error).toContain('LLM call failed');
   }, 15_000);
+});
+
+describe('runScrapeForQuery airline_direct -> google_flights diversification (issue #65)', () => {
+  const TURKISH_QUERY = {
+    ...BASE_QUERY,
+    origin: 'BRI',
+    destination: 'JFK',
+    dateFrom: new Date('2026-11-07'),
+    dateTo: new Date('2026-11-07'),
+    tripType: 'one_way',
+    preferredAirlines: ['Turkish Airlines'],
+    currency: 'EUR',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsKnownAirline.mockReturnValue(true);
+    mockPrisma.query.findUnique.mockResolvedValue(TURKISH_QUERY);
+    mockPrisma.fetchRun.create.mockResolvedValue({ id: 'run1' });
+    mockPrisma.fetchRun.update.mockResolvedValue({});
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+    });
+    mockPrisma.priceSnapshot.findMany.mockResolvedValue([]);
+    mockPrisma.priceSnapshot.createMany.mockResolvedValue({ count: 1 });
+    mockPrisma.apiUsageLog.create.mockResolvedValue({});
+    mockNavigateAirlineDirect.mockResolvedValue({
+      html: '<stub-page-1964-chars>',
+      url: 'https://www.turkishairlines.com/en-us/flights/?origin=BRI&destination=JFK',
+      resultsFound: true,
+      source: 'airline_direct',
+    });
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<google-results>',
+      url: 'https://www.google.com/travel/flights?q=BRI+to+JFK',
+      resultsFound: true,
+      source: 'google_flights',
+    });
+  });
+
+  // T3: the headline issue 65 fix. Turkish stub passes navigation but yields 0
+  // prices on extraction. Same attempt now tries Google Flights and succeeds.
+  it('falls back to Google Flights when airline_direct extracts empty_extraction', async () => {
+    mockExtractPrices
+      .mockResolvedValueOnce({
+        prices: [],
+        usage: { inputTokens: 100, outputTokens: 0 },
+        failureReason: 'empty_extraction',
+      })
+      .mockResolvedValueOnce({
+        prices: [{
+          travelDate: '2026-11-07',
+          price: 431,
+          currency: 'EUR',
+          airline: 'Turkish Airlines',
+          bookingUrl: 'https://google.com/booking',
+          stops: 1,
+          duration: '12h 30m',
+          departureTime: '10:25 AM',
+          arrivalTime: '2:55 PM',
+          seatsLeft: null,
+        }],
+        usage: { inputTokens: 200, outputTokens: 50 },
+      });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('success');
+    expect(result.snapshotsCount).toBe(1);
+    expect(mockNavigateAirlineDirect).toHaveBeenCalledTimes(1);
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(1);
+    expect(mockExtractPrices).toHaveBeenCalledTimes(2);
+
+    // FetchRun.source records the composite label so operators can grep for
+    // diversification events without a schema migration.
+    const fetchRunUpdate = mockPrisma.fetchRun.update.mock.calls[0]![0] as { data: { source: string } };
+    expect(fetchRunUpdate.data.source).toContain('airline_direct');
+    expect(fetchRunUpdate.data.source).toContain('google_flights');
+  });
+
+  // T4: real flights existed but the LLM correctly filtered them out per the
+  // user-supplied maxStops/maxPrice. That is a true signal, not a stub-page
+  // failure: diversification must NOT fire (no Google Flights navigation).
+  // The outer attempt loop still iterates on non-retryable reasons (the
+  // RETRYABLE_FAILURES gate only suppresses the inter-attempt delay), so the
+  // airline-direct call count is incidental — the diversification check is
+  // strictly: did we trigger a Google Flights navigation?
+  it('does NOT diversify when airline_direct returns all_filtered_out', async () => {
+    mockExtractPrices.mockResolvedValue({
+      prices: [],
+      usage: { inputTokens: 100, outputTokens: 10 },
+      failureReason: 'all_filtered_out',
+    });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('failed');
+    expect(mockNavigateGoogleFlights).not.toHaveBeenCalled();
+  });
+
+  // T5: a user typing "only Lufthansa flights from FRA to JFK" still gets the
+  // airline filter applied on the Google fallback extraction. Removing the
+  // auto-derive in Phase 1 was about the IMPLICIT case; explicit user intent
+  // must survive.
+  it('preserves explicit preferredAirlines on the Google fallback extractPrices call', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...TURKISH_QUERY,
+      preferredAirlines: ['Lufthansa'],
+    });
+    mockExtractPrices
+      .mockResolvedValueOnce({
+        prices: [],
+        usage: { inputTokens: 100, outputTokens: 0 },
+        failureReason: 'empty_extraction',
+      })
+      .mockResolvedValueOnce({
+        prices: [{
+          travelDate: '2026-11-07',
+          price: 522,
+          currency: 'EUR',
+          airline: 'Lufthansa',
+          bookingUrl: 'https://google.com/booking',
+          stops: 1,
+          duration: '11h 45m',
+          departureTime: '8:00 AM',
+          arrivalTime: '12:45 PM',
+          seatsLeft: null,
+        }],
+        usage: { inputTokens: 200, outputTokens: 50 },
+      });
+
+    await runScrapeForQuery('q1');
+
+    // 4th positional argument to extractPrices is the QueryFilters object
+    const googleExtractCall = mockExtractPrices.mock.calls[1];
+    expect(googleExtractCall).toBeDefined();
+    const filtersArg = googleExtractCall![3] as { preferredAirlines: string[] };
+    expect(filtersArg.preferredAirlines).toEqual(['Lufthansa']);
+  });
 });
 
 describe('PriceSnapshot schema', () => {

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -66,9 +66,14 @@ async function scrapeOneDatePair(
   let inputTokens = 0;
   let outputTokens = 0;
   let lastFailureReason: string | undefined;
+  // Hoisted so the diversification block (issue 65) can flip airline-direct off
+  // for the retry: once we know a route returns a stub on the airline site, the
+  // attempt-2 retry must skip the broken Playwright launch and go straight to
+  // Google Flights.
+  let attemptUseAirlineDirect = useAirlineDirect;
 
   async function navigateAll(): Promise<NavigationResult[]> {
-    if (useAirlineDirect) {
+    if (attemptUseAirlineDirect) {
       const results = await Promise.all(
         directAirlines.map(async (airline) => {
           try {
@@ -106,6 +111,41 @@ async function scrapeOneDatePair(
       if (result.failureReason) {
         lastFailureReason = result.failureReason;
         await saveDebugHtml(queryId, nav.html, attempt);
+      }
+    }
+
+    // Issue 65: when airline-direct navigation succeeds (stub page passes
+    // hasFlightPriceSignal) but extraction yields zero prices, fall back to
+    // Google Flights in the same attempt rather than retrying the same broken
+    // airline page. all_filtered_out is not diversifiable: that means real
+    // flights existed and the user filters excluded them.
+    const usedAirlineDirect = navResults.some((n) => n.source === 'airline_direct');
+    const usedGoogleFlights = navResults.some((n) => n.source === 'google_flights');
+    const diversifiableReasons: ExtractionFailureReason[] = ['empty_extraction', 'no_json_in_response', 'page_not_loaded', 'llm_error'];
+    const shouldDiversify =
+      usedAirlineDirect && !usedGoogleFlights && prices.length === 0 &&
+      lastFailureReason !== undefined &&
+      diversifiableReasons.includes(lastFailureReason as ExtractionFailureReason);
+    if (shouldDiversify) {
+      console.log(`[scrape] query=${queryId} pair=${travelDateFallback} diversifying airline_direct -> google_flights (reason: ${lastFailureReason})`);
+      try {
+        const gNav = await navigateGoogleFlights(pairParams, countryProfile, proxyUrl);
+        sources.add(gNav.source);
+        const gResult = await extractPrices(
+          gNav.html, gNav.url, travelDateFallback, filters, undefined, gNav.resultsFound, gNav.source, effectiveCurrency,
+        );
+        prices = prices.concat(gResult.prices);
+        inputTokens += gResult.usage.inputTokens;
+        outputTokens += gResult.usage.outputTokens;
+        if (gResult.failureReason) {
+          lastFailureReason = gResult.failureReason;
+          await saveDebugHtml(queryId, gNav.html, attempt);
+        } else {
+          lastFailureReason = undefined;
+        }
+        attemptUseAirlineDirect = false;
+      } catch (err) {
+        console.error(`[scrape] query=${queryId} pair=${travelDateFallback} google_flights diversification threw err=${err instanceof Error ? err.message : err}`);
       }
     }
 

--- a/packages/cli/src/__tests__/create-queries.test.ts
+++ b/packages/cli/src/__tests__/create-queries.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockQueryCreate, mockSnapshotCreateMany } = vi.hoisted(() => ({
+  mockQueryCreate: vi.fn().mockImplementation((args: { data: Record<string, unknown> }) =>
+    Promise.resolve({ id: 'q-' + Math.random().toString(36).slice(2, 8), ...args.data })
+  ),
+  mockSnapshotCreateMany: vi.fn().mockResolvedValue({ count: 0 }),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    query: { create: mockQueryCreate },
+    priceSnapshot: { createMany: mockSnapshotCreateMany },
+  },
+}));
+
+import { createTrackedQueries } from '../lib/create-queries.js';
+
+const baseParsed = {
+  origin: 'BRI',
+  originName: 'Bari',
+  destination: 'JFK',
+  destinationName: 'New York JFK',
+  origins: [{ code: 'BRI', name: 'Bari' }],
+  destinations: [{ code: 'JFK', name: 'New York JFK' }],
+  dateFrom: '2026-11-07',
+  dateTo: '2026-11-07',
+  flexibility: 0,
+  tripType: 'one_way' as const,
+  cabinClass: 'economy' as const,
+  maxPrice: null,
+  maxStops: null,
+  maxDurationHours: null,
+  preferredAirlines: [] as string[],
+  timePreference: 'any' as const,
+  currency: 'EUR',
+};
+
+const baseRoute = {
+  origin: 'BRI',
+  originName: 'Bari',
+  destination: 'JFK',
+  destinationName: 'New York JFK',
+  date: '2026-11-07',
+  flights: [],
+};
+
+describe('createTrackedQueries', () => {
+  beforeEach(() => {
+    mockQueryCreate.mockClear();
+    mockSnapshotCreateMany.mockClear();
+  });
+
+  // Issue 65: a picked Turkish flight used to silently flag the saved query as
+  // preferredAirlines=['Turkish'], routing cron through a broken
+  // turkishairlines.com URL forever.
+  it('does NOT auto-derive preferredAirlines from selected flights', async () => {
+    await createTrackedQueries(
+      { ...baseParsed, preferredAirlines: [] },
+      'BRI to JFK Nov 7',
+      [{
+        route: { ...baseRoute, flights: [] },
+        flights: [
+          { travelDate: '2026-11-07', price: 431, currency: 'EUR', airline: 'Turkish Airlines', bookingUrl: 'https://turkishairlines.com', stops: 1, duration: '12h 30m', departureTime: '10:25 AM', arrivalTime: '4:45 PM', seatsLeft: null, flightNumber: 'TK 1' },
+        ],
+      }],
+    );
+    const createCall = mockQueryCreate.mock.calls[0]![0] as { data: { preferredAirlines: string[] } };
+    expect(createCall.data.preferredAirlines).toEqual([]);
+  });
+
+  it('preserves explicit preferredAirlines even when selected flights contain other airlines', async () => {
+    await createTrackedQueries(
+      { ...baseParsed, preferredAirlines: ['Lufthansa'] },
+      'Lufthansa flights BRI to JFK Nov 7',
+      [{
+        route: { ...baseRoute, flights: [] },
+        flights: [
+          { travelDate: '2026-11-07', price: 431, currency: 'EUR', airline: 'Turkish Airlines', bookingUrl: 'https://turkishairlines.com', stops: 1, duration: '12h 30m', departureTime: '10:25 AM', arrivalTime: '4:45 PM', seatsLeft: null, flightNumber: 'TK 1' },
+        ],
+      }],
+    );
+    const createCall = mockQueryCreate.mock.calls[0]![0] as { data: { preferredAirlines: string[] } };
+    expect(createCall.data.preferredAirlines).toEqual(['Lufthansa']);
+  });
+});

--- a/packages/cli/src/lib/create-queries.ts
+++ b/packages/cli/src/lib/create-queries.ts
@@ -40,11 +40,6 @@ export async function createTrackedQueries(
     const routeExpiry = new Date(routeTo);
     routeExpiry.setDate(routeExpiry.getDate() + routeFlex);
 
-    let routeAirlines = parsed.preferredAirlines;
-    if (routeAirlines.length === 0 && flights.length > 0) {
-      routeAirlines = [...new Set(flights.map((f) => f.airline))];
-    }
-
     const query = await prisma.query.create({
       data: {
         rawInput,
@@ -57,7 +52,7 @@ export async function createTrackedQueries(
         flexibility: routeFlex,
         maxPrice: parsed.maxPrice,
         maxStops: parsed.maxStops,
-        preferredAirlines: routeAirlines,
+        preferredAirlines: parsed.preferredAirlines,
         timePreference: parsed.timePreference || 'any',
         cabinClass: parsed.cabinClass || 'economy',
         tripType: parsed.tripType === 'one_way' ? 'one_way' : 'round_trip',


### PR DESCRIPTION
## Summary

Fixes the cron silent-fail class reported by @antoniods97 in #65 (comment from 2026-05-13). The preview path worked correctly for BRI to JFK; the 3-hour cron job failed every cycle on the same route. Root cause was a three-layer interaction in the scraper pipeline that produced a stub-page extraction loop. Two independent reviews (Codex/GPT and a fresh Opus critique) confirmed the diagnosis; three /critique-plan rounds shaped the implementation.

## Why it happened

1. `apps/web/src/app/api/queries/route.ts:120-126` (and the CLI duplicate at `packages/cli/src/lib/create-queries.ts:43-46`) auto-derived `preferredAirlines` from the user-picked flights in the preview picker. Picking a Turkish flight at €431 silently flagged the saved Query as `preferredAirlines=['Turkish Airlines']` even though the user never asked for an airline filter.
2. `apps/web/src/lib/scraper/run-scrape.ts:136-137` treats `preferredAirlines` as a navigation strategy: `useAirlineDirect = directAirlines.length > 0`. So cron stopped consulting Google Flights and went straight to `https://www.turkishairlines.com/...?origin=BRI&destination=JFK&...`.
3. Turkish's booking site does not accept raw IATA codes. It auto-resolves BRI to Lecce and renders a 1964 char marketing stub.
4. `navigate.ts:584-595` accepted any single currency-symbol-plus-digit page as `resultsFound=true`. The stub contained "EUR" in marketing copy. Heuristic passed.
5. `run-scrape.ts:70-90` only fell back to Google Flights when ALL airline-direct navigations returned `resultsFound=false`. Turkish "succeeded" navigation, so no fallback. Gemini extraction returned `[]`, marked `empty_extraction`. Next attempt hit the same stub. Loop forever.

Preview never tripped this because preview's `preferredAirlines` came from the natural-language LLM parse (empty for "BRI to JFK Nov 7") and preview's airline-direct gate requires `length === 1`.

## What changed

Four commits, each a discrete phase that leaves the codebase in a working state:

| Commit | File | Change |
|---|---|---|
| `2152844` | `queries/route.ts` + `create-queries.ts` (CLI) | Stop auto-deriving `preferredAirlines` from picked flights. Picked flights still seed the initial PriceSnapshot at `route.ts:163-176`; they no longer poison cron navigation. |
| `a4f6bfc` | `navigate.ts` | New `hasFlightPriceSignal` helper. Two-criterion check: currency density (3+ mentions) AND a letter-bounded price token. Stub rejects, `EUR99`/`EUR 1,200`/`€431`/`EUR 1.299` accept. `EURO` and `INDUSTRY` correctly blocked via lookaround. |
| `4c2caba` | `run-scrape.ts` | `scrapeOneDatePair` diversifies to Google Flights when `airline_direct` extracts zero prices with `empty_extraction`/`no_json_in_response`/`page_not_loaded`/`llm_error`. Does NOT diversify on `all_filtered_out` (real flights, filters worked). Hoisted `attemptUseAirlineDirect` is flipped off after diversification so attempt-2 retry skips the broken airline launch. Composite `FetchRun.source` label (`airline_direct+google_flights`) lets operators grep historical fetch runs without a schema migration. |
| `b176517` | `CHANGELOG.md` | Unreleased entry. |

## What this also fixes

- antoniods97's existing frozen BRI to JFK rows recover via the diversification fallback (phase 3); no DB migration needed for legacy `preferredAirlines` pollution.
- Multi-airline pick amplification (where 2+ airlines in `preferredAirlines` fired in parallel and any single stub success blocked Google fallback) is closed by the same diversification path.

## What this does NOT change

- Explicit user intent: a query like "only Lufthansa flights from FRA to JFK" still routes through airline-direct first, and the `filters.preferredAirlines` filter is preserved on the Google fallback if airline-direct fails. T5 locks this in.
- `all_filtered_out` semantics: real flights that the user's `maxStops`/`maxPrice`/`maxDurationHours` filters legitimately excluded do NOT trigger a redundant Google scrape. T4 locks this in.

## Test plan

- [x] `npm run ci` passes: 509 tests across 32 files (+13 new vs main).
- [x] T1 + T2 (`route.test.ts`): empty `preferredAirlines` + picked Turkish flight yields `preferredAirlines=[]`; explicit `preferredAirlines: ['Lufthansa']` preserved.
- [x] CLI smoke test (new file `packages/cli/src/__tests__/create-queries.test.ts`): same invariants for the CLI path.
- [x] 10 new cases for `hasFlightPriceSignal` in `navigate.test.ts` cover stub rejection (1 mention), `INDUSTRY` false positive blocked, `EURO` false positive blocked, real-shaped multi-row page accepted, symbol-only prices accepted, mixed currency tokens accepted, no-results chrome-only page rejected, no-space `EUR99` accepted.
- [x] T3 + T4 + T5 (`run-scrape.test.ts`): diversification on `empty_extraction`; no diversification on `all_filtered_out`; explicit `preferredAirlines` survives into Google fallback `filters` arg.
- [ ] Manual verification on @antoniods97's BRI to JFK route once deployed.

## Review process

- Two independent second-opinion reviews on the diagnosis before any code: `/codex` (GPT, adversarial) and a fresh Opus subagent. Both confirmed root cause and surfaced two amplifiers I had missed.
- Three `/critique-plan` rounds on the implementation plan with fresh Opus agents. Round 1 caught the CLI duplicate and a too-loose regex. Round 2 caught a too-tight regex that would have false-negative-rejected real airline prices (`EUR 1,200`, `EUR 1.299`). Round 3 caught a mock-setup blocker in `run-scrape.test.ts` that would have failed Phase 3 tests.

Related to #65 (reporter wants to verify before closing).
