### PR TITLE
feat: unified tracking link and dates for flex queries (#78)

### DIFF
--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -3,6 +3,7 @@ import { redirect, notFound } from 'next/navigation';
 import { prisma } from '@/lib/prisma';
 import { isMultiUserEnabled } from '@/lib/multi-user';
 import { getCurrentUser } from '@/lib/user-auth';
+import { groupQueries, type GroupableQuery } from '@/lib/query-grouping';
 import styles from './page.module.css';
 
 export const dynamic = 'force-dynamic';
@@ -27,11 +28,31 @@ export default async function AccountPage() {
       active: true,
       expiresAt: true,
       createdAt: true,
+      groupId: true,
+      scrapeInterval: true,
       _count: { select: { snapshots: true } },
     },
   });
 
-  const fmt = (d: Date) => d.toISOString().split('T')[0];
+  const groupable: GroupableQuery[] = queries.map((q) => ({
+    id: q.id,
+    origin: q.origin,
+    destination: q.destination,
+    originName: q.originName,
+    destinationName: q.destinationName,
+    dateFrom: q.dateFrom.toISOString(),
+    dateTo: q.dateTo.toISOString(),
+    groupId: q.groupId,
+    active: q.active,
+    expiresAt: q.expiresAt.toISOString(),
+    scrapeInterval: q.scrapeInterval,
+    snapshotCount: q._count.snapshots,
+    createdAt: q.createdAt.toISOString(),
+  }));
+
+  const groups = groupQueries(groupable);
+
+  const fmt = (iso: string) => iso.split('T')[0];
 
   return (
     <main className={styles.root}>
@@ -50,25 +71,32 @@ export default async function AccountPage() {
 
       <section className={styles.section}>
         <h2 className={styles.sectionTitle}>Your trackers</h2>
-        {queries.length === 0 ? (
+        {groups.length === 0 ? (
           <p className={styles.empty}>
             No trackers yet. <Link href="/">Search for a flight</Link> to get started.
           </p>
         ) : (
           <div className={styles.list}>
-            {queries.map((q) => (
-              <Link key={q.id} href={`/q/${q.id}`} className={styles.row}>
-                <div className={styles.rowRoute}>
-                  <span className={styles.rowCode}>{q.origin}</span>
-                  <span className={styles.rowArrow}>→</span>
-                  <span className={styles.rowCode}>{q.destination}</span>
-                </div>
-                <div className={styles.rowMeta}>
-                  {fmt(q.dateFrom)} {' '} {fmt(q.dateTo)} {' '} {q._count.snapshots} snapshots
-                  {!q.active && <span className={styles.paused}>paused</span>}
-                </div>
-              </Link>
-            ))}
+            {groups.map((g) => {
+              const extraDestinations = g.destinations.length - 1;
+              return (
+                <Link key={g.primaryId} href={`/q/${g.primaryId}`} className={styles.row}>
+                  <div className={styles.rowRoute}>
+                    <span className={styles.rowCode}>{g.origin}</span>
+                    <span className={styles.rowArrow}>→</span>
+                    <span className={styles.rowCode}>{g.destination}</span>
+                    {extraDestinations > 0 && (
+                      <span className={styles.rowMeta}>+ {extraDestinations} more</span>
+                    )}
+                  </div>
+                  <div className={styles.rowMeta}>
+                    {fmt(g.dateFrom)} {' '} {fmt(g.dateTo)} {' '} {g.snapshotCount} snapshots
+                    {g.routeCount > 1 && ` · ${g.routeCount} charts`}
+                    {!g.anyActive && <span className={styles.paused}>paused</span>}
+                  </div>
+                </Link>
+              );
+            })}
           </div>
         )}
       </section>

--- a/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
+++ b/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
@@ -1,16 +1,10 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { type QueryGroup, type GroupableQuery } from '@/lib/query-grouping';
 import styles from './page.module.css';
 
-interface QueryData {
-  id: string;
-  origin: string;
-  originName: string;
-  destination: string;
-  destinationName: string;
-  dateFrom: string;
-  dateTo: string;
+export interface AdminQuery extends GroupableQuery {
   active: boolean;
   expiresAt: string;
   scrapeInterval: number | null;
@@ -22,28 +16,36 @@ function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
-export function QueryRow({ query }: { query: QueryData }) {
+export function QueryGroupRow({ group }: { group: QueryGroup<AdminQuery> }) {
   const router = useRouter();
-  const expired = new Date() > new Date(query.expiresAt);
+  const expired = group.allExpired;
+  const runCount = group.queries.reduce((sum, q) => sum + q.runCount, 0);
+  const extraDestinations = group.destinations.length - 1;
 
   const handleToggle = async () => {
-    await fetch(`/api/admin/queries/${query.id}`, {
+    await fetch(`/api/queries/${group.primaryId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ active: !query.active }),
+      body: JSON.stringify({ active: !group.anyActive }),
     });
     router.refresh();
   };
 
   const handleDelete = async () => {
-    if (!confirm(`Delete tracker for ${query.origin} → ${query.destination}?`)) return;
-    await fetch(`/api/admin/queries/${query.id}`, { method: 'DELETE' });
+    const label = `${group.origin} → ${group.destination}`;
+    const suffix = group.routeCount > 1 ? ` (${group.routeCount} charts)?` : '?';
+    if (!confirm(`Delete tracker for ${label}${suffix}`)) return;
+    await fetch(`/api/queries/${group.primaryId}`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ groupDelete: group.routeCount > 1 }),
+    });
     router.refresh();
   };
 
   const handleIntervalChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value === '' ? null : Number(e.target.value);
-    await fetch(`/api/admin/queries/${query.id}`, {
+    await fetch(`/api/queries/${group.primaryId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ scrapeInterval: value }),
@@ -54,21 +56,27 @@ export function QueryRow({ query }: { query: QueryData }) {
   return (
     <div className={styles.row}>
       <div className={styles.rowRoute}>
-        <span className={styles.rowCode}>{query.origin}</span>
+        <span className={styles.rowCode}>{group.origin}</span>
         <span className={styles.rowArrow}>→</span>
-        <span className={styles.rowCode}>{query.destination}</span>
+        <span className={styles.rowCode}>{group.destination}</span>
+        {extraDestinations > 0 && (
+          <span className={styles.rowGroupTag}>+ {extraDestinations} more</span>
+        )}
+        {group.routeCount > 1 && (
+          <span className={styles.rowGroupTag}>{group.routeCount} charts</span>
+        )}
       </div>
       <div className={styles.rowMeta}>
-        <span>{formatDate(query.dateFrom)} — {formatDate(query.dateTo)}</span>
+        <span>{formatDate(group.dateFrom)} — {formatDate(group.dateTo)}</span>
         <span className={styles.rowSep}>·</span>
-        <span>{query.snapshotCount} snapshots</span>
+        <span>{group.snapshotCount} snapshots</span>
         <span className={styles.rowSep}>·</span>
-        <span>{query.runCount} runs</span>
+        <span>{runCount} runs</span>
       </div>
       <div className={styles.rowActions}>
         <select
           className={styles.intervalSelect}
-          value={query.scrapeInterval ?? ''}
+          value={group.scrapeInterval ?? ''}
           onChange={handleIntervalChange}
         >
           <option value="">Follow global</option>
@@ -79,13 +87,13 @@ export function QueryRow({ query }: { query: QueryData }) {
           <option value={24}>Every 24h</option>
         </select>
         <button
-          className={query.active ? styles.pauseButton : styles.resumeButton}
+          className={group.anyActive ? styles.pauseButton : styles.resumeButton}
           onClick={handleToggle}
           disabled={expired}
         >
-          {expired ? 'Expired' : query.active ? 'Pause' : 'Resume'}
+          {expired ? 'Expired' : group.anyActive ? 'Pause' : 'Resume'}
         </button>
-        <a href={`/q/${query.id}`} className={styles.viewLink} target="_blank" rel="noopener noreferrer">
+        <a href={`/q/${group.primaryId}`} className={styles.viewLink} target="_blank" rel="noopener noreferrer">
           View
         </a>
         <button className={styles.deleteButton} onClick={handleDelete}>

--- a/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
+++ b/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
@@ -23,7 +23,7 @@ export function QueryGroupRow({ group }: { group: QueryGroup<AdminQuery> }) {
   const extraDestinations = group.destinations.length - 1;
 
   const handleToggle = async () => {
-    await fetch(`/api/queries/${group.primaryId}`, {
+    await fetch(`/api/admin/queries/${group.primaryId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ active: !group.anyActive }),
@@ -35,7 +35,7 @@ export function QueryGroupRow({ group }: { group: QueryGroup<AdminQuery> }) {
     const label = `${group.origin} → ${group.destination}`;
     const suffix = group.routeCount > 1 ? ` (${group.routeCount} charts)?` : '?';
     if (!confirm(`Delete tracker for ${label}${suffix}`)) return;
-    await fetch(`/api/queries/${group.primaryId}`, {
+    await fetch(`/api/admin/queries/${group.primaryId}`, {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ groupDelete: group.routeCount > 1 }),
@@ -45,7 +45,7 @@ export function QueryGroupRow({ group }: { group: QueryGroup<AdminQuery> }) {
 
   const handleIntervalChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value === '' ? null : Number(e.target.value);
-    await fetch(`/api/queries/${group.primaryId}`, {
+    await fetch(`/api/admin/queries/${group.primaryId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ scrapeInterval: value }),

--- a/apps/web/src/app/admin/(dashboard)/queries/page.module.css
+++ b/apps/web/src/app/admin/(dashboard)/queries/page.module.css
@@ -54,6 +54,18 @@
   color: var(--muted);
 }
 
+.rowGroupTag {
+  margin-left: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  letter-spacing: 0.02em;
+}
+
 .rowMeta {
   display: flex;
   align-items: center;

--- a/apps/web/src/app/admin/(dashboard)/queries/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/queries/page.tsx
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma';
-import { QueryRow } from './QueryRow';
+import { groupQueries } from '@/lib/query-grouping';
+import { QueryGroupRow, type AdminQuery } from './QueryRow';
 import styles from './page.module.css';
 
 export const dynamic = 'force-dynamic';
@@ -12,34 +13,37 @@ export default async function QueriesPage() {
     },
   });
 
+  const adminRows: AdminQuery[] = queries.map((q) => ({
+    id: q.id,
+    origin: q.origin,
+    originName: q.originName,
+    destination: q.destination,
+    destinationName: q.destinationName,
+    dateFrom: q.dateFrom.toISOString(),
+    dateTo: q.dateTo.toISOString(),
+    groupId: q.groupId,
+    active: q.active,
+    expiresAt: q.expiresAt.toISOString(),
+    scrapeInterval: q.scrapeInterval,
+    snapshotCount: q._count.snapshots,
+    runCount: q._count.fetchRuns,
+    createdAt: q.createdAt.toISOString(),
+  }));
+
+  const groups = groupQueries(adminRows);
+
   return (
     <div className={styles.root}>
       <h1 className={styles.title}>Tracked Queries</h1>
 
-      {queries.length === 0 ? (
+      {groups.length === 0 ? (
         <p className={styles.empty}>
           No queries yet. Go to the <a href="/">home page</a> to create one.
         </p>
       ) : (
         <div className={styles.list}>
-          {queries.map((q) => (
-            <QueryRow
-              key={q.id}
-              query={{
-                id: q.id,
-                origin: q.origin,
-                originName: q.originName,
-                destination: q.destination,
-                destinationName: q.destinationName,
-                dateFrom: q.dateFrom.toISOString(),
-                dateTo: q.dateTo.toISOString(),
-                active: q.active,
-                expiresAt: q.expiresAt.toISOString(),
-                scrapeInterval: q.scrapeInterval,
-                snapshotCount: q._count.snapshots,
-                runCount: q._count.fetchRuns,
-              }}
-            />
+          {groups.map((group) => (
+            <QueryGroupRow key={group.primaryId} group={group} />
           ))}
         </div>
       )}

--- a/apps/web/src/app/api/admin/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/admin/queries/[id]/route.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockQueryFindUnique = vi.fn();
+const mockQueryUpdate = vi.fn();
+const mockQueryUpdateMany = vi.fn();
+const mockQueryDelete = vi.fn();
+const mockQueryDeleteMany = vi.fn();
+const mockUserFindUnique = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    query: {
+      findUnique: (...args: unknown[]) => mockQueryFindUnique(...args),
+      update: (...args: unknown[]) => mockQueryUpdate(...args),
+      updateMany: (...args: unknown[]) => mockQueryUpdateMany(...args),
+      delete: (...args: unknown[]) => mockQueryDelete(...args),
+      deleteMany: (...args: unknown[]) => mockQueryDeleteMany(...args),
+    },
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+    },
+  },
+}));
+
+vi.mock('@/lib/admin-guard', () => ({
+  requireAdminApi: () => Promise.resolve(null),
+}));
+
+import { DELETE, PATCH } from './route';
+
+function patchRequest(id: string, body: Record<string, unknown>): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost/api/admin/queries/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+function deleteRequest(id: string, body?: Record<string, unknown>): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost/api/admin/queries/${id}`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : '{}',
+    }),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+describe('admin PATCH /api/admin/queries/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryUpdate.mockResolvedValue({});
+    mockQueryUpdateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('cascades active to every sibling when the query has a groupId', async () => {
+    mockQueryFindUnique.mockResolvedValue({ groupId: 'g1' });
+    mockQueryUpdateMany.mockResolvedValue({ count: 3 });
+    const res = await PATCH(...patchRequest('q1', { active: false }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data).toMatchObject({ active: false, updated: 3 });
+    expect(mockQueryUpdateMany).toHaveBeenCalledWith({
+      where: { groupId: 'g1' },
+      data: { active: false },
+    });
+    expect(mockQueryUpdate).not.toHaveBeenCalled();
+  });
+
+  it('cascades scrapeInterval to siblings', async () => {
+    mockQueryFindUnique.mockResolvedValue({ groupId: 'g1' });
+    mockQueryUpdateMany.mockResolvedValue({ count: 2 });
+    const res = await PATCH(...patchRequest('q1', { scrapeInterval: 6 }));
+    expect(res.status).toBe(200);
+    expect(mockQueryUpdateMany).toHaveBeenCalledWith({
+      where: { groupId: 'g1' },
+      data: { scrapeInterval: 6 },
+    });
+  });
+
+  it('updates single row when query has no groupId', async () => {
+    mockQueryFindUnique.mockResolvedValue({ groupId: null });
+    const res = await PATCH(...patchRequest('q1', { active: true }));
+    expect(res.status).toBe(200);
+    expect(mockQueryUpdate).toHaveBeenCalledWith({
+      where: { id: 'q1' },
+      data: { active: true },
+    });
+    expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('keeps userId reassignment single-row even on a grouped query', async () => {
+    mockQueryFindUnique.mockResolvedValue({ groupId: 'g1' });
+    mockUserFindUnique.mockResolvedValue({ id: 'user_42' });
+    const res = await PATCH(...patchRequest('q1', { userId: 'user_42' }));
+    expect(res.status).toBe(200);
+    expect(mockQueryUpdate).toHaveBeenCalledWith({
+      where: { id: 'q1' },
+      data: { userId: 'user_42' },
+    });
+    expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin DELETE /api/admin/queries/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryDelete.mockResolvedValue({});
+    mockQueryDeleteMany.mockResolvedValue({ count: 0 });
+  });
+
+  it('deletes the whole group when groupDelete=true', async () => {
+    mockQueryFindUnique.mockResolvedValue({ groupId: 'g1' });
+    mockQueryDeleteMany.mockResolvedValue({ count: 4 });
+    const res = await DELETE(...deleteRequest('q1', { groupDelete: true }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data).toEqual({ deleted: true, groupDeleted: true, count: 4 });
+    expect(mockQueryDeleteMany).toHaveBeenCalledWith({ where: { groupId: 'g1' } });
+    expect(mockQueryDelete).not.toHaveBeenCalled();
+  });
+
+  it('falls back to single-row delete when groupId is null even if groupDelete=true', async () => {
+    mockQueryFindUnique.mockResolvedValue({ groupId: null });
+    const res = await DELETE(...deleteRequest('q1', { groupDelete: true }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data).toEqual({ deleted: true, groupDeleted: false });
+    expect(mockQueryDelete).toHaveBeenCalledWith({ where: { id: 'q1' } });
+    expect(mockQueryDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it('deletes single row when groupDelete is omitted', async () => {
+    mockQueryFindUnique.mockResolvedValue({ groupId: 'g1' });
+    const res = await DELETE(...deleteRequest('q1'));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data).toEqual({ deleted: true, groupDeleted: false });
+    expect(mockQueryDelete).toHaveBeenCalledWith({ where: { id: 'q1' } });
+    expect(mockQueryDeleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/admin/queries/[id]/route.ts
+++ b/apps/web/src/app/api/admin/queries/[id]/route.ts
@@ -3,6 +3,11 @@ import { apiSuccess, apiError } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
 import { requireAdminApi } from '@/lib/admin-guard';
 
+// Fields that cascade across a query's group when groupId is set. userId
+// reassignment stays single-row because it would not make sense to move an
+// entire group to a different owner via a UI nudge.
+const GROUP_CASCADING_FIELDS = new Set(['active', 'scrapeInterval', 'maxDurationHours']);
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -14,7 +19,7 @@ export async function PATCH(
   const body = await request.json().catch(() => null);
   if (!body) return apiError('Invalid JSON body', 400);
 
-  const existing = await prisma.query.findUnique({ where: { id } });
+  const existing = await prisma.query.findUnique({ where: { id }, select: { groupId: true } });
   if (!existing) return apiError('Query not found', 404);
 
   const data: Record<string, unknown> = {};
@@ -38,12 +43,26 @@ export async function PATCH(
     data.userId = body.userId;
   }
 
+  // Cascade group-safe fields to every sibling when this query is part of a
+  // group, mirroring the user PATCH route's behavior. Owner reassignment is
+  // single-row only.
+  const updatedKeys = Object.keys(data);
+  const cascade = existing.groupId && updatedKeys.every((k) => GROUP_CASCADING_FIELDS.has(k));
+
+  if (cascade && existing.groupId) {
+    const result = await prisma.query.updateMany({
+      where: { groupId: existing.groupId },
+      data,
+    });
+    return apiSuccess({ ...data, updated: result.count });
+  }
+
   const updated = await prisma.query.update({ where: { id }, data });
   return apiSuccess(updated);
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const denial = await requireAdminApi();
@@ -51,9 +70,17 @@ export async function DELETE(
 
   const { id } = await params;
 
-  const existing = await prisma.query.findUnique({ where: { id } });
+  const body = await request.json().catch(() => null);
+  const groupDelete = body?.groupDelete === true;
+
+  const existing = await prisma.query.findUnique({ where: { id }, select: { groupId: true } });
   if (!existing) return apiError('Query not found', 404);
 
+  if (groupDelete && existing.groupId) {
+    const result = await prisma.query.deleteMany({ where: { groupId: existing.groupId } });
+    return apiSuccess({ deleted: true, groupDeleted: true, count: result.count });
+  }
+
   await prisma.query.delete({ where: { id } });
-  return apiSuccess({ deleted: true });
+  return apiSuccess({ deleted: true, groupDeleted: false });
 }

--- a/apps/web/src/app/api/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 
 const mockQueryFindUnique = vi.fn();
 const mockQueryDelete = vi.fn();
+const mockQueryDeleteMany = vi.fn();
 const mockQueryFindMany = vi.fn();
 const mockQueryUpdateMany = vi.fn();
 
@@ -11,6 +12,7 @@ vi.mock('@/lib/prisma', () => ({
     query: {
       findUnique: (...args: unknown[]) => mockQueryFindUnique(...args),
       delete: (...args: unknown[]) => mockQueryDelete(...args),
+      deleteMany: (...args: unknown[]) => mockQueryDeleteMany(...args),
       findMany: (...args: unknown[]) => mockQueryFindMany(...args),
       updateMany: (...args: unknown[]) => mockQueryUpdateMany(...args),
     },
@@ -45,6 +47,7 @@ describe('DELETE /api/queries/[id]', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQueryDelete.mockResolvedValue({});
+    mockQueryDeleteMany.mockResolvedValue({ count: 0 });
     mockIsMultiUserEnabled.mockResolvedValue(false);
     mockGetCurrentUser.mockResolvedValue(null);
     delete process.env.SELF_HOSTED;
@@ -165,6 +168,69 @@ describe('DELETE /api/queries/[id]', () => {
       expect(res.status).toBe(403);
     });
   });
+
+  describe('groupDelete', () => {
+    it('deletes all siblings via deleteMany when groupDelete=true (hosted)', async () => {
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: 'g1', userId: null });
+      mockQueryDeleteMany.mockResolvedValue({ count: 3 });
+      const res = await DELETE(...makeDeleteRequest('q1', { deleteToken: 'real-token', groupDelete: true }));
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.data).toEqual({ deleted: true, groupDeleted: true, count: 3 });
+      expect(mockQueryDeleteMany).toHaveBeenCalledWith({ where: { groupId: 'g1' } });
+      expect(mockQueryDelete).not.toHaveBeenCalled();
+    });
+
+    it('rejects groupDelete with wrong token (hosted, no deleteMany call)', async () => {
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: 'g1', userId: null });
+      const res = await DELETE(...makeDeleteRequest('q1', { deleteToken: 'wrong', groupDelete: true }));
+      expect(res.status).toBe(403);
+      expect(mockQueryDeleteMany).not.toHaveBeenCalled();
+      expect(mockQueryDelete).not.toHaveBeenCalled();
+    });
+
+    it('admin can groupDelete without token in multi user mode', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockIsMultiUserEnabled.mockResolvedValue(true);
+      mockGetCurrentUser.mockResolvedValue({ id: 'admin_1', isAdmin: true });
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: 'g1', userId: 'someone_else' });
+      mockQueryDeleteMany.mockResolvedValue({ count: 2 });
+      const res = await DELETE(...makeDeleteRequest('q1', { groupDelete: true }));
+      expect(res.status).toBe(200);
+      expect(mockQueryDeleteMany).toHaveBeenCalledWith({ where: { groupId: 'g1' } });
+    });
+
+    it('owner can groupDelete via user session in multi user mode', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockIsMultiUserEnabled.mockResolvedValue(true);
+      mockGetCurrentUser.mockResolvedValue({ id: 'user_1', isAdmin: false });
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: 'g1', userId: 'user_1' });
+      mockQueryDeleteMany.mockResolvedValue({ count: 4 });
+      const res = await DELETE(...makeDeleteRequest('q1', { groupDelete: true }));
+      expect(res.status).toBe(200);
+      expect(mockQueryDeleteMany).toHaveBeenCalledWith({ where: { groupId: 'g1' } });
+    });
+
+    it('falls back to single-row delete when groupId is null even if groupDelete=true', async () => {
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: null, userId: null });
+      const res = await DELETE(...makeDeleteRequest('q1', { deleteToken: 'real-token', groupDelete: true }));
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.data).toEqual({ deleted: true, groupDeleted: false });
+      expect(mockQueryDelete).toHaveBeenCalledWith({ where: { id: 'q1' } });
+      expect(mockQueryDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it('single-row delete still works when groupDelete omitted on a grouped row', async () => {
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: 'g1', userId: null });
+      const res = await DELETE(...makeDeleteRequest('q1', { deleteToken: 'real-token' }));
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.data).toEqual({ deleted: true, groupDeleted: false });
+      expect(mockQueryDelete).toHaveBeenCalledWith({ where: { id: 'q1' } });
+      expect(mockQueryDeleteMany).not.toHaveBeenCalled();
+    });
+  });
 });
 
 function makePatchRequest(id: string, body: Record<string, unknown>): [NextRequest, { params: Promise<{ id: string }> }] {
@@ -220,5 +286,73 @@ describe('PATCH /api/queries/[id]', () => {
     mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null });
     const res = await PATCH(...makePatchRequest('q1', { scrapeInterval: 99 }));
     expect(res.status).toBe(400);
+  });
+
+  it('rejects empty body (no updatable fields)', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null });
+    const res = await PATCH(...makePatchRequest('q1', {}));
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.error).toContain('No updatable fields');
+  });
+
+  describe('active toggle', () => {
+    it('updates active with valid token (hosted) and cascades by groupId', async () => {
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: 'g1', userId: null });
+      mockQueryFindMany.mockResolvedValue([{ id: 'q2' }, { id: 'q3' }]);
+      mockQueryUpdateMany.mockResolvedValue({ count: 3 });
+      const res = await PATCH(...makePatchRequest('q1', { deleteToken: 'real-token', active: false }));
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.data).toMatchObject({ active: false, updated: 3 });
+      expect(mockQueryUpdateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['q1', 'q2', 'q3'] } },
+        data: { active: false },
+      });
+    });
+
+    it('updates active without cascade when groupId is null', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { active: true }));
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.data).toMatchObject({ active: true, updated: 1 });
+      expect(mockQueryUpdateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['q1'] } },
+        data: { active: true },
+      });
+    });
+
+    it('rejects non-boolean active', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { active: 'yes' }));
+      const data = await res.json();
+      expect(res.status).toBe(400);
+      expect(data.error).toContain('active');
+    });
+
+    it('updates both scrapeInterval and active in one call', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: 'g1', userId: null });
+      mockQueryFindMany.mockResolvedValue([{ id: 'q2' }]);
+      const res = await PATCH(...makePatchRequest('q1', { scrapeInterval: 3, active: true }));
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.data).toMatchObject({ scrapeInterval: 3, active: true, updated: 2 });
+      expect(mockQueryUpdateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['q1', 'q2'] } },
+        data: { scrapeInterval: 3, active: true },
+      });
+    });
+
+    it('rejects active toggle without token (hosted)', async () => {
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token', groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { active: false }));
+      expect(res.status).toBe(401);
+      expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/app/api/queries/[id]/route.ts
+++ b/apps/web/src/app/api/queries/[id]/route.ts
@@ -75,15 +75,30 @@ export async function PATCH(
   const auth = await authorizeMutation(query, token);
   if (!auth.ok) return apiError(auth.error ?? 'Forbidden', auth.status ?? 403);
 
-  // Accept null (means "follow global") or one of the allowed numeric intervals.
-  let interval: number | null;
-  if (body.scrapeInterval === null) {
-    interval = null;
-  } else {
-    interval = Number(body.scrapeInterval);
-    if (!ALLOWED_INTERVALS.includes(interval)) {
-      return apiError(`scrapeInterval must be null or one of: ${ALLOWED_INTERVALS.join(', ')}`, 400);
+  const updateData: { scrapeInterval?: number | null; active?: boolean } = {};
+
+  if (body && Object.prototype.hasOwnProperty.call(body, 'scrapeInterval')) {
+    let interval: number | null;
+    if (body.scrapeInterval === null) {
+      interval = null;
+    } else {
+      interval = Number(body.scrapeInterval);
+      if (!ALLOWED_INTERVALS.includes(interval)) {
+        return apiError(`scrapeInterval must be null or one of: ${ALLOWED_INTERVALS.join(', ')}`, 400);
+      }
     }
+    updateData.scrapeInterval = interval;
+  }
+
+  if (body && Object.prototype.hasOwnProperty.call(body, 'active')) {
+    if (typeof body.active !== 'boolean') {
+      return apiError('active must be a boolean', 400);
+    }
+    updateData.active = body.active;
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    return apiError('No updatable fields supplied', 400);
   }
 
   // Update this query and all siblings in the group
@@ -98,10 +113,10 @@ export async function PATCH(
 
   await prisma.query.updateMany({
     where: { id: { in: idsToUpdate } },
-    data: { scrapeInterval: interval },
+    data: updateData,
   });
 
-  return apiSuccess({ scrapeInterval: interval, updated: idsToUpdate.length });
+  return apiSuccess({ ...updateData, updated: idsToUpdate.length });
 }
 
 export async function DELETE(
@@ -112,10 +127,11 @@ export async function DELETE(
 
   const body = await request.json().catch(() => null);
   const token = body?.deleteToken;
+  const groupDelete = body?.groupDelete === true;
 
   const query = await prisma.query.findUnique({
     where: { id },
-    select: { deleteToken: true, userId: true },
+    select: { deleteToken: true, groupId: true, userId: true },
   });
 
   if (!query) {
@@ -125,7 +141,12 @@ export async function DELETE(
   const auth = await authorizeMutation(query, token);
   if (!auth.ok) return apiError(auth.error ?? 'Forbidden', auth.status ?? 403);
 
+  if (groupDelete && query.groupId) {
+    const result = await prisma.query.deleteMany({ where: { groupId: query.groupId } });
+    return apiSuccess({ deleted: true, groupDeleted: true, count: result.count });
+  }
+
   await prisma.query.delete({ where: { id } });
 
-  return apiSuccess({ deleted: true });
+  return apiSuccess({ deleted: true, groupDeleted: false });
 }

--- a/apps/web/src/app/q/[id]/page.module.css
+++ b/apps/web/src/app/q/[id]/page.module.css
@@ -131,7 +131,7 @@
 
 .routeBlockHeader {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 0.5rem;
   flex-wrap: wrap;
 }
@@ -153,6 +153,14 @@
   font-size: 0.875rem;
   color: var(--text-secondary);
   margin-left: 0.5rem;
+}
+
+.routeBlockDate {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
 }
 
 /* Sections */

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -11,6 +11,7 @@ import { ScrapeInterval } from '@/components/ScrapeInterval';
 import { ChartActions } from '@/components/ChartActions';
 import { PriceCalendar } from '@/components/PriceCalendar';
 import { Footer } from '@/components/Footer';
+import { StackedSortControls, type StackedItem } from '@/components/StackedSortControls';
 import styles from './page.module.css';
 
 interface Props {
@@ -86,6 +87,87 @@ interface QueryWithSnapshots {
   }>;
   lastRun: { startedAt: Date } | null;
   globalScrapeInterval: number;
+}
+
+function renderRouteBlock(qData: QueryWithSnapshots, isMultiRoute: boolean) {
+  const isRoundTrip = qData.query.tripType === 'round_trip';
+  const hasDistinctReturn = qData.query.dateFrom.getTime() < qData.query.dateTo.getTime();
+  const dateLabel = isRoundTrip && hasDistinctReturn
+    ? `${formatDate(qData.query.dateFrom)} → ${formatDate(qData.query.dateTo)}`
+    : formatDate(qData.query.dateFrom);
+
+  return (
+    <div key={qData.query.id} className={styles.routeBlock}>
+      {isMultiRoute && (
+        <div className={styles.routeBlockHeader}>
+          <span className={styles.routeBlockCode}>{qData.query.origin}</span>
+          <span className={styles.routeBlockArrow}>→</span>
+          <span className={styles.routeBlockCode}>{qData.query.destination}</span>
+          <span className={styles.routeBlockName}>
+            {qData.query.originName} to {qData.query.destinationName}
+          </span>
+          <span className={styles.routeBlockDate}>{dateLabel}</span>
+        </div>
+      )}
+
+      <section className={styles.chart}>
+        <PriceChart snapshots={qData.snapshots} currency={qData.query.currency ?? 'USD'} />
+        {qData.query.vpnCountries.length > 0 && !qData.snapshots.some((s) => s.vpnCountry) && (
+          <p className={styles.vpnPending}>
+            VPN comparison in progress -- prices from {qData.query.vpnCountries.map((c) =>
+              String.fromCodePoint(...c.split('').map((ch) => 0x1f1e6 + ch.charCodeAt(0) - 65)) + ' ' + c
+            ).join(', ')} will appear after the next scrape
+          </p>
+        )}
+      </section>
+
+      <section className={styles.best}>
+        <BestPrice snapshots={qData.snapshots} />
+      </section>
+
+      <section className={styles.history}>
+        <PriceHistory snapshots={qData.snapshots} />
+      </section>
+
+      <section className={styles.calendar}>
+        <PriceCalendar snapshots={qData.snapshots} currency={qData.query.currency ?? 'USD'} />
+      </section>
+    </div>
+  );
+}
+
+/**
+ * "Current price" per sibling = the lowest latest-scrape price across the
+ * distinct flights that were scraped for this route. We group snapshots by
+ * `flightId ?? airline`, keep the most recent `scrapedAt` per group, then
+ * take the minimum across those latest snapshots. Returns null when the row
+ * has no snapshots yet so the sort dropdown can push it to the bottom in
+ * "lowest price first" mode.
+ */
+function currentPriceForSibling(qData: QueryWithSnapshots): number | null {
+  if (qData.snapshots.length === 0) return null;
+  const latestByGroup = new Map<string, { price: number; scrapedAt: string }>();
+  for (const s of qData.snapshots) {
+    const key = s.flightId ?? s.airline;
+    const existing = latestByGroup.get(key);
+    if (!existing || s.scrapedAt > existing.scrapedAt) {
+      latestByGroup.set(key, { price: s.price, scrapedAt: s.scrapedAt });
+    }
+  }
+  let min = Number.POSITIVE_INFINITY;
+  for (const v of latestByGroup.values()) {
+    if (v.price < min) min = v.price;
+  }
+  return Number.isFinite(min) ? min : null;
+}
+
+function buildStackedItem(qData: QueryWithSnapshots): StackedItem {
+  return {
+    key: qData.query.id,
+    outboundDate: qData.query.dateFrom.toISOString().slice(0, 10),
+    currentPrice: currentPriceForSibling(qData),
+    node: renderRouteBlock(qData, true),
+  };
 }
 
 async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | null> {
@@ -275,52 +357,11 @@ export default async function ChartPage({ params }: Props) {
         </div>
       ) : null}
 
-      {allQueries.map((qData) => {
-        const isRoundTrip = qData.query.tripType === 'round_trip';
-        const hasDistinctReturn = qData.query.dateFrom.getTime() < qData.query.dateTo.getTime();
-        const dateLabel = isRoundTrip && hasDistinctReturn
-          ? `${formatDate(qData.query.dateFrom)} → ${formatDate(qData.query.dateTo)}`
-          : formatDate(qData.query.dateFrom);
-
-        return (
-          <div key={qData.query.id} className={styles.routeBlock}>
-            {isMultiRoute && (
-              <div className={styles.routeBlockHeader}>
-                <span className={styles.routeBlockCode}>{qData.query.origin}</span>
-                <span className={styles.routeBlockArrow}>→</span>
-                <span className={styles.routeBlockCode}>{qData.query.destination}</span>
-                <span className={styles.routeBlockName}>
-                  {qData.query.originName} to {qData.query.destinationName}
-                </span>
-                <span className={styles.routeBlockDate}>{dateLabel}</span>
-              </div>
-            )}
-
-            <section className={styles.chart}>
-              <PriceChart snapshots={qData.snapshots} currency={qData.query.currency ?? 'USD'} />
-              {qData.query.vpnCountries.length > 0 && !qData.snapshots.some((s) => s.vpnCountry) && (
-                <p className={styles.vpnPending}>
-                  VPN comparison in progress -- prices from {qData.query.vpnCountries.map((c) =>
-                    String.fromCodePoint(...c.split('').map((ch) => 0x1f1e6 + ch.charCodeAt(0) - 65)) + ' ' + c
-                  ).join(', ')} will appear after the next scrape
-                </p>
-              )}
-            </section>
-
-            <section className={styles.best}>
-              <BestPrice snapshots={qData.snapshots} />
-            </section>
-
-            <section className={styles.history}>
-              <PriceHistory snapshots={qData.snapshots} />
-            </section>
-
-            <section className={styles.calendar}>
-              <PriceCalendar snapshots={qData.snapshots} currency={qData.query.currency ?? 'USD'} />
-            </section>
-          </div>
-        );
-      })}
+      {isMultiRoute ? (
+        <StackedSortControls items={allQueries.map(buildStackedItem)} />
+      ) : (
+        renderRouteBlock(primary, false)
+      )}
 
       <div className={styles.footerMeta}>
         <div className={styles.footerRow}>

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -56,6 +56,7 @@ interface QueryWithSnapshots {
     dateFrom: Date;
     dateTo: Date;
     flexibility: number;
+    tripType: string;
     expiresAt: Date;
     createdAt: Date;
     firstViewedAt: Date | null;
@@ -274,43 +275,52 @@ export default async function ChartPage({ params }: Props) {
         </div>
       ) : null}
 
-      {allQueries.map((qData) => (
-        <div key={qData.query.id} className={styles.routeBlock}>
-          {isMultiRoute && (
-            <div className={styles.routeBlockHeader}>
-              <span className={styles.routeBlockCode}>{qData.query.origin}</span>
-              <span className={styles.routeBlockArrow}>→</span>
-              <span className={styles.routeBlockCode}>{qData.query.destination}</span>
-              <span className={styles.routeBlockName}>
-                {qData.query.originName} to {qData.query.destinationName}
-              </span>
-            </div>
-          )}
+      {allQueries.map((qData) => {
+        const isRoundTrip = qData.query.tripType === 'round_trip';
+        const hasDistinctReturn = qData.query.dateFrom.getTime() < qData.query.dateTo.getTime();
+        const dateLabel = isRoundTrip && hasDistinctReturn
+          ? `${formatDate(qData.query.dateFrom)} → ${formatDate(qData.query.dateTo)}`
+          : formatDate(qData.query.dateFrom);
 
-          <section className={styles.chart}>
-            <PriceChart snapshots={qData.snapshots} currency={qData.query.currency ?? 'USD'} />
-            {qData.query.vpnCountries.length > 0 && !qData.snapshots.some((s) => s.vpnCountry) && (
-              <p className={styles.vpnPending}>
-                VPN comparison in progress -- prices from {qData.query.vpnCountries.map((c) =>
-                  String.fromCodePoint(...c.split('').map((ch) => 0x1f1e6 + ch.charCodeAt(0) - 65)) + ' ' + c
-                ).join(', ')} will appear after the next scrape
-              </p>
+        return (
+          <div key={qData.query.id} className={styles.routeBlock}>
+            {isMultiRoute && (
+              <div className={styles.routeBlockHeader}>
+                <span className={styles.routeBlockCode}>{qData.query.origin}</span>
+                <span className={styles.routeBlockArrow}>→</span>
+                <span className={styles.routeBlockCode}>{qData.query.destination}</span>
+                <span className={styles.routeBlockName}>
+                  {qData.query.originName} to {qData.query.destinationName}
+                </span>
+                <span className={styles.routeBlockDate}>{dateLabel}</span>
+              </div>
             )}
-          </section>
 
-          <section className={styles.best}>
-            <BestPrice snapshots={qData.snapshots} />
-          </section>
+            <section className={styles.chart}>
+              <PriceChart snapshots={qData.snapshots} currency={qData.query.currency ?? 'USD'} />
+              {qData.query.vpnCountries.length > 0 && !qData.snapshots.some((s) => s.vpnCountry) && (
+                <p className={styles.vpnPending}>
+                  VPN comparison in progress -- prices from {qData.query.vpnCountries.map((c) =>
+                    String.fromCodePoint(...c.split('').map((ch) => 0x1f1e6 + ch.charCodeAt(0) - 65)) + ' ' + c
+                  ).join(', ')} will appear after the next scrape
+                </p>
+              )}
+            </section>
 
-          <section className={styles.history}>
-            <PriceHistory snapshots={qData.snapshots} />
-          </section>
+            <section className={styles.best}>
+              <BestPrice snapshots={qData.snapshots} />
+            </section>
 
-          <section className={styles.calendar}>
-            <PriceCalendar snapshots={qData.snapshots} currency={qData.query.currency ?? 'USD'} />
-          </section>
-        </div>
-      ))}
+            <section className={styles.history}>
+              <PriceHistory snapshots={qData.snapshots} />
+            </section>
+
+            <section className={styles.calendar}>
+              <PriceCalendar snapshots={qData.snapshots} currency={qData.query.currency ?? 'USD'} />
+            </section>
+          </div>
+        );
+      })}
 
       <div className={styles.footerMeta}>
         <div className={styles.footerRow}>

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -140,22 +140,25 @@ function renderRouteBlock(qData: QueryWithSnapshots, isMultiRoute: boolean) {
  * "Current price" per sibling = the lowest latest-scrape price across the
  * distinct flights that were scraped for this route. We group snapshots by
  * `flightId ?? airline`, keep the most recent `scrapedAt` per group, then
- * take the minimum across those latest snapshots. Returns null when the row
- * has no snapshots yet so the sort dropdown can push it to the bottom in
- * "lowest price first" mode.
+ * take the minimum across those latest snapshots. Sold-out flights are
+ * excluded so the price sort can't rank a row by an unavailable fare
+ * (matches the bookable filter used in BestPrice). Returns null when the
+ * row has no available snapshots so the sort dropdown can push it to the
+ * bottom in "lowest price first" mode.
  */
 function currentPriceForSibling(qData: QueryWithSnapshots): number | null {
   if (qData.snapshots.length === 0) return null;
-  const latestByGroup = new Map<string, { price: number; scrapedAt: string }>();
+  const latestByGroup = new Map<string, { price: number; scrapedAt: string; status: string }>();
   for (const s of qData.snapshots) {
     const key = s.flightId ?? s.airline;
     const existing = latestByGroup.get(key);
     if (!existing || s.scrapedAt > existing.scrapedAt) {
-      latestByGroup.set(key, { price: s.price, scrapedAt: s.scrapedAt });
+      latestByGroup.set(key, { price: s.price, scrapedAt: s.scrapedAt, status: s.status });
     }
   }
   let min = Number.POSITIVE_INFINITY;
   for (const v of latestByGroup.values()) {
+    if (v.status === 'sold_out') continue;
     if (v.price < min) min = v.price;
   }
   return Number.isFinite(min) ? min : null;
@@ -263,8 +266,17 @@ export default async function ChartPage({ params }: Props) {
   }
 
   const isMultiRoute = allQueries.length > 1;
-  const expired = new Date() > primary.query.expiresAt;
-  const daysLeft = daysUntil(primary.query.expiresAt);
+  // Expiry is computed across the whole group so a partly-expired flex query
+  // (earliest sibling past its expiresAt but later siblings still active)
+  // keeps the tracker controls visible. The page-level countdown shows the
+  // *latest* expiresAt so the user sees the most generous remaining window.
+  const now = Date.now();
+  const groupExpiresAt = allQueries.reduce<Date>(
+    (max, q) => (q.query.expiresAt.getTime() > max.getTime() ? q.query.expiresAt : max),
+    primary.query.expiresAt,
+  );
+  const expired = allQueries.every((q) => now > q.query.expiresAt.getTime());
+  const daysLeft = daysUntil(groupExpiresAt);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -352,7 +364,7 @@ export default async function ChartPage({ params }: Props) {
 
       {expired ? (
         <div className={styles.expiredNotice}>
-          <p>This tracker expired on {formatDate(primary.query.expiresAt)}.</p>
+          <p>This tracker expired on {formatDate(groupExpiresAt)}.</p>
           <p>The data below is a snapshot of prices collected during the tracking period.</p>
         </div>
       ) : null}

--- a/apps/web/src/components/SavedTrackers.tsx
+++ b/apps/web/src/components/SavedTrackers.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { getSavedTrackers, getDeleteToken, removeSavedTracker } from '@/lib/tracker-storage';
+import { getSavedTrackers, getDeleteToken, removeSavedTracker, type SavedTracker } from '@/lib/tracker-storage';
+import { groupQueries, type GroupableQuery, type QueryGroup } from '@/lib/query-grouping';
 import styles from './SavedTrackers.module.css';
 
 interface ActiveQuery {
@@ -21,14 +22,13 @@ interface ActiveQuery {
   createdAt: string;
 }
 
-interface DisplayTracker {
-  id: string;
-  origin: string;
-  destination: string;
-  dateFrom: string;
-  dateTo: string;
-  snapshotCount: number;
-  lastScrapedAt: string | null;
+interface DisplayQuery extends GroupableQuery {
+  status: 'active' | 'paused' | 'expired' | 'deleted';
+  hasDeleteToken: boolean;
+}
+
+interface DisplayGroup {
+  group: QueryGroup<DisplayQuery>;
   status: 'active' | 'paused' | 'expired' | 'deleted';
   hasDeleteToken: boolean;
 }
@@ -51,15 +51,33 @@ function timeAgo(iso: string): string {
   return `${days}d ago`;
 }
 
+function deriveGroupStatus(group: QueryGroup<DisplayQuery>): DisplayGroup['status'] {
+  // If every sibling is "deleted" upstream (only happens in the localStorage
+  // fallback path) → group is deleted. Otherwise prefer active over paused
+  // over expired so a partly-active group keeps the tracking badge.
+  if (group.queries.every((q) => q.status === 'deleted')) return 'deleted';
+  if (group.queries.some((q) => q.status === 'active')) return 'active';
+  if (group.queries.some((q) => q.status === 'paused')) return 'paused';
+  return 'expired';
+}
+
+function toDisplayGroups(queries: DisplayQuery[]): DisplayGroup[] {
+  return groupQueries(queries).map((group) => ({
+    group,
+    status: deriveGroupStatus(group),
+    hasDeleteToken: group.queries.some((q) => q.hasDeleteToken),
+  }));
+}
+
 export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: boolean } = {}) {
-  const [trackers, setTrackers] = useState<DisplayTracker[]>([]);
+  const [groups, setGroups] = useState<DisplayGroup[]>([]);
 
   useEffect(() => {
     // In multi user mode the server response is authoritative for the current
     // user — localStorage fallback only made sense in the deleteToken era.
     const localTrackers = isAuthenticated ? [] : getSavedTrackers();
-    const deleteTokenMap = new Map(
-      localTrackers.filter((t) => t.deleteToken).map((t) => [t.id, t.deleteToken!])
+    const deleteTokenSet = new Set(
+      localTrackers.filter((t) => t.deleteToken).map((t) => t.id)
     );
 
     // Fetch all active queries from server
@@ -68,7 +86,7 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
       .then((data) => {
         if (!data.ok || !data.data?.queries) {
           if (isAuthenticated) {
-            setTrackers([]);
+            setGroups([]);
             return;
           }
           fallbackToLocal(localTrackers);
@@ -80,29 +98,34 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
         if (serverQueries.length > 0 || isAuthenticated) {
           // Server response is authoritative when logged in. Solo/anonymous
           // still gets the localStorage merge for backward compat.
-          const display: DisplayTracker[] = serverQueries.map((q) => ({
+          const display: DisplayQuery[] = serverQueries.map((q) => ({
             id: q.id,
             origin: q.origin,
             destination: q.destination,
+            originName: q.originName,
+            destinationName: q.destinationName,
             dateFrom: q.dateFrom,
             dateTo: q.dateTo,
+            groupId: q.groupId,
+            active: q.active,
+            createdAt: q.createdAt,
             snapshotCount: q.snapshotCount,
             lastScrapedAt: q.lastScrapedAt,
             status: q.active ? 'active' : 'paused',
-            hasDeleteToken: deleteTokenMap.has(q.id),
+            hasDeleteToken: deleteTokenSet.has(q.id),
           }));
-          setTrackers(display);
+          setGroups(toDisplayGroups(display));
         } else {
           // No server queries — fall back to localStorage
           fallbackToLocal(localTrackers);
         }
       })
       .catch(() => {
-        if (isAuthenticated) setTrackers([]);
+        if (isAuthenticated) setGroups([]);
         else fallbackToLocal(localTrackers);
       });
 
-    function fallbackToLocal(saved: typeof localTrackers) {
+    function fallbackToLocal(saved: SavedTracker[]) {
       if (saved.length === 0) return;
       fetch('/api/queries/status', {
         method: 'POST',
@@ -113,41 +136,56 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
         .then((data) => {
           if (!data.ok) return;
           const statusMap = data.data as Record<string, 'active' | 'expired' | 'deleted'>;
-          setTrackers(
-            saved.map((t) => ({
-              id: t.id,
-              origin: t.origin,
-              destination: t.destination,
-              dateFrom: t.dateFrom,
-              dateTo: t.dateTo,
-              snapshotCount: 0,
-              lastScrapedAt: null,
-              status: statusMap[t.id] ?? 'deleted',
-              hasDeleteToken: Boolean(t.deleteToken),
-            }))
-          );
+          const display: DisplayQuery[] = saved.map((t) => ({
+            id: t.id,
+            origin: t.origin,
+            destination: t.destination,
+            originName: t.originName,
+            destinationName: t.destinationName,
+            dateFrom: t.dateFrom,
+            dateTo: t.dateTo,
+            groupId: null,
+            createdAt: t.createdAt,
+            snapshotCount: 0,
+            lastScrapedAt: null,
+            status: statusMap[t.id] ?? 'deleted',
+            hasDeleteToken: Boolean(t.deleteToken),
+          }));
+          setGroups(toDisplayGroups(display));
         })
         .catch(() => {
-          setTrackers(
-            saved.map((t) => ({
-              ...t,
-              snapshotCount: 0,
-              lastScrapedAt: null,
-              status: 'active' as const,
-              hasDeleteToken: Boolean(t.deleteToken),
-            }))
-          );
+          const display: DisplayQuery[] = saved.map((t) => ({
+            id: t.id,
+            origin: t.origin,
+            destination: t.destination,
+            originName: t.originName,
+            destinationName: t.destinationName,
+            dateFrom: t.dateFrom,
+            dateTo: t.dateTo,
+            groupId: null,
+            createdAt: t.createdAt,
+            snapshotCount: 0,
+            lastScrapedAt: null,
+            status: 'active',
+            hasDeleteToken: Boolean(t.deleteToken),
+          }));
+          setGroups(toDisplayGroups(display));
         });
     }
   }, [isAuthenticated]);
 
-  const handleRemove = async (id: string) => {
-    const token = getDeleteToken(id);
+  const handleRemove = async (entry: DisplayGroup) => {
+    const { group } = entry;
+    const label = `${group.origin} → ${group.destination}`;
+    const suffix = group.routeCount > 1 ? ` (${group.routeCount} charts)` : '';
+    if (!confirm(`Delete tracker for ${label}${suffix}?`)) return;
+
+    const token = getDeleteToken(group.primaryId);
     try {
-      const res = await fetch(`/api/queries/${id}`, {
+      const res = await fetch(`/api/queries/${group.primaryId}`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ deleteToken: token }),
+        body: JSON.stringify({ deleteToken: token, groupDelete: group.routeCount > 1 }),
       });
       const data = await res.json();
       if (!data.ok) {
@@ -157,27 +195,47 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
     } catch {
       // Network error -- still remove from local view
     }
-    removeSavedTracker(id);
-    setTrackers((prev) => prev.filter((t) => t.id !== id));
+    for (const q of group.queries) {
+      removeSavedTracker(q.id);
+    }
+    setGroups((prev) => prev.filter((g) => g.group.primaryId !== group.primaryId));
   };
 
-  const handleTogglePause = async (id: string, currentlyActive: boolean) => {
-    const res = await fetch(`/api/admin/queries/${id}`, {
+  const handleTogglePause = async (entry: DisplayGroup) => {
+    const { group } = entry;
+    const currentlyActive = entry.status === 'active';
+    const nextActive = !currentlyActive;
+    const token = getDeleteToken(group.primaryId);
+    const res = await fetch(`/api/queries/${group.primaryId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ active: !currentlyActive }),
+      body: JSON.stringify({ deleteToken: token, active: nextActive }),
     });
     const data = await res.json();
-    if (data.ok) {
-      setTrackers((prev) =>
-        prev.map((t) =>
-          t.id === id ? { ...t, status: currentlyActive ? 'paused' : 'active' } : t
-        )
-      );
-    }
+    if (!data.ok) return;
+    setGroups((prev) =>
+      prev.map((g) =>
+        g.group.primaryId !== group.primaryId
+          ? g
+          : {
+              ...g,
+              status: nextActive ? 'active' : 'paused',
+              group: {
+                ...g.group,
+                anyActive: nextActive,
+                anyPaused: !nextActive,
+                queries: g.group.queries.map((q) => ({
+                  ...q,
+                  active: nextActive,
+                  status: nextActive ? 'active' : 'paused',
+                })),
+              },
+            }
+      )
+    );
   };
 
-  if (trackers.length === 0) {
+  if (groups.length === 0) {
     return (
       <div className={styles.root}>
         <div className={styles.empty}>
@@ -193,75 +251,90 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
     <div className={styles.root}>
       <h3 className={styles.title}>Your Trackers</h3>
       <div className={styles.list}>
-        {trackers.map((t) => (
-          <div key={t.id} className={styles.card}>
-            <button
-              className={styles.remove}
-              onClick={() => handleRemove(t.id)}
-              title="Remove"
-              aria-label="Remove tracker"
-            >
-              &times;
-            </button>
+        {groups.map((entry) => {
+          const { group, status } = entry;
+          const extraDestinations = group.destinations.length - 1;
+          return (
+            <div key={group.primaryId} className={styles.card}>
+              <button
+                className={styles.remove}
+                onClick={() => handleRemove(entry)}
+                title="Remove"
+                aria-label="Remove tracker"
+              >
+                &times;
+              </button>
 
-            {t.status === 'deleted' ? (
-              <div className={styles.content}>
-                <div className={styles.route}>
-                  <span className={styles.code}>{t.origin}</span>
-                  <span className={styles.arrow}>&rarr;</span>
-                  <span className={styles.code}>{t.destination}</span>
-                </div>
-                <span className={`${styles.badge} ${styles.badgeDeleted}`}>Unavailable</span>
-              </div>
-            ) : (
-              <Link href={`/q/${t.id}`} className={styles.link}>
+              {status === 'deleted' ? (
                 <div className={styles.content}>
                   <div className={styles.route}>
-                    <span className={styles.code}>{t.origin}</span>
+                    <span className={styles.code}>{group.origin}</span>
                     <span className={styles.arrow}>&rarr;</span>
-                    <span className={styles.code}>{t.destination}</span>
-                  </div>
-                  <span className={styles.dates}>
-                    {formatDate(t.dateFrom)} &mdash; {formatDate(t.dateTo)}
-                  </span>
-                  <div className={styles.meta}>
-                    {t.snapshotCount > 0 && (
-                      <span className={styles.snapshots}>
-                        {t.snapshotCount} price{t.snapshotCount !== 1 ? 's' : ''}
-                      </span>
-                    )}
-                    {t.lastScrapedAt && (
-                      <span className={styles.lastScrape}>
-                        {timeAgo(t.lastScrapedAt)}
-                      </span>
+                    <span className={styles.code}>{group.destination}</span>
+                    {extraDestinations > 0 && (
+                      <span className={styles.dates}>+ {extraDestinations} more</span>
                     )}
                   </div>
-                  <div className={styles.cardActions}>
-                    <span className={`${styles.badge} ${
-                      t.status === 'active' ? styles.badgeActive
-                        : t.status === 'paused' ? styles.badgePaused
-                        : styles.badgeExpired
-                    }`}>
-                      {t.status === 'active' ? 'Tracking' : t.status === 'paused' ? 'Paused' : 'Expired'}
-                    </span>
-                    {(t.status === 'active' || t.status === 'paused') && (
-                      <button
-                        className={styles.pauseBtn}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handleTogglePause(t.id, t.status === 'active');
-                        }}
-                        title={t.status === 'active' ? 'Pause tracking' : 'Resume tracking'}
-                      >
-                        {t.status === 'active' ? '⏸' : '▶'}
-                      </button>
-                    )}
-                  </div>
+                  <span className={`${styles.badge} ${styles.badgeDeleted}`}>Unavailable</span>
                 </div>
-              </Link>
-            )}
-          </div>
-        ))}
+              ) : (
+                <Link href={`/q/${group.primaryId}`} className={styles.link}>
+                  <div className={styles.content}>
+                    <div className={styles.route}>
+                      <span className={styles.code}>{group.origin}</span>
+                      <span className={styles.arrow}>&rarr;</span>
+                      <span className={styles.code}>{group.destination}</span>
+                      {extraDestinations > 0 && (
+                        <span className={styles.dates}>+ {extraDestinations} more</span>
+                      )}
+                    </div>
+                    <span className={styles.dates}>
+                      {formatDate(group.dateFrom)} &mdash; {formatDate(group.dateTo)}
+                    </span>
+                    <div className={styles.meta}>
+                      {group.routeCount > 1 && (
+                        <span className={styles.snapshots}>
+                          {group.routeCount} charts
+                        </span>
+                      )}
+                      {group.snapshotCount > 0 && (
+                        <span className={styles.snapshots}>
+                          {group.snapshotCount} price{group.snapshotCount !== 1 ? 's' : ''}
+                        </span>
+                      )}
+                      {group.lastScrapedAt && (
+                        <span className={styles.lastScrape}>
+                          {timeAgo(group.lastScrapedAt)}
+                        </span>
+                      )}
+                    </div>
+                    <div className={styles.cardActions}>
+                      <span className={`${styles.badge} ${
+                        status === 'active' ? styles.badgeActive
+                          : status === 'paused' ? styles.badgePaused
+                          : styles.badgeExpired
+                      }`}>
+                        {status === 'active' ? 'Tracking' : status === 'paused' ? 'Paused' : 'Expired'}
+                      </span>
+                      {(status === 'active' || status === 'paused') && (
+                        <button
+                          className={styles.pauseBtn}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            handleTogglePause(entry);
+                          }}
+                          title={status === 'active' ? 'Pause tracking' : 'Resume tracking'}
+                        >
+                          {status === 'active' ? '⏸' : '▶'}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </Link>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/web/src/components/StackedSortControls.module.css
+++ b/apps/web/src/components/StackedSortControls.module.css
@@ -1,0 +1,36 @@
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.label {
+  letter-spacing: 0.04em;
+}
+
+.select {
+  padding: 0.375rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text);
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.footnote {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  background: var(--surface);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  text-align: center;
+}

--- a/apps/web/src/components/StackedSortControls.tsx
+++ b/apps/web/src/components/StackedSortControls.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useMemo, useState, type ReactNode } from 'react';
+import styles from './StackedSortControls.module.css';
+
+export interface StackedItem {
+  key: string;
+  outboundDate: string;
+  currentPrice: number | null;
+  node: ReactNode;
+}
+
+type SortMode = 'date' | 'price';
+
+function sortItems(items: StackedItem[], mode: SortMode): StackedItem[] {
+  const next = [...items];
+  if (mode === 'date') {
+    next.sort((a, b) => {
+      if (a.outboundDate !== b.outboundDate) {
+        return a.outboundDate < b.outboundDate ? -1 : 1;
+      }
+      return a.key.localeCompare(b.key);
+    });
+    return next;
+  }
+  // mode === 'price'
+  next.sort((a, b) => {
+    const aNull = a.currentPrice === null;
+    const bNull = b.currentPrice === null;
+    if (aNull && bNull) {
+      // Both unpriced — keep chronological order so the bottom of the list
+      // stays predictable.
+      return a.outboundDate < b.outboundDate ? -1 : a.outboundDate > b.outboundDate ? 1 : 0;
+    }
+    if (aNull) return 1;
+    if (bNull) return -1;
+    if (a.currentPrice !== b.currentPrice) {
+      return (a.currentPrice ?? 0) - (b.currentPrice ?? 0);
+    }
+    return a.outboundDate < b.outboundDate ? -1 : a.outboundDate > b.outboundDate ? 1 : 0;
+  });
+  return next;
+}
+
+export function StackedSortControls({ items }: { items: StackedItem[] }) {
+  const [mode, setMode] = useState<SortMode>('date');
+  const ordered = useMemo(() => sortItems(items, mode), [items, mode]);
+  const hiddenInPriceMode = mode === 'price'
+    ? items.filter((i) => i.currentPrice === null).length
+    : 0;
+
+  return (
+    <>
+      <div className={styles.controls}>
+        <label htmlFor="stack-sort" className={styles.label}>Sort</label>
+        <select
+          id="stack-sort"
+          className={styles.select}
+          value={mode}
+          onChange={(e) => setMode(e.target.value as SortMode)}
+        >
+          <option value="date">By date</option>
+          <option value="price">Lowest price first</option>
+        </select>
+      </div>
+      {ordered.map((item) => (
+        <div key={item.key}>{item.node}</div>
+      ))}
+      {hiddenInPriceMode > 0 && (
+        <p className={styles.footnote}>
+          {hiddenInPriceMode} route{hiddenInPriceMode === 1 ? '' : 's'} placed last — no current price yet.
+        </p>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/lib/query-grouping.test.ts
+++ b/apps/web/src/lib/query-grouping.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { groupQueries, type GroupableQuery } from './query-grouping';
+
+function row(overrides: Partial<GroupableQuery> & { id: string }): GroupableQuery {
+  return {
+    origin: 'JFK',
+    destination: 'LAX',
+    originName: 'New York',
+    destinationName: 'Los Angeles',
+    dateFrom: '2026-06-10',
+    dateTo: '2026-06-10',
+    groupId: null,
+    active: true,
+    createdAt: '2026-05-01T00:00:00Z',
+    snapshotCount: 0,
+    lastScrapedAt: null,
+    ...overrides,
+  };
+}
+
+describe('groupQueries', () => {
+  it('returns empty array for empty input', () => {
+    expect(groupQueries([])).toEqual([]);
+  });
+
+  it('treats a single ungrouped row as a one-item group', () => {
+    const result = groupQueries([row({ id: 'q1' })]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      primaryId: 'q1',
+      groupId: null,
+      routeCount: 1,
+      origin: 'JFK',
+      destination: 'LAX',
+      dateFrom: '2026-06-10',
+      dateTo: '2026-06-10',
+    });
+  });
+
+  it('collapses N rows sharing a groupId into one group with min/max dates', () => {
+    const rows = [
+      row({ id: 'q2', groupId: 'g1', dateFrom: '2026-06-12', dateTo: '2026-06-19' }),
+      row({ id: 'q1', groupId: 'g1', dateFrom: '2026-06-10', dateTo: '2026-06-17' }),
+      row({ id: 'q3', groupId: 'g1', dateFrom: '2026-06-14', dateTo: '2026-06-21' }),
+    ];
+    const result = groupQueries(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      groupId: 'g1',
+      routeCount: 3,
+      dateFrom: '2026-06-10',
+      dateTo: '2026-06-21',
+    });
+    // queries are sorted by dateFrom asc
+    expect(result[0]!.queries.map((q) => q.id)).toEqual(['q1', 'q2', 'q3']);
+    expect(result[0]!.primaryId).toBe('q1');
+  });
+
+  it('uses id.localeCompare as tiebreaker when siblings share dateFrom', () => {
+    const rows = [
+      row({ id: 'q-beta', groupId: 'g1', dateFrom: '2026-06-10' }),
+      row({ id: 'q-alpha', groupId: 'g1', dateFrom: '2026-06-10' }),
+    ];
+    const result = groupQueries(rows);
+    expect(result[0]!.primaryId).toBe('q-alpha');
+  });
+
+  it('orders groups by latest createdAt descending', () => {
+    const rows = [
+      row({ id: 'old', createdAt: '2026-01-01T00:00:00Z' }),
+      row({ id: 'mid-g1-a', groupId: 'g1', createdAt: '2026-03-01T00:00:00Z' }),
+      row({ id: 'mid-g1-b', groupId: 'g1', createdAt: '2026-03-02T00:00:00Z' }),
+      row({ id: 'new', createdAt: '2026-05-01T00:00:00Z' }),
+    ];
+    const result = groupQueries(rows);
+    expect(result.map((g) => g.primaryId)).toEqual(['new', 'mid-g1-a', 'old']);
+  });
+
+  it('exposes unique destinations/origins arrays', () => {
+    const rows = [
+      row({ id: 'q1', groupId: 'g1', destination: 'NRT', destinationName: 'Tokyo' }),
+      row({ id: 'q2', groupId: 'g1', destination: 'ICN', destinationName: 'Seoul' }),
+      row({ id: 'q3', groupId: 'g1', destination: 'NRT', destinationName: 'Tokyo' }),
+    ];
+    const result = groupQueries(rows);
+    expect(result[0]!.destinations).toEqual([
+      { code: 'NRT', name: 'Tokyo' },
+      { code: 'ICN', name: 'Seoul' },
+    ]);
+    expect(result[0]!.origins).toEqual([{ code: 'JFK', name: 'New York' }]);
+    // primary destination follows queries[0]
+    expect(result[0]!.destination).toBe('NRT');
+  });
+
+  it('reflects multi-origin groups symmetrically', () => {
+    const rows = [
+      row({ id: 'q1', groupId: 'g1', origin: 'JFK', originName: 'New York' }),
+      row({ id: 'q2', groupId: 'g1', origin: 'EWR', originName: 'Newark' }),
+    ];
+    const result = groupQueries(rows);
+    expect(result[0]!.origins).toEqual([
+      { code: 'JFK', name: 'New York' },
+      { code: 'EWR', name: 'Newark' },
+    ]);
+  });
+
+  it('computes anyActive and anyPaused across mixed sibling states', () => {
+    const mixed = groupQueries([
+      row({ id: 'q1', groupId: 'g1', active: true }),
+      row({ id: 'q2', groupId: 'g1', active: false }),
+    ]);
+    expect(mixed[0]).toMatchObject({ anyActive: true, anyPaused: true });
+
+    const allActive = groupQueries([
+      row({ id: 'q1', groupId: 'g2', active: true }),
+      row({ id: 'q2', groupId: 'g2', active: true }),
+    ]);
+    expect(allActive[0]).toMatchObject({ anyActive: true, anyPaused: false });
+  });
+
+  it('flags allExpired only when every member is past its expiresAt', () => {
+    const expired = groupQueries([
+      row({ id: 'q1', groupId: 'g1', expiresAt: '2024-01-01T00:00:00Z' }),
+      row({ id: 'q2', groupId: 'g1', expiresAt: '2024-02-01T00:00:00Z' }),
+    ]);
+    expect(expired[0]!.allExpired).toBe(true);
+
+    const mixed = groupQueries([
+      row({ id: 'q1', groupId: 'g2', expiresAt: '2024-01-01T00:00:00Z' }),
+      row({ id: 'q2', groupId: 'g2', expiresAt: '2999-01-01T00:00:00Z' }),
+    ]);
+    expect(mixed[0]!.allExpired).toBe(false);
+
+    const noExpiry = groupQueries([row({ id: 'q1', groupId: 'g3' })]);
+    expect(noExpiry[0]!.allExpired).toBe(false);
+  });
+
+  it('sums snapshotCount and tracks the latest lastScrapedAt', () => {
+    const result = groupQueries([
+      row({ id: 'q1', groupId: 'g1', snapshotCount: 5, lastScrapedAt: '2026-05-01T08:00:00Z' }),
+      row({ id: 'q2', groupId: 'g1', snapshotCount: 7, lastScrapedAt: '2026-05-02T08:00:00Z' }),
+      row({ id: 'q3', groupId: 'g1', snapshotCount: 0, lastScrapedAt: null }),
+    ]);
+    expect(result[0]!.snapshotCount).toBe(12);
+    expect(result[0]!.lastScrapedAt).toBe('2026-05-02T08:00:00Z');
+  });
+
+  it('handles rows with undefined optional fields without throwing', () => {
+    const minimal: GroupableQuery = {
+      id: 'q1',
+      origin: 'JFK',
+      destination: 'LAX',
+      dateFrom: '2026-06-10',
+      dateTo: '2026-06-10',
+      groupId: null,
+    };
+    const result = groupQueries([minimal]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      snapshotCount: 0,
+      lastScrapedAt: null,
+      anyActive: false,
+      anyPaused: false,
+      allExpired: false,
+      originName: 'JFK',
+      destinationName: 'LAX',
+    });
+  });
+});

--- a/apps/web/src/lib/query-grouping.ts
+++ b/apps/web/src/lib/query-grouping.ts
@@ -1,0 +1,152 @@
+/**
+ * Collapse a flat list of `Query` rows into one entry per `groupId` so the
+ * dashboard lists show one card for a flex search even when the create
+ * handler fanned it out into N sibling queries. Ungrouped rows
+ * (`groupId === null`) each become a single-item group, so consumers can
+ * iterate without branching.
+ */
+
+export interface GroupableQuery {
+  id: string;
+  origin: string;
+  destination: string;
+  originName?: string;
+  destinationName?: string;
+  dateFrom: string;
+  dateTo: string;
+  groupId: string | null;
+  active?: boolean;
+  expiresAt?: string;
+  scrapeInterval?: number | null;
+  snapshotCount?: number;
+  lastScrapedAt?: string | null;
+  createdAt?: string;
+}
+
+export interface QueryGroup<T extends GroupableQuery> {
+  primaryId: string;
+  groupId: string | null;
+  origin: string;
+  destination: string;
+  originName: string;
+  destinationName: string;
+  origins: Array<{ code: string; name: string }>;
+  destinations: Array<{ code: string; name: string }>;
+  dateFrom: string;
+  dateTo: string;
+  routeCount: number;
+  snapshotCount: number;
+  lastScrapedAt: string | null;
+  anyActive: boolean;
+  anyPaused: boolean;
+  allExpired: boolean;
+  scrapeInterval: number | null;
+  queries: T[];
+}
+
+function uniquePairs(
+  rows: GroupableQuery[],
+  codeKey: 'origin' | 'destination',
+  nameKey: 'originName' | 'destinationName',
+): Array<{ code: string; name: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ code: string; name: string }> = [];
+  for (const row of rows) {
+    const code = row[codeKey];
+    if (seen.has(code)) continue;
+    seen.add(code);
+    out.push({ code, name: row[nameKey] ?? code });
+  }
+  return out;
+}
+
+export function groupQueries<T extends GroupableQuery>(rows: T[]): QueryGroup<T>[] {
+  if (rows.length === 0) return [];
+
+  const buckets = new Map<string, T[]>();
+  for (const row of rows) {
+    const key = row.groupId ?? `solo:${row.id}`;
+    const list = buckets.get(key);
+    if (list) {
+      list.push(row);
+    } else {
+      buckets.set(key, [row]);
+    }
+  }
+
+  const now = Date.now();
+  const groups: QueryGroup<T>[] = [];
+
+  for (const queries of buckets.values()) {
+    queries.sort((a, b) => {
+      if (a.dateFrom !== b.dateFrom) return a.dateFrom < b.dateFrom ? -1 : 1;
+      return a.id.localeCompare(b.id);
+    });
+
+    const primary = queries[0]!;
+    const dateFromValues = queries.map((q) => q.dateFrom);
+    const dateToValues = queries.map((q) => q.dateTo);
+    const dateFrom = dateFromValues.reduce((a, b) => (a < b ? a : b));
+    const dateTo = dateToValues.reduce((a, b) => (a > b ? a : b));
+
+    const snapshotCount = queries.reduce((sum, q) => sum + (q.snapshotCount ?? 0), 0);
+
+    let lastScrapedAt: string | null = null;
+    for (const q of queries) {
+      if (!q.lastScrapedAt) continue;
+      if (lastScrapedAt === null || q.lastScrapedAt > lastScrapedAt) {
+        lastScrapedAt = q.lastScrapedAt;
+      }
+    }
+
+    const anyActive = queries.some((q) => q.active === true);
+    const anyPaused = queries.some((q) => q.active === false);
+
+    const expiresValues = queries
+      .map((q) => q.expiresAt)
+      .filter((v): v is string => typeof v === 'string');
+    const allExpired = expiresValues.length > 0
+      && expiresValues.every((v) => new Date(v).getTime() <= now);
+
+    groups.push({
+      primaryId: primary.id,
+      groupId: primary.groupId,
+      origin: primary.origin,
+      destination: primary.destination,
+      originName: primary.originName ?? primary.origin,
+      destinationName: primary.destinationName ?? primary.destination,
+      origins: uniquePairs(queries, 'origin', 'originName'),
+      destinations: uniquePairs(queries, 'destination', 'destinationName'),
+      dateFrom,
+      dateTo,
+      routeCount: queries.length,
+      snapshotCount,
+      lastScrapedAt,
+      anyActive,
+      anyPaused,
+      allExpired,
+      scrapeInterval: primary.scrapeInterval ?? null,
+      queries,
+    });
+  }
+
+  // Sort groups by their most recent createdAt descending so the newest
+  // tracker floats to the top of the list (matching prior list ordering).
+  // When createdAt is missing on every member, preserve insertion order.
+  groups.sort((a, b) => {
+    const aCreated = a.queries.reduce<string | null>(
+      (max, q) => (q.createdAt && (max === null || q.createdAt > max) ? q.createdAt : max),
+      null,
+    );
+    const bCreated = b.queries.reduce<string | null>(
+      (max, q) => (q.createdAt && (max === null || q.createdAt > max) ? q.createdAt : max),
+      null,
+    );
+    if (aCreated === null && bCreated === null) return 0;
+    if (aCreated === null) return 1;
+    if (bCreated === null) return -1;
+    return aCreated < bCreated ? 1 : aCreated > bCreated ? -1 : 0;
+  });
+
+  return groups;
+}


### PR DESCRIPTION
Addresses #78.

Three things:

1. Flex queries no longer fan out into 10 or 20 dashboard rows. SavedTrackers, `/account`, and `/admin/queries` now collapse siblings by the `groupId` the create handler was already stamping. One card per query, with a "N charts" chip when the group has more than one date and a "+N more" tail when it spans multiple destinations.
2. Every chart block on `/q/[id]` shows its own outbound date (plus return for round trips). Page header still has the overall window.
3. Bonus: sort dropdown on the stacked view. Ascending date by default, or lowest current price first. Sold out flights are skipped so a stale price can't rank a route as cheapest.

To make this work the user PATCH `/api/queries/[id]` now also accepts `active` and cascades to siblings (`scrapeInterval` already did), and DELETE gains a `groupDelete: true` body flag that routes through `deleteMany({where:{groupId}})`. The admin route got the matching cascades plus `groupDelete`. `userId` reassignment stays single row. No schema change, `groupId` already existed and was indexed.

While in there: SavedTrackers' pause button used to hit `/api/admin/queries/[id]`, which 401s for anonymous users. Now it hits the user route. Old bug, fixed in passing.

A second pass review on the branch caught three edge cases which are fixed in the last commit before push:

* Page level `expired` was derived from the primary sibling. Since `primaryId` is the earliest by `dateFrom`, on a per date flex group the earliest can be expired while later siblings are still alive. Now `every(q => now > q.expiresAt)`.
* `currentPriceForSibling` was including sold out flights' last known prices. Filtered out (matches BestPrice).
* Phase 4 briefly routed admin dashboard mutations through the user PATCH route, which 401s in hosted mode. Reverted, with the cascade added to the admin route instead.

### Test plan

* `npm run ci`: 627 passed across 43 files.
* New unit tests for `groupQueries`. New cascade + `groupDelete` coverage on both `/api/queries/[id]` and `/api/admin/queries/[id]`.
* [x] Flex round trip across two destinations (4 siblings spanning 2 destinations × 2 dates). Verified against a real dev server + Postgres: `/api/queries/active` returns all 4 with `groupId`, `/q/[primaryId]` renders 4 route blocks with date spans, sort dropdown markup present with both options, `/admin/queries` collapses to one row with `+ 1 more` and `4 charts` chips, admin group delete cleared all 4 siblings.
* [x] Single route tracker UX unchanged: standalone `/q/[id]` renders 200, no sort dropdown, no `routeBlockHeader`.
* [x] Admin pause cascade: PATCH `/api/admin/queries/[one sibling id]` with `{active:false}` flipped all 4 flex siblings to paused; the standalone tracker was untouched.
