### PR TITLE
fix(q-page): use group min/max in /q/[id] header date bubble (#78)

### DIFF
--- a/apps/web/src/app/q/[id]/group-date-range.test.ts
+++ b/apps/web/src/app/q/[id]/group-date-range.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { groupDateRange } from './group-date-range';
+
+function row(from: string, to: string) {
+  return { dateFrom: new Date(from), dateTo: new Date(to) };
+}
+
+describe('groupDateRange', () => {
+  it('returns the row dates verbatim for a single row', () => {
+    const result = groupDateRange([row('2026-11-07', '2026-11-07')]);
+    expect(result.dateFrom).toEqual(new Date('2026-11-07'));
+    expect(result.dateTo).toEqual(new Date('2026-11-07'));
+  });
+
+  it('regression #78: 4 flex siblings with pinned single-day dates span the union (Nov 7 to Nov 11)', () => {
+    // Issue #78 follow-up: header used to read the primary sibling alone
+    // which gave "Nov 7, 2026 - Nov 7, 2026" instead of the real window.
+    const result = groupDateRange([
+      row('2026-11-07', '2026-11-07'),
+      row('2026-11-08', '2026-11-08'),
+      row('2026-11-09', '2026-11-09'),
+      row('2026-11-11', '2026-11-11'),
+    ]);
+    expect(result.dateFrom).toEqual(new Date('2026-11-07'));
+    expect(result.dateTo).toEqual(new Date('2026-11-11'));
+  });
+
+  it('handles a round trip flex group where each sibling spans outbound to return', () => {
+    const result = groupDateRange([
+      row('2026-11-07', '2026-11-14'),
+      row('2026-11-09', '2026-11-16'),
+      row('2026-11-11', '2026-11-18'),
+    ]);
+    expect(result.dateFrom).toEqual(new Date('2026-11-07'));
+    expect(result.dateTo).toEqual(new Date('2026-11-18'));
+  });
+
+  it('is order independent', () => {
+    const ascending = groupDateRange([
+      row('2026-11-07', '2026-11-07'),
+      row('2026-11-08', '2026-11-08'),
+      row('2026-11-09', '2026-11-09'),
+    ]);
+    const descending = groupDateRange([
+      row('2026-11-09', '2026-11-09'),
+      row('2026-11-08', '2026-11-08'),
+      row('2026-11-07', '2026-11-07'),
+    ]);
+    expect(ascending).toEqual(descending);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => groupDateRange([])).toThrow(/at least one row/);
+  });
+});

--- a/apps/web/src/app/q/[id]/group-date-range.ts
+++ b/apps/web/src/app/q/[id]/group-date-range.ts
@@ -1,0 +1,20 @@
+/**
+ * Travel window across every row in a flex group. Each sibling in a flex
+ * group stores a single pinned date (dateFrom == dateTo), so the union of
+ * their dates is the only correct way to summarise the window in the page
+ * header and the OpenGraph share card. Lives in its own module so the
+ * regression test can run without pulling in next/navigation or prisma
+ * from page.tsx.
+ */
+export function groupDateRange(rows: Array<{ dateFrom: Date; dateTo: Date }>): { dateFrom: Date; dateTo: Date } {
+  if (rows.length === 0) {
+    throw new Error('groupDateRange requires at least one row');
+  }
+  let from = rows[0]!.dateFrom;
+  let to = rows[0]!.dateTo;
+  for (const row of rows) {
+    if (row.dateFrom.getTime() < from.getTime()) from = row.dateFrom;
+    if (row.dateTo.getTime() > to.getTime()) to = row.dateTo;
+  }
+  return { dateFrom: from, dateTo: to };
+}

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -12,6 +12,7 @@ import { ChartActions } from '@/components/ChartActions';
 import { PriceCalendar } from '@/components/PriceCalendar';
 import { Footer } from '@/components/Footer';
 import { StackedSortControls, type StackedItem } from '@/components/StackedSortControls';
+import { groupDateRange } from './group-date-range';
 import styles from './page.module.css';
 
 interface Props {
@@ -24,8 +25,23 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   if (!query) return {};
 
+  // When the row is part of a flex group, every sibling stores a single
+  // pinned date, so the row's own dateFrom/dateTo span only one day. Fetch
+  // the siblings to surface the real travel window on the share card.
+  let dateFrom = query.dateFrom;
+  let dateTo = query.dateTo;
+  if (query.groupId) {
+    const siblings = await prisma.query.findMany({
+      where: { groupId: query.groupId },
+      select: { dateFrom: true, dateTo: true },
+    });
+    if (siblings.length > 0) {
+      ({ dateFrom, dateTo } = groupDateRange(siblings));
+    }
+  }
+
   const title = `${query.originName} to ${query.destinationName} Flight Prices`;
-  const dateRange = `${formatDate(query.dateFrom)} - ${formatDate(query.dateTo)}`;
+  const dateRange = `${formatDate(dateFrom)} - ${formatDate(dateTo)}`;
   const description = `Track ${query.origin} → ${query.destination} flight prices (${dateRange}). See price history, compare airlines, and book at the right moment.`;
 
   return {
@@ -266,14 +282,17 @@ export default async function ChartPage({ params }: Props) {
   }
 
   const isMultiRoute = allQueries.length > 1;
-  // Expiry is computed across the whole group so a partly-expired flex query
-  // (earliest sibling past its expiresAt but later siblings still active)
-  // keeps the tracker controls visible. The page-level countdown shows the
-  // *latest* expiresAt so the user sees the most generous remaining window.
+  // Expiry and the page-level date bubble both span the whole group. Each
+  // sibling in a flex group stores a single pinned date (dateFrom == dateTo),
+  // so reading the primary alone would show "Nov 7 - Nov 7" for a window
+  // that actually runs Nov 7 to Nov 11.
   const now = Date.now();
   const groupExpiresAt = allQueries.reduce<Date>(
     (max, q) => (q.query.expiresAt.getTime() > max.getTime() ? q.query.expiresAt : max),
     primary.query.expiresAt,
+  );
+  const { dateFrom: groupDateFrom, dateTo: groupDateTo } = groupDateRange(
+    allQueries.map((q) => q.query),
   );
   const expired = allQueries.every((q) => now > q.query.expiresAt.getTime());
   const daysLeft = daysUntil(groupExpiresAt);
@@ -316,7 +335,7 @@ export default async function ChartPage({ params }: Props) {
               <span>{primary.query.rawInput}</span>
             </div>
             <div className={styles.meta}>
-              <span>{formatDate(primary.query.dateFrom)} — {formatDate(primary.query.dateTo)}</span>
+              <span>{formatDate(groupDateFrom)} — {formatDate(groupDateTo)}</span>
               {primary.query.flexibility > 0 && (
                 <>
                   <span className={styles.sep}>·</span>
@@ -335,7 +354,7 @@ export default async function ChartPage({ params }: Props) {
             <div className={styles.meta}>
               <span>{primary.query.originName} to {primary.query.destinationName}</span>
               <span className={styles.sep}>·</span>
-              <span>{formatDate(primary.query.dateFrom)} — {formatDate(primary.query.dateTo)}</span>
+              <span>{formatDate(groupDateFrom)} — {formatDate(groupDateTo)}</span>
               {primary.query.flexibility > 0 && (
                 <>
                   <span className={styles.sep}>·</span>


### PR DESCRIPTION
Follow up on the v0.7.1 patch from #79. Reporter on #78 caught a regression: the page-level date bubble on `/q/[id]` reads `primary.query.dateFrom — primary.query.dateTo`, which for a flex group is a single pinned day. Their Nov 7 to Nov 11 window rendered as `Nov 7, 2026 - Nov 7, 2026`.

Same root cause as the `expired` flag I already fixed: every sibling in a flex group stores `dateFrom == dateTo == one day`, so reading the primary alone misses the union. Two lines above the `expired` derivation, the date label was still using the primary; I fixed one cousin and missed the other.

### Fix

* Extracted `groupDateRange` into its own module so the test can hit it without pulling in `next/navigation` or `prisma` from the server component.
* Used the helper in both the multi route and single route header branches.
* Used the helper in `generateMetadata` too (a flex group's share card title/description had the same wrong range).
* New `group-date-range.test.ts` with the exact Nov 7 to Nov 11 case from the reporter's screenshot plus order-independence and empty-input cases.

### Test plan

* `npm run ci`: 632 passed across 44 files.
* New regression test `group-date-range.test.ts` (5 cases) covers the union, order independence, single row, and empty input.
* [ ] Manual: load a flex group on `/q/[id]` and confirm the top bubble reads the full window.
