### PR TITLE
feat: manual force scrape + visual scrape status indicator (#78)

### DIFF
--- a/apps/web/src/app/account/page.module.css
+++ b/apps/web/src/app/account/page.module.css
@@ -95,13 +95,22 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  text-decoration: none;
-  color: inherit;
   transition: border-color 0.15s;
 }
 
 .row:hover {
   border-color: var(--accent-dim);
+}
+
+.rowBody {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex: 1 1 auto;
+  text-decoration: none;
+  color: inherit;
 }
 
 .rowRoute {

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -4,9 +4,17 @@ import { prisma } from '@/lib/prisma';
 import { isMultiUserEnabled } from '@/lib/multi-user';
 import { getCurrentUser } from '@/lib/user-auth';
 import { groupQueries, type GroupableQuery } from '@/lib/query-grouping';
+import { aggregateScrapeStatus } from '@/lib/scrape-status';
+import { ScrapeStatusDot } from '@/components/ScrapeStatusDot';
+import { ForceScrapeButton } from '@/components/ForceScrapeButton';
 import styles from './page.module.css';
 
 export const dynamic = 'force-dynamic';
+
+interface AccountQuery extends GroupableQuery {
+  scrapeStatus: string | null;
+  scrapeError: string | null;
+}
 
 export default async function AccountPage() {
   if (!(await isMultiUserEnabled())) notFound();
@@ -31,10 +39,15 @@ export default async function AccountPage() {
       groupId: true,
       scrapeInterval: true,
       _count: { select: { snapshots: true } },
+      fetchRuns: {
+        orderBy: { startedAt: 'desc' },
+        take: 1,
+        select: { startedAt: true, status: true, error: true },
+      },
     },
   });
 
-  const groupable: GroupableQuery[] = queries.map((q) => ({
+  const groupable: AccountQuery[] = queries.map((q) => ({
     id: q.id,
     origin: q.origin,
     destination: q.destination,
@@ -47,6 +60,9 @@ export default async function AccountPage() {
     expiresAt: q.expiresAt.toISOString(),
     scrapeInterval: q.scrapeInterval,
     snapshotCount: q._count.snapshots,
+    lastScrapedAt: q.fetchRuns[0]?.startedAt.toISOString() ?? null,
+    scrapeStatus: q.fetchRuns[0]?.status ?? null,
+    scrapeError: q.fetchRuns[0]?.error ?? null,
     createdAt: q.createdAt.toISOString(),
   }));
 
@@ -79,22 +95,42 @@ export default async function AccountPage() {
           <div className={styles.list}>
             {groups.map((g) => {
               const extraDestinations = g.destinations.length - 1;
+              const aggregate = aggregateScrapeStatus(
+                g.queries.map((q) => ({
+                  status: q.scrapeStatus,
+                  error: q.scrapeError,
+                  startedAt: q.lastScrapedAt ?? null,
+                })),
+              );
               return (
-                <Link key={g.primaryId} href={`/q/${g.primaryId}`} className={styles.row}>
-                  <div className={styles.rowRoute}>
-                    <span className={styles.rowCode}>{g.origin}</span>
-                    <span className={styles.rowArrow}>→</span>
-                    <span className={styles.rowCode}>{g.destination}</span>
-                    {extraDestinations > 0 && (
-                      <span className={styles.rowMeta}>+ {extraDestinations} more</span>
-                    )}
-                  </div>
-                  <div className={styles.rowMeta}>
-                    {fmt(g.dateFrom)} {' '} {fmt(g.dateTo)} {' '} {g.snapshotCount} snapshots
-                    {g.routeCount > 1 && ` · ${g.routeCount} charts`}
-                    {!g.anyActive && <span className={styles.paused}>paused</span>}
-                  </div>
-                </Link>
+                <div key={g.primaryId} className={styles.row}>
+                  <Link href={`/q/${g.primaryId}`} className={styles.rowBody}>
+                    <div className={styles.rowRoute}>
+                      <span className={styles.rowCode}>{g.origin}</span>
+                      <span className={styles.rowArrow}>→</span>
+                      <span className={styles.rowCode}>{g.destination}</span>
+                      {extraDestinations > 0 && (
+                        <span className={styles.rowMeta}>+ {extraDestinations} more</span>
+                      )}
+                    </div>
+                    <div className={styles.rowMeta}>
+                      <ScrapeStatusDot
+                        status={aggregate.status}
+                        error={aggregate.error}
+                        lastScrapedAt={aggregate.startedAt}
+                      />
+                      {fmt(g.dateFrom)} {' '} {fmt(g.dateTo)} {' '} {g.snapshotCount} snapshots
+                      {g.routeCount > 1 && ` · ${g.routeCount} charts`}
+                      {!g.anyActive && <span className={styles.paused}>paused</span>}
+                    </div>
+                  </Link>
+                  {g.anyActive && (
+                    <ForceScrapeButton
+                      queryId={g.primaryId}
+                      ariaLabel="Refresh prices now"
+                    />
+                  )}
+                </div>
               );
             })}
           </div>

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -124,7 +124,7 @@ export default async function AccountPage() {
                       {!g.anyActive && <span className={styles.paused}>paused</span>}
                     </div>
                   </Link>
-                  {g.anyActive && (
+                  {g.anyActive && !g.allExpired && (
                     <ForceScrapeButton
                       queryId={g.primaryId}
                       ariaLabel="Refresh prices now"

--- a/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
+++ b/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
@@ -2,6 +2,9 @@
 
 import { useRouter } from 'next/navigation';
 import { type QueryGroup, type GroupableQuery } from '@/lib/query-grouping';
+import { aggregateScrapeStatus } from '@/lib/scrape-status';
+import { ScrapeStatusDot } from '@/components/ScrapeStatusDot';
+import { ForceScrapeButton } from '@/components/ForceScrapeButton';
 import styles from './page.module.css';
 
 export interface AdminQuery extends GroupableQuery {
@@ -10,6 +13,8 @@ export interface AdminQuery extends GroupableQuery {
   scrapeInterval: number | null;
   snapshotCount: number;
   runCount: number;
+  scrapeStatus: string | null;
+  scrapeError: string | null;
 }
 
 function formatDate(iso: string): string {
@@ -21,6 +26,13 @@ export function QueryGroupRow({ group }: { group: QueryGroup<AdminQuery> }) {
   const expired = group.allExpired;
   const runCount = group.queries.reduce((sum, q) => sum + q.runCount, 0);
   const extraDestinations = group.destinations.length - 1;
+  const aggregate = aggregateScrapeStatus(
+    group.queries.map((q) => ({
+      status: q.scrapeStatus,
+      error: q.scrapeError,
+      startedAt: q.lastScrapedAt ?? null,
+    })),
+  );
 
   const handleToggle = async () => {
     await fetch(`/api/admin/queries/${group.primaryId}`, {
@@ -67,6 +79,11 @@ export function QueryGroupRow({ group }: { group: QueryGroup<AdminQuery> }) {
         )}
       </div>
       <div className={styles.rowMeta}>
+        <ScrapeStatusDot
+          status={aggregate.status}
+          error={aggregate.error}
+          lastScrapedAt={aggregate.startedAt}
+        />
         <span>{formatDate(group.dateFrom)} — {formatDate(group.dateTo)}</span>
         <span className={styles.rowSep}>·</span>
         <span>{group.snapshotCount} snapshots</span>
@@ -86,6 +103,13 @@ export function QueryGroupRow({ group }: { group: QueryGroup<AdminQuery> }) {
           <option value={12}>Every 12h</option>
           <option value={24}>Every 24h</option>
         </select>
+        {group.anyActive && !expired && (
+          <ForceScrapeButton
+            queryId={group.primaryId}
+            onScraped={(result) => { if (result.accepted) router.refresh(); }}
+            ariaLabel="Refresh prices now"
+          />
+        )}
         <button
           className={group.anyActive ? styles.pauseButton : styles.resumeButton}
           onClick={handleToggle}

--- a/apps/web/src/app/admin/(dashboard)/queries/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/queries/page.tsx
@@ -10,6 +10,11 @@ export default async function QueriesPage() {
     orderBy: { createdAt: 'desc' },
     include: {
       _count: { select: { snapshots: true, fetchRuns: true } },
+      fetchRuns: {
+        orderBy: { startedAt: 'desc' },
+        take: 1,
+        select: { startedAt: true, status: true, error: true },
+      },
     },
   });
 
@@ -28,6 +33,9 @@ export default async function QueriesPage() {
     snapshotCount: q._count.snapshots,
     runCount: q._count.fetchRuns,
     createdAt: q.createdAt.toISOString(),
+    lastScrapedAt: q.fetchRuns[0]?.startedAt.toISOString() ?? null,
+    scrapeStatus: q.fetchRuns[0]?.status ?? null,
+    scrapeError: q.fetchRuns[0]?.error ?? null,
   }));
 
   const groups = groupQueries(adminRows);

--- a/apps/web/src/app/api/admin/queries/route.ts
+++ b/apps/web/src/app/api/admin/queries/route.ts
@@ -9,6 +9,11 @@ export async function GET() {
     orderBy: { createdAt: 'desc' },
     include: {
       _count: { select: { snapshots: true, fetchRuns: true } },
+      fetchRuns: {
+        orderBy: { startedAt: 'desc' },
+        take: 1,
+        select: { startedAt: true, status: true, error: true },
+      },
     },
   });
 

--- a/apps/web/src/app/api/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/route.test.ts
@@ -30,6 +30,16 @@ vi.mock('@/lib/user-auth', () => ({
   getCurrentUser: () => mockGetCurrentUser(),
 }));
 
+// After authorizeMutation moved to @/lib/query-auth, every hosted mode path
+// calls getSessionToken() -> cookies() from next/headers. Without this mock
+// jsdom-less Vitest blows up the moment authorizeMutation is invoked.
+const mockGetSessionToken = vi.fn().mockResolvedValue(undefined);
+const mockVerifySessionToken = vi.fn().mockReturnValue(false);
+vi.mock('@/lib/admin-auth', () => ({
+  getSessionToken: () => mockGetSessionToken(),
+  verifySessionToken: (token: string) => mockVerifySessionToken(token),
+}));
+
 import { DELETE, PATCH } from './route';
 
 function makeDeleteRequest(id: string, body?: Record<string, unknown>): [NextRequest, { params: Promise<{ id: string }> }] {
@@ -123,6 +133,24 @@ describe('DELETE /api/queries/[id]', () => {
     mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token' });
     const res = await DELETE(...makeDeleteRequest('q1', {}));
     expect(res.status).toBe(401);
+  });
+
+  it('hosted mode: legacy admin session cookie authorizes without a token', async () => {
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token' });
+    mockGetSessionToken.mockResolvedValueOnce('admin:1234.abc');
+    mockVerifySessionToken.mockReturnValueOnce(true);
+    const res = await DELETE(...makeDeleteRequest('q1', {}));
+    expect(res.status).toBe(200);
+    expect(mockQueryDelete).toHaveBeenCalledWith({ where: { id: 'q1' } });
+  });
+
+  it('hosted mode: invalid admin session falls through to token check', async () => {
+    mockQueryFindUnique.mockResolvedValue({ deleteToken: 'real-token' });
+    mockGetSessionToken.mockResolvedValueOnce('admin:1234.deadbeef');
+    mockVerifySessionToken.mockReturnValueOnce(false);
+    const res = await DELETE(...makeDeleteRequest('q1', {}));
+    expect(res.status).toBe(401);
+    expect(mockQueryDelete).not.toHaveBeenCalled();
   });
 
   describe('self hosted multi user mode', () => {

--- a/apps/web/src/app/api/queries/[id]/route.ts
+++ b/apps/web/src/app/api/queries/[id]/route.ts
@@ -1,60 +1,9 @@
 import { NextRequest } from 'next/server';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
-import { isMultiUserEnabled } from '@/lib/multi-user';
-import { getCurrentUser } from '@/lib/user-auth';
+import { authorizeMutation } from '@/lib/query-auth';
 
 const ALLOWED_INTERVALS = [1, 3, 6, 12, 24];
-
-interface AuthResult {
-  ok: boolean;
-  status?: number;
-  error?: string;
-}
-
-/**
- * Authorize a mutation on `query` for the current request. The rules:
- *
- *   - hosted (SELF_HOSTED unset): require a matching deleteToken (existing
- *     behavior, public users own their queries via the cookie they get back
- *     at create time)
- *   - self hosted solo mode (multiUserMode off): no token check; whoever has
- *     access to the box owns everything (existing behavior)
- *   - self hosted multi user mode: admin session OR matching deleteToken OR
- *     matching user session whose userId equals query.userId. Queries with
- *     no owner (e.g. seeds) are admin only.
- */
-async function authorizeMutation(
-  query: { deleteToken: string | null; userId?: string | null },
-  token: string | undefined | null,
-): Promise<AuthResult> {
-  const isSelfHosted = process.env.SELF_HOSTED === 'true';
-  const multiUser = isSelfHosted ? await isMultiUserEnabled() : false;
-
-  if (isSelfHosted && !multiUser) {
-    return { ok: true };
-  }
-
-  if (multiUser) {
-    const user = await getCurrentUser();
-    if (user?.isAdmin) return { ok: true };
-    if (token && query.deleteToken && query.deleteToken === token) {
-      return { ok: true };
-    }
-    if (user && query.userId && query.userId === user.id) {
-      return { ok: true };
-    }
-    return { ok: false, status: 403, error: 'Not authorized to modify this tracker' };
-  }
-
-  if (!token || typeof token !== 'string') {
-    return { ok: false, status: 401, error: 'Missing delete token' };
-  }
-  if (!query.deleteToken || query.deleteToken !== token) {
-    return { ok: false, status: 403, error: 'Invalid delete token' };
-  }
-  return { ok: true };
-}
 
 export async function PATCH(
   request: NextRequest,

--- a/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockQueryFindUnique = vi.fn();
+const mockQueryFindMany = vi.fn();
+const mockFetchRunCreate = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    query: {
+      findUnique: (...args: unknown[]) => mockQueryFindUnique(...args),
+      findMany: (...args: unknown[]) => mockQueryFindMany(...args),
+    },
+    fetchRun: {
+      create: (...args: unknown[]) => mockFetchRunCreate(...args),
+    },
+  },
+}));
+
+const mockIsMultiUserEnabled = vi.fn().mockResolvedValue(false);
+const mockGetCurrentUser = vi.fn().mockResolvedValue(null);
+vi.mock('@/lib/multi-user', () => ({ isMultiUserEnabled: () => mockIsMultiUserEnabled() }));
+vi.mock('@/lib/user-auth', () => ({ getCurrentUser: () => mockGetCurrentUser() }));
+
+const mockGetSessionToken = vi.fn().mockResolvedValue(undefined);
+const mockVerifySessionToken = vi.fn().mockReturnValue(false);
+vi.mock('@/lib/admin-auth', () => ({
+  getSessionToken: () => mockGetSessionToken(),
+  verifySessionToken: (token: string) => mockVerifySessionToken(token),
+}));
+
+const mockRedisSet = vi.fn();
+const mockRedisRef = { current: { set: mockRedisSet } as { set: typeof mockRedisSet } | null };
+vi.mock('@/lib/redis', () => ({
+  get redis() {
+    return mockRedisRef.current;
+  },
+}));
+
+const mockRunFullScrapeForQuery = vi.fn().mockResolvedValue([]);
+vi.mock('@/lib/scraper/run-scrape', () => ({
+  runFullScrapeForQuery: (queryId: string, opts?: { fetchRunId?: string }) =>
+    mockRunFullScrapeForQuery(queryId, opts),
+}));
+
+import { POST } from './route';
+
+function makeRequest(id: string, body?: Record<string, unknown>): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost/api/queries/${id}/scrape`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : '{}',
+    }),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+async function flushIifeMicrotasks() {
+  // The handler kicks the scrape in a fire-and-forget IIFE. The runs are
+  // sequential so a single microtask flush is enough to let the first call
+  // appear in the mock; the loop continues on the same tick chain.
+  await new Promise((r) => setImmediate(r));
+}
+
+describe('POST /api/queries/[id]/scrape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunFullScrapeForQuery.mockResolvedValue([]);
+    mockRedisRef.current = { set: mockRedisSet };
+    mockRedisSet.mockResolvedValue('OK');
+    mockFetchRunCreate.mockImplementation(({ data }: { data: { queryId: string } }) =>
+      Promise.resolve({ id: `fr_${data.queryId}`, queryId: data.queryId }),
+    );
+    mockIsMultiUserEnabled.mockResolvedValue(false);
+    mockGetCurrentUser.mockResolvedValue(null);
+    mockGetSessionToken.mockResolvedValue(undefined);
+    mockVerifySessionToken.mockReturnValue(false);
+    delete process.env.SELF_HOSTED;
+  });
+
+  afterEach(() => {
+    delete process.env.SELF_HOSTED;
+  });
+
+  it('returns 404 when the query does not exist', async () => {
+    mockQueryFindUnique.mockResolvedValue(null);
+    const res = await POST(...makeRequest('missing', { deleteToken: 'tok' }));
+    expect(res.status).toBe(404);
+    expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 in hosted mode without a token or admin cookie', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
+    });
+    const res = await POST(...makeRequest('q1', {}));
+    expect(res.status).toBe(401);
+    expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 in hosted mode with a wrong token', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
+    });
+    const res = await POST(...makeRequest('q1', { deleteToken: 'nope' }));
+    expect(res.status).toBe(403);
+    expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 on a paused tracker', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: null, userId: null, active: false, isSeed: false,
+    });
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    const data = await res.json();
+    expect(res.status).toBe(409);
+    expect(data.error).toContain('paused');
+    expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 on a seed query', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: true,
+    });
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    expect(res.status).toBe(409);
+    expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
+  });
+
+  it('hosted mode + valid token: fires once, pre-creates one FetchRun row, returns accepted', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
+    });
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data).toMatchObject({ accepted: true, count: 1, groupId: null });
+    expect(mockFetchRunCreate).toHaveBeenCalledTimes(1);
+    expect(mockFetchRunCreate).toHaveBeenCalledWith({
+      data: { queryId: 'q1', status: 'in_progress', source: 'manual' },
+      select: { id: true, queryId: true },
+    });
+    await flushIifeMicrotasks();
+    expect(mockRunFullScrapeForQuery).toHaveBeenCalledWith('q1', { fetchRunId: 'fr_q1' });
+  });
+
+  it('cascades across siblings in serial when the row has a groupId', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: 'g1', userId: null, active: true, isSeed: false,
+    });
+    mockQueryFindMany.mockResolvedValue([
+      { id: 'q1' }, { id: 'q2' }, { id: 'q3' }, { id: 'q4' },
+    ]);
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data).toMatchObject({ accepted: true, count: 4, groupId: 'g1' });
+    expect(mockFetchRunCreate).toHaveBeenCalledTimes(4);
+    // Run a few microtasks so the IIFE can reach every sibling.
+    for (let i = 0; i < 6; i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    expect(mockRunFullScrapeForQuery).toHaveBeenCalledTimes(4);
+    expect(mockRunFullScrapeForQuery.mock.calls.map((c) => c[0])).toEqual(['q1', 'q2', 'q3', 'q4']);
+  });
+
+  it('returns 429 when Redis says the throttle key already exists', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: 'g1', userId: null, active: true, isSeed: false,
+    });
+    mockQueryFindMany.mockResolvedValue([{ id: 'q1' }, { id: 'q2' }]);
+    mockRedisSet.mockResolvedValueOnce(null);
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    expect(res.status).toBe(429);
+    expect(mockFetchRunCreate).not.toHaveBeenCalled();
+    expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
+  });
+
+  it('continues when Redis throws (graceful degrade)', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
+    });
+    mockRedisSet.mockRejectedValueOnce(new Error('redis down'));
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    expect(res.status).toBe(200);
+    await flushIifeMicrotasks();
+    expect(mockRunFullScrapeForQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues when Redis is disabled (redis === null)', async () => {
+    mockRedisRef.current = null;
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
+    });
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.throttledUntil).toBeNull();
+    await flushIifeMicrotasks();
+    expect(mockRunFullScrapeForQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('hosted mode legacy admin session authorises without a token', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
+    });
+    mockGetSessionToken.mockResolvedValueOnce('admin:1234.abc');
+    mockVerifySessionToken.mockReturnValueOnce(true);
+    const res = await POST(...makeRequest('q1', {}));
+    expect(res.status).toBe(200);
+    await flushIifeMicrotasks();
+    expect(mockRunFullScrapeForQuery).toHaveBeenCalledTimes(1);
+  });
+
+  describe('self hosted multi user mode', () => {
+    beforeEach(() => {
+      process.env.SELF_HOSTED = 'true';
+      mockIsMultiUserEnabled.mockResolvedValue(true);
+    });
+
+    it('admin session passes without token', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'admin_1', isAdmin: true });
+      mockQueryFindUnique.mockResolvedValue({
+        deleteToken: 'real-token', groupId: null, userId: 'someone_else', active: true, isSeed: false,
+      });
+      const res = await POST(...makeRequest('q1', {}));
+      expect(res.status).toBe(200);
+      await flushIifeMicrotasks();
+      expect(mockRunFullScrapeForQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('owner user passes', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user_1', isAdmin: false });
+      mockQueryFindUnique.mockResolvedValue({
+        deleteToken: 'real-token', groupId: null, userId: 'user_1', active: true, isSeed: false,
+      });
+      const res = await POST(...makeRequest('q1', {}));
+      expect(res.status).toBe(200);
+    });
+
+    it('non owner non admin gets 403', async () => {
+      mockGetCurrentUser.mockResolvedValue({ id: 'user_2', isAdmin: false });
+      mockQueryFindUnique.mockResolvedValue({
+        deleteToken: 'real-token', groupId: null, userId: 'user_1', active: true, isSeed: false,
+      });
+      const res = await POST(...makeRequest('q1', {}));
+      expect(res.status).toBe(403);
+      expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from 'next/server';
 const mockQueryFindUnique = vi.fn();
 const mockQueryFindMany = vi.fn();
 const mockFetchRunCreate = vi.fn();
+const mockFetchRunFindFirst = vi.fn();
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
@@ -13,6 +14,7 @@ vi.mock('@/lib/prisma', () => ({
     },
     fetchRun: {
       create: (...args: unknown[]) => mockFetchRunCreate(...args),
+      findFirst: (...args: unknown[]) => mockFetchRunFindFirst(...args),
     },
   },
 }));
@@ -63,6 +65,21 @@ async function flushIifeMicrotasks() {
   await new Promise((r) => setImmediate(r));
 }
 
+const FAR_FUTURE = new Date('2099-01-01T00:00:00Z');
+const FAR_PAST = new Date('2000-01-01T00:00:00Z');
+
+function rowDefaults(overrides: Record<string, unknown> = {}) {
+  return {
+    deleteToken: 'real-token',
+    groupId: null,
+    userId: null,
+    active: true,
+    isSeed: false,
+    expiresAt: FAR_FUTURE,
+    ...overrides,
+  };
+}
+
 describe('POST /api/queries/[id]/scrape', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,6 +89,7 @@ describe('POST /api/queries/[id]/scrape', () => {
     mockFetchRunCreate.mockImplementation(({ data }: { data: { queryId: string } }) =>
       Promise.resolve({ id: `fr_${data.queryId}`, queryId: data.queryId }),
     );
+    mockFetchRunFindFirst.mockResolvedValue(null);
     mockIsMultiUserEnabled.mockResolvedValue(false);
     mockGetCurrentUser.mockResolvedValue(null);
     mockGetSessionToken.mockResolvedValue(undefined);
@@ -91,27 +109,21 @@ describe('POST /api/queries/[id]/scrape', () => {
   });
 
   it('returns 401 in hosted mode without a token or admin cookie', async () => {
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults());
     const res = await POST(...makeRequest('q1', {}));
     expect(res.status).toBe(401);
     expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
   });
 
   it('returns 403 in hosted mode with a wrong token', async () => {
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults());
     const res = await POST(...makeRequest('q1', { deleteToken: 'nope' }));
     expect(res.status).toBe(403);
     expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
   });
 
   it('returns 409 on a paused tracker', async () => {
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: null, userId: null, active: false, isSeed: false,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults({ active: false }));
     const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
     const data = await res.json();
     expect(res.status).toBe(409);
@@ -120,18 +132,44 @@ describe('POST /api/queries/[id]/scrape', () => {
   });
 
   it('returns 409 on a seed query', async () => {
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: true,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults({ isSeed: true }));
     const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
     expect(res.status).toBe(409);
     expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
   });
 
+  it('returns 410 on an expired tracker (active but past expiresAt)', async () => {
+    mockQueryFindUnique.mockResolvedValue(rowDefaults({ expiresAt: FAR_PAST }));
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    const data = await res.json();
+    expect(res.status).toBe(410);
+    expect(data.error).toContain('expired');
+    expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when a sibling already has an in_progress FetchRun row', async () => {
+    mockQueryFindUnique.mockResolvedValue(rowDefaults({ groupId: 'g1' }));
+    mockQueryFindMany.mockResolvedValue([{ id: 'q1' }, { id: 'q2' }]);
+    mockFetchRunFindFirst.mockResolvedValueOnce({ id: 'stuck-run' });
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    const data = await res.json();
+    expect(res.status).toBe(429);
+    expect(data.error).toContain('already running');
+    expect(mockFetchRunCreate).not.toHaveBeenCalled();
+    expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
+  });
+
+  it('still blocks an in-progress run even when Redis is disabled', async () => {
+    mockRedisRef.current = null;
+    mockQueryFindUnique.mockResolvedValue(rowDefaults());
+    mockFetchRunFindFirst.mockResolvedValueOnce({ id: 'stuck-run' });
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    expect(res.status).toBe(429);
+    expect(mockFetchRunCreate).not.toHaveBeenCalled();
+  });
+
   it('hosted mode + valid token: fires once, pre-creates one FetchRun row, returns accepted', async () => {
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults());
     const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
     const data = await res.json();
     expect(res.status).toBe(200);
@@ -146,9 +184,7 @@ describe('POST /api/queries/[id]/scrape', () => {
   });
 
   it('cascades across siblings in serial when the row has a groupId', async () => {
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: 'g1', userId: null, active: true, isSeed: false,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults({ groupId: 'g1' }));
     mockQueryFindMany.mockResolvedValue([
       { id: 'q1' }, { id: 'q2' }, { id: 'q3' }, { id: 'q4' },
     ]);
@@ -166,9 +202,7 @@ describe('POST /api/queries/[id]/scrape', () => {
   });
 
   it('returns 429 when Redis says the throttle key already exists', async () => {
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: 'g1', userId: null, active: true, isSeed: false,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults({ groupId: 'g1' }));
     mockQueryFindMany.mockResolvedValue([{ id: 'q1' }, { id: 'q2' }]);
     mockRedisSet.mockResolvedValueOnce(null);
     const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
@@ -178,9 +212,7 @@ describe('POST /api/queries/[id]/scrape', () => {
   });
 
   it('continues when Redis throws (graceful degrade)', async () => {
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults());
     mockRedisSet.mockRejectedValueOnce(new Error('redis down'));
     const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
     expect(res.status).toBe(200);
@@ -190,9 +222,7 @@ describe('POST /api/queries/[id]/scrape', () => {
 
   it('continues when Redis is disabled (redis === null)', async () => {
     mockRedisRef.current = null;
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults());
     const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
     const data = await res.json();
     expect(res.status).toBe(200);
@@ -202,9 +232,7 @@ describe('POST /api/queries/[id]/scrape', () => {
   });
 
   it('hosted mode legacy admin session authorises without a token', async () => {
-    mockQueryFindUnique.mockResolvedValue({
-      deleteToken: 'real-token', groupId: null, userId: null, active: true, isSeed: false,
-    });
+    mockQueryFindUnique.mockResolvedValue(rowDefaults());
     mockGetSessionToken.mockResolvedValueOnce('admin:1234.abc');
     mockVerifySessionToken.mockReturnValueOnce(true);
     const res = await POST(...makeRequest('q1', {}));
@@ -221,9 +249,7 @@ describe('POST /api/queries/[id]/scrape', () => {
 
     it('admin session passes without token', async () => {
       mockGetCurrentUser.mockResolvedValue({ id: 'admin_1', isAdmin: true });
-      mockQueryFindUnique.mockResolvedValue({
-        deleteToken: 'real-token', groupId: null, userId: 'someone_else', active: true, isSeed: false,
-      });
+      mockQueryFindUnique.mockResolvedValue(rowDefaults({ userId: 'someone_else' }));
       const res = await POST(...makeRequest('q1', {}));
       expect(res.status).toBe(200);
       await flushIifeMicrotasks();
@@ -232,18 +258,14 @@ describe('POST /api/queries/[id]/scrape', () => {
 
     it('owner user passes', async () => {
       mockGetCurrentUser.mockResolvedValue({ id: 'user_1', isAdmin: false });
-      mockQueryFindUnique.mockResolvedValue({
-        deleteToken: 'real-token', groupId: null, userId: 'user_1', active: true, isSeed: false,
-      });
+      mockQueryFindUnique.mockResolvedValue(rowDefaults({ userId: 'user_1' }));
       const res = await POST(...makeRequest('q1', {}));
       expect(res.status).toBe(200);
     });
 
     it('non owner non admin gets 403', async () => {
       mockGetCurrentUser.mockResolvedValue({ id: 'user_2', isAdmin: false });
-      mockQueryFindUnique.mockResolvedValue({
-        deleteToken: 'real-token', groupId: null, userId: 'user_1', active: true, isSeed: false,
-      });
+      mockQueryFindUnique.mockResolvedValue(rowDefaults({ userId: 'user_1' }));
       const res = await POST(...makeRequest('q1', {}));
       expect(res.status).toBe(403);
       expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();

--- a/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
-const mockQueryFindUnique = vi.fn();
-const mockQueryFindMany = vi.fn();
-const mockFetchRunCreate = vi.fn();
-const mockFetchRunFindFirst = vi.fn();
+const {
+  mockQueryFindUnique,
+  mockQueryFindMany,
+  mockFetchRunCreate,
+  mockFetchRunFindFirst,
+} = vi.hoisted(() => ({
+  mockQueryFindUnique: vi.fn(),
+  mockQueryFindMany: vi.fn(),
+  mockFetchRunCreate: vi.fn(),
+  mockFetchRunFindFirst: vi.fn(),
+}));
 
-vi.mock('@/lib/prisma', () => ({
-  prisma: {
+vi.mock('@/lib/prisma', () => {
+  const txClient = {
     query: {
       findUnique: (...args: unknown[]) => mockQueryFindUnique(...args),
       findMany: (...args: unknown[]) => mockQueryFindMany(...args),
@@ -16,8 +23,17 @@ vi.mock('@/lib/prisma', () => ({
       create: (...args: unknown[]) => mockFetchRunCreate(...args),
       findFirst: (...args: unknown[]) => mockFetchRunFindFirst(...args),
     },
-  },
-}));
+  };
+  return {
+    prisma: {
+      ...txClient,
+      $transaction: async (
+        cb: (tx: typeof txClient) => Promise<unknown>,
+        _opts?: unknown,
+      ) => cb(txClient),
+    },
+  };
+});
 
 const mockIsMultiUserEnabled = vi.fn().mockResolvedValue(false);
 const mockGetCurrentUser = vi.fn().mockResolvedValue(null);
@@ -168,7 +184,7 @@ describe('POST /api/queries/[id]/scrape', () => {
     expect(mockFetchRunCreate).not.toHaveBeenCalled();
   });
 
-  it('hosted mode + valid token: fires once, pre-creates one FetchRun row, returns accepted', async () => {
+  it('hosted mode + valid token: pre-creates only the primary row, fires once, returns accepted', async () => {
     mockQueryFindUnique.mockResolvedValue(rowDefaults());
     const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
     const data = await res.json();
@@ -177,28 +193,38 @@ describe('POST /api/queries/[id]/scrape', () => {
     expect(mockFetchRunCreate).toHaveBeenCalledTimes(1);
     expect(mockFetchRunCreate).toHaveBeenCalledWith({
       data: { queryId: 'q1', status: 'in_progress', source: 'manual' },
-      select: { id: true, queryId: true },
+      select: { id: true },
     });
     await flushIifeMicrotasks();
     expect(mockRunFullScrapeForQuery).toHaveBeenCalledWith('q1', { fetchRunId: 'fr_q1' });
   });
 
-  it('cascades across siblings in serial when the row has a groupId', async () => {
+  it('cascades across siblings in serial: primary first with reused row, rest without opts', async () => {
     mockQueryFindUnique.mockResolvedValue(rowDefaults({ groupId: 'g1' }));
     mockQueryFindMany.mockResolvedValue([
-      { id: 'q1' }, { id: 'q2' }, { id: 'q3' }, { id: 'q4' },
+      { id: 'q2' }, { id: 'q1' }, { id: 'q3' }, { id: 'q4' },
     ]);
     const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
     const data = await res.json();
     expect(res.status).toBe(200);
     expect(data.data).toMatchObject({ accepted: true, count: 4, groupId: 'g1' });
-    expect(mockFetchRunCreate).toHaveBeenCalledTimes(4);
-    // Run a few microtasks so the IIFE can reach every sibling.
+    // Only the primary's row is pre-created. Sibling rows are created
+    // inside runScrapeForQuery as the loop reaches them (mocked out here).
+    expect(mockFetchRunCreate).toHaveBeenCalledTimes(1);
+    expect(mockFetchRunCreate).toHaveBeenCalledWith({
+      data: { queryId: 'q1', status: 'in_progress', source: 'manual' },
+      select: { id: true },
+    });
+    // Run microtasks so the serial IIFE can reach every sibling.
     for (let i = 0; i < 6; i++) {
       await new Promise((r) => setImmediate(r));
     }
     expect(mockRunFullScrapeForQuery).toHaveBeenCalledTimes(4);
+    // Primary runs first and reuses the pre-created row id; the rest pass
+    // no opts and let runScrapeForQuery create rows just-in-time.
     expect(mockRunFullScrapeForQuery.mock.calls.map((c) => c[0])).toEqual(['q1', 'q2', 'q3', 'q4']);
+    expect(mockRunFullScrapeForQuery.mock.calls[0]?.[1]).toEqual({ fetchRunId: 'fr_q1' });
+    expect(mockRunFullScrapeForQuery.mock.calls[1]?.[1]).toBeUndefined();
   });
 
   it('returns 429 when Redis says the throttle key already exists', async () => {

--- a/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
@@ -6,11 +6,13 @@ const {
   mockQueryFindMany,
   mockFetchRunCreate,
   mockFetchRunFindFirst,
+  mockFetchRunUpdate,
 } = vi.hoisted(() => ({
   mockQueryFindUnique: vi.fn(),
   mockQueryFindMany: vi.fn(),
   mockFetchRunCreate: vi.fn(),
   mockFetchRunFindFirst: vi.fn(),
+  mockFetchRunUpdate: vi.fn(),
 }));
 
 vi.mock('@/lib/prisma', () => {
@@ -22,6 +24,7 @@ vi.mock('@/lib/prisma', () => {
     fetchRun: {
       create: (...args: unknown[]) => mockFetchRunCreate(...args),
       findFirst: (...args: unknown[]) => mockFetchRunFindFirst(...args),
+      update: (...args: unknown[]) => mockFetchRunUpdate(...args),
     },
   };
   return {
@@ -106,6 +109,7 @@ describe('POST /api/queries/[id]/scrape', () => {
       Promise.resolve({ id: `fr_${data.queryId}`, queryId: data.queryId }),
     );
     mockFetchRunFindFirst.mockResolvedValue(null);
+    mockFetchRunUpdate.mockResolvedValue({});
     mockIsMultiUserEnabled.mockResolvedValue(false);
     mockGetCurrentUser.mockResolvedValue(null);
     mockGetSessionToken.mockResolvedValue(undefined);
@@ -255,6 +259,21 @@ describe('POST /api/queries/[id]/scrape', () => {
     expect(data.data.throttledUntil).toBeNull();
     await flushIifeMicrotasks();
     expect(mockRunFullScrapeForQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the pre-created primary row failed when runFullScrapeForQuery throws', async () => {
+    mockQueryFindUnique.mockResolvedValue(rowDefaults());
+    mockRunFullScrapeForQuery.mockRejectedValueOnce(new Error('boom'));
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    expect(res.status).toBe(200);
+    // Let the background IIFE settle.
+    for (let i = 0; i < 4; i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    expect(mockFetchRunUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'fr_q1' },
+      data: expect.objectContaining({ status: 'failed', error: 'boom' }),
+    }));
   });
 
   it('hosted mode legacy admin session authorises without a token', async () => {

--- a/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
@@ -188,6 +188,22 @@ describe('POST /api/queries/[id]/scrape', () => {
     expect(mockFetchRunCreate).not.toHaveBeenCalled();
   });
 
+  it('ignores stale in_progress rows older than the staleness cutoff', async () => {
+    mockQueryFindUnique.mockResolvedValue(rowDefaults());
+    // No in-progress row younger than the cutoff -> findFirst returns null.
+    // We assert the query the endpoint sent includes a startedAt>staleBefore
+    // filter so a half-finished crashed run cannot deadlock the group.
+    mockFetchRunFindFirst.mockImplementation(({ where }: { where: { startedAt?: { gt?: Date } } }) => {
+      expect(where.startedAt?.gt).toBeInstanceOf(Date);
+      expect(where.startedAt!.gt!.getTime()).toBeLessThan(Date.now());
+      return Promise.resolve(null);
+    });
+    const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+    expect(res.status).toBe(200);
+    await flushIifeMicrotasks();
+    expect(mockRunFullScrapeForQuery).toHaveBeenCalledTimes(1);
+  });
+
   it('hosted mode + valid token: pre-creates only the primary row, fires once, returns accepted', async () => {
     mockQueryFindUnique.mockResolvedValue(rowDefaults());
     const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));

--- a/apps/web/src/app/api/queries/[id]/scrape/route.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.ts
@@ -89,38 +89,56 @@ export async function POST(
     return apiError('Force scrape was triggered less than a minute ago. Try again shortly.', 429);
   }
 
-  // Second lock that outlasts the Redis TTL. Multi-sibling or multi-VPN
-  // runs can take many minutes; the Redis key expires long before then. A
-  // direct DB check on `in_progress` rows catches that case AND also works
-  // when Redis is disabled entirely.
-  const stale = await prisma.fetchRun.findFirst({
-    where: { queryId: { in: targetIds }, status: 'in_progress' },
-    select: { id: true },
-  });
-  if (stale) {
-    return apiError('A scrape is already running for this tracker. Wait for it to finish.', 429);
+  // Atomic check-and-reserve. Two concurrent POSTs (different tabs, admin +
+  // account view on the same group) could both read "no in_progress rows"
+  // before either inserted, then both pre-create + fire. A Serializable
+  // transaction makes one of them retry (the loser sees Prisma's P2034 or
+  // a Postgres 40001) so only one scrape kicks off. Also catches the case
+  // where Redis is disabled entirely.
+  //
+  // Only the row for the originally-clicked id (`id`, not every sibling) is
+  // pre-created. Sibling rows are created inside `runScrapeForQuery` when
+  // the loop reaches them, so an early-exit (paused mid-cascade, process
+  // crash, etc.) cannot leave orphaned in_progress rows behind to block
+  // future refreshes.
+  let primaryFetchRun: { id: string };
+  try {
+    primaryFetchRun = await prisma.$transaction(async (tx) => {
+      const inProgress = await tx.fetchRun.findFirst({
+        where: { queryId: { in: targetIds }, status: 'in_progress' },
+        select: { id: true },
+      });
+      if (inProgress) {
+        throw new Error('SCRAPE_IN_PROGRESS');
+      }
+      return tx.fetchRun.create({
+        data: { queryId: id, status: 'in_progress', source: 'manual' },
+        select: { id: true },
+      });
+    }, { isolationLevel: 'Serializable' });
+  } catch (err) {
+    if (err instanceof Error && err.message === 'SCRAPE_IN_PROGRESS') {
+      return apiError('A scrape is already running for this tracker. Wait for it to finish.', 429);
+    }
+    const code = (err as { code?: string } | null)?.code;
+    if (code === 'P2034') {
+      // Postgres serialization conflict — another request beat us to it.
+      return apiError('A scrape is already running for this tracker. Wait for it to finish.', 429);
+    }
+    throw err;
   }
 
-  // Pre-create one FetchRun row per target so the next /api/queries/active
-  // call sees status=in_progress immediately, well before VPN connect.
-  const fetchRuns = await Promise.all(
-    targetIds.map((qid) =>
-      prisma.fetchRun.create({
-        data: { queryId: qid, status: 'in_progress', source: 'manual' },
-        select: { id: true, queryId: true },
-      }),
-    ),
-  );
-
-  // Fire scrapes serially in the background so siblings don't race the VPN
-  // sidecar. Errors are swallowed per sibling (the FetchRun row's own
-  // failed status surfaces them in the UI).
-  const fetchRunByQuery = new Map(fetchRuns.map((fr) => [fr.queryId, fr.id]));
+  // Reorder so the user-clicked row scrapes first (and reuses the pre-
+  // created row). Subsequent siblings get their FetchRun rows created
+  // just-in-time inside runScrapeForQuery; any sibling we never reach
+  // simply has no row, instead of an orphan stuck at in_progress.
+  const orderedTargets = [id, ...targetIds.filter((qid) => qid !== id)];
   void (async () => {
-    for (const qid of targetIds) {
-      const fetchRunId = fetchRunByQuery.get(qid);
+    for (let i = 0; i < orderedTargets.length; i++) {
+      const qid = orderedTargets[i]!;
+      const passOpts = i === 0 ? { fetchRunId: primaryFetchRun.id } : undefined;
       try {
-        await runFullScrapeForQuery(qid, fetchRunId ? { fetchRunId } : undefined);
+        await runFullScrapeForQuery(qid, passOpts);
       } catch (err) {
         console.error(
           `[scrape] manual run failed query=${qid}: ${err instanceof Error ? err.message : err}`,

--- a/apps/web/src/app/api/queries/[id]/scrape/route.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.ts
@@ -140,9 +140,20 @@ export async function POST(
       try {
         await runFullScrapeForQuery(qid, passOpts);
       } catch (err) {
-        console.error(
-          `[scrape] manual run failed query=${qid}: ${err instanceof Error ? err.message : err}`,
-        );
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        console.error(`[scrape] manual run failed query=${qid}: ${errorMsg}`);
+        // If runFullScrapeForQuery throws before runScrapeForQuery has a
+        // chance to finalise the pre-created primary row, that row stays
+        // at in_progress forever and the DB lock blocks every future
+        // refresh for this group. Best-effort failure update closes the
+        // loop on the i=0 case (cron/sibling rows are created inside
+        // runFullScrapeForQuery's loop so they finalise themselves).
+        if (i === 0) {
+          await prisma.fetchRun.update({
+            where: { id: primaryFetchRun.id },
+            data: { status: 'failed', error: errorMsg, completedAt: new Date() },
+          }).catch(() => {});
+        }
       }
     }
   })();

--- a/apps/web/src/app/api/queries/[id]/scrape/route.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest } from 'next/server';
+import { apiSuccess, apiError } from '@/lib/api-response';
+import { prisma } from '@/lib/prisma';
+import { authorizeMutation } from '@/lib/query-auth';
+import { redis } from '@/lib/redis';
+import { runFullScrapeForQuery } from '@/lib/scraper/run-scrape';
+
+const THROTTLE_SECONDS = 60;
+
+/**
+ * Manual force-scrape endpoint. Fires `runFullScrapeForQuery` for the row
+ * and (when present) every sibling sharing the `groupId`, the same way
+ * pause/delete cascade. Returns 200 the instant the FetchRun rows are
+ * pre-created so the UI dot can light up before the network IO begins;
+ * the actual scrapes run sequentially in a background IIFE so multiple
+ * siblings never race on the shared VPN sidecar.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const body = await request.json().catch(() => null);
+  const token = body?.deleteToken;
+
+  const query = await prisma.query.findUnique({
+    where: { id },
+    select: {
+      deleteToken: true,
+      groupId: true,
+      userId: true,
+      active: true,
+      isSeed: true,
+    },
+  });
+
+  if (!query) return apiError('Tracker not found', 404);
+
+  const auth = await authorizeMutation(query, token);
+  if (!auth.ok) return apiError(auth.error ?? 'Forbidden', auth.status ?? 403);
+
+  if (!query.active || query.isSeed) {
+    return apiError('Tracker is paused or a seed; resume it before refreshing.', 409);
+  }
+
+  const targetIds = query.groupId
+    ? (await prisma.query.findMany({
+        where: { groupId: query.groupId, active: true, isSeed: false },
+        select: { id: true },
+      })).map((q) => q.id)
+    : [id];
+
+  if (targetIds.length === 0) {
+    return apiError('No active siblings to refresh', 409);
+  }
+
+  const throttleKey = `scrape:throttle:${query.groupId ?? id}`;
+  let throttled = false;
+  if (redis) {
+    try {
+      const reserved = await redis.set(throttleKey, '1', 'EX', THROTTLE_SECONDS, 'NX');
+      throttled = reserved !== 'OK';
+    } catch (err) {
+      console.warn(`[scrape] redis throttle failed: ${err instanceof Error ? err.message : err}; allowing request`);
+    }
+  }
+  if (throttled) {
+    return apiError('Force scrape was triggered less than a minute ago. Try again shortly.', 429);
+  }
+
+  // Pre-create one FetchRun row per target so the next /api/queries/active
+  // call sees status=in_progress immediately, well before VPN connect.
+  const fetchRuns = await Promise.all(
+    targetIds.map((qid) =>
+      prisma.fetchRun.create({
+        data: { queryId: qid, status: 'in_progress', source: 'manual' },
+        select: { id: true, queryId: true },
+      }),
+    ),
+  );
+
+  // Fire scrapes serially in the background so siblings don't race the VPN
+  // sidecar. Errors are swallowed per sibling (the FetchRun row's own
+  // failed status surfaces them in the UI).
+  const fetchRunByQuery = new Map(fetchRuns.map((fr) => [fr.queryId, fr.id]));
+  void (async () => {
+    for (const qid of targetIds) {
+      const fetchRunId = fetchRunByQuery.get(qid);
+      try {
+        await runFullScrapeForQuery(qid, fetchRunId ? { fetchRunId } : undefined);
+      } catch (err) {
+        console.error(
+          `[scrape] manual run failed query=${qid}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+  })();
+
+  return apiSuccess({
+    accepted: true,
+    count: targetIds.length,
+    groupId: query.groupId,
+    throttledUntil: redis ? new Date(Date.now() + THROTTLE_SECONDS * 1000).toISOString() : null,
+  });
+}

--- a/apps/web/src/app/api/queries/[id]/scrape/route.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.ts
@@ -14,6 +14,13 @@ const THROTTLE_SECONDS = 60;
  * pre-created so the UI dot can light up before the network IO begins;
  * the actual scrapes run sequentially in a background IIFE so multiple
  * siblings never race on the shared VPN sidecar.
+ *
+ * Two layered locks prevent overlapping kickoffs:
+ *   - Redis SET NX EX (60s) catches accidental double-clicks at zero DB
+ *     cost. Skipped gracefully when Redis is null or throws.
+ *   - "Any in_progress FetchRun for any target" is a precise lock that
+ *     outlasts the Redis TTL on multi-VPN runs (a single VPN connect can
+ *     already take 30+ seconds). Always checked, even with Redis off.
  */
 export async function POST(
   request: NextRequest,
@@ -32,6 +39,7 @@ export async function POST(
       userId: true,
       active: true,
       isSeed: true,
+      expiresAt: true,
     },
   });
 
@@ -44,9 +52,21 @@ export async function POST(
     return apiError('Tracker is paused or a seed; resume it before refreshing.', 409);
   }
 
+  if (query.expiresAt.getTime() <= Date.now()) {
+    return apiError('Tracker has expired; create a fresh one to keep scraping.', 410);
+  }
+
+  // Only target siblings that are themselves still alive (active, non-seed,
+  // not expired). The primary already passed those checks above.
+  const now = new Date();
   const targetIds = query.groupId
     ? (await prisma.query.findMany({
-        where: { groupId: query.groupId, active: true, isSeed: false },
+        where: {
+          groupId: query.groupId,
+          active: true,
+          isSeed: false,
+          expiresAt: { gt: now },
+        },
         select: { id: true },
       })).map((q) => q.id)
     : [id];
@@ -67,6 +87,18 @@ export async function POST(
   }
   if (throttled) {
     return apiError('Force scrape was triggered less than a minute ago. Try again shortly.', 429);
+  }
+
+  // Second lock that outlasts the Redis TTL. Multi-sibling or multi-VPN
+  // runs can take many minutes; the Redis key expires long before then. A
+  // direct DB check on `in_progress` rows catches that case AND also works
+  // when Redis is disabled entirely.
+  const stale = await prisma.fetchRun.findFirst({
+    where: { queryId: { in: targetIds }, status: 'in_progress' },
+    select: { id: true },
+  });
+  if (stale) {
+    return apiError('A scrape is already running for this tracker. Wait for it to finish.', 429);
   }
 
   // Pre-create one FetchRun row per target so the next /api/queries/active

--- a/apps/web/src/app/api/queries/[id]/scrape/route.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.ts
@@ -6,6 +6,10 @@ import { redis } from '@/lib/redis';
 import { runFullScrapeForQuery } from '@/lib/scraper/run-scrape';
 
 const THROTTLE_SECONDS = 60;
+// A multi-VPN run can stretch past 10 minutes per sibling. Anything older
+// than this cutoff is treated as a stale row from a crashed process so the
+// lock can't deadlock indefinitely on a stuck in_progress row.
+const STALE_LOCK_AFTER_MS = 15 * 60 * 1000;
 
 /**
  * Manual force-scrape endpoint. Fires `runFullScrapeForQuery` for the row
@@ -15,12 +19,20 @@ const THROTTLE_SECONDS = 60;
  * the actual scrapes run sequentially in a background IIFE so multiple
  * siblings never race on the shared VPN sidecar.
  *
- * Two layered locks prevent overlapping kickoffs:
+ * Two layered locks prevent overlapping kickoffs FOR THIS GROUP:
  *   - Redis SET NX EX (60s) catches accidental double-clicks at zero DB
  *     cost. Skipped gracefully when Redis is null or throws.
- *   - "Any in_progress FetchRun for any target" is a precise lock that
- *     outlasts the Redis TTL on multi-VPN runs (a single VPN connect can
- *     already take 30+ seconds). Always checked, even with Redis off.
+ *   - "Any non-stale in_progress FetchRun for any target" is a precise
+ *     lock that outlasts the Redis TTL on multi-VPN runs (a single VPN
+ *     connect can already take 30+ seconds). Rows older than 15 minutes
+ *     are treated as crashed and ignored, so a half-finished scrape
+ *     can't deadlock the group forever.
+ *
+ * Cross-group serialization (a manual click on Group A while cron or
+ * another manual click on Group B is mid-VPN-connect) is NOT enforced
+ * here. Both Fairtrail's cron and this endpoint share one ExpressVPN
+ * sidecar; a global serializer would coordinate them. Accepted v1
+ * tradeoff. See "Race with active cron" in the plan.
  */
 export async function POST(
   request: NextRequest,
@@ -101,11 +113,16 @@ export async function POST(
   // the loop reaches them, so an early-exit (paused mid-cascade, process
   // crash, etc.) cannot leave orphaned in_progress rows behind to block
   // future refreshes.
+  const staleBefore = new Date(Date.now() - STALE_LOCK_AFTER_MS);
   let primaryFetchRun: { id: string };
   try {
     primaryFetchRun = await prisma.$transaction(async (tx) => {
       const inProgress = await tx.fetchRun.findFirst({
-        where: { queryId: { in: targetIds }, status: 'in_progress' },
+        where: {
+          queryId: { in: targetIds },
+          status: 'in_progress',
+          startedAt: { gt: staleBefore },
+        },
         select: { id: true },
       });
       if (inProgress) {

--- a/apps/web/src/app/api/queries/active/route.test.ts
+++ b/apps/web/src/app/api/queries/active/route.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFindMany = vi.fn();
+vi.mock('@/lib/prisma', () => ({
+  prisma: { query: { findMany: (...args: unknown[]) => mockFindMany(...args) } },
+}));
+
+const mockIsMultiUserEnabled = vi.fn().mockResolvedValue(false);
+const mockGetCurrentUser = vi.fn().mockResolvedValue(null);
+vi.mock('@/lib/multi-user', () => ({ isMultiUserEnabled: () => mockIsMultiUserEnabled() }));
+vi.mock('@/lib/user-auth', () => ({ getCurrentUser: () => mockGetCurrentUser() }));
+
+import { GET } from './route';
+
+function shapedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'q1',
+    active: true,
+    origin: 'JFK',
+    destination: 'LAX',
+    originName: 'New York',
+    destinationName: 'Los Angeles',
+    dateFrom: new Date('2026-06-10'),
+    dateTo: new Date('2026-06-17'),
+    scrapeInterval: null,
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    expiresAt: new Date('2026-08-01T00:00:00Z'),
+    groupId: null,
+    fetchRuns: [],
+    _count: { snapshots: 0 },
+    ...overrides,
+  };
+}
+
+describe('GET /api/queries/active', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsMultiUserEnabled.mockResolvedValue(false);
+    mockGetCurrentUser.mockResolvedValue(null);
+  });
+
+  it('surfaces lastScrapeStatus and lastScrapeError on success', async () => {
+    mockFindMany.mockResolvedValue([
+      shapedRow({
+        fetchRuns: [
+          {
+            startedAt: new Date('2026-05-20T12:00:00Z'),
+            status: 'success',
+            error: null,
+          },
+        ],
+      }),
+    ]);
+    const res = await GET();
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.data.queries[0]).toMatchObject({
+      lastScrapeStatus: 'success',
+      lastScrapeError: null,
+    });
+  });
+
+  it('surfaces lastScrapeStatus=failed plus the error message', async () => {
+    mockFindMany.mockResolvedValue([
+      shapedRow({
+        fetchRuns: [
+          {
+            startedAt: new Date('2026-05-20T12:00:00Z'),
+            status: 'failed',
+            error: 'LLM response contained no parseable JSON array.',
+          },
+        ],
+      }),
+    ]);
+    const res = await GET();
+    const data = await res.json();
+    expect(data.data.queries[0]).toMatchObject({
+      lastScrapeStatus: 'failed',
+      lastScrapeError: 'LLM response contained no parseable JSON array.',
+    });
+  });
+
+  it('returns null status/error when the query has no fetchRuns yet', async () => {
+    mockFindMany.mockResolvedValue([shapedRow({ fetchRuns: [] })]);
+    const res = await GET();
+    const data = await res.json();
+    expect(data.data.queries[0]).toMatchObject({
+      lastScrapeStatus: null,
+      lastScrapeError: null,
+      lastScrapedAt: null,
+    });
+  });
+});

--- a/apps/web/src/app/api/queries/active/route.ts
+++ b/apps/web/src/app/api/queries/active/route.ts
@@ -45,7 +45,7 @@ export async function GET() {
       fetchRuns: {
         orderBy: { startedAt: 'desc' },
         take: 1,
-        select: { startedAt: true },
+        select: { startedAt: true, status: true, error: true },
       },
       _count: {
         select: { snapshots: true },
@@ -65,6 +65,8 @@ export async function GET() {
     scrapeInterval: q.scrapeInterval,
     snapshotCount: q._count.snapshots,
     lastScrapedAt: q.fetchRuns[0]?.startedAt.toISOString() ?? null,
+    lastScrapeStatus: q.fetchRuns[0]?.status ?? null,
+    lastScrapeError: q.fetchRuns[0]?.error ?? null,
     groupId: q.groupId,
     createdAt: q.createdAt.toISOString(),
   }));

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -12,6 +12,9 @@ import { ChartActions } from '@/components/ChartActions';
 import { PriceCalendar } from '@/components/PriceCalendar';
 import { Footer } from '@/components/Footer';
 import { StackedSortControls, type StackedItem } from '@/components/StackedSortControls';
+import { ScrapeStatusDot } from '@/components/ScrapeStatusDot';
+import { ForceScrapeButton } from '@/components/ForceScrapeButton';
+import { aggregateScrapeStatus } from '@/lib/scrape-status';
 import { groupDateRange } from './group-date-range';
 import styles from './page.module.css';
 
@@ -74,6 +77,7 @@ interface QueryWithSnapshots {
     dateTo: Date;
     flexibility: number;
     tripType: string;
+    active: boolean;
     expiresAt: Date;
     createdAt: Date;
     firstViewedAt: Date | null;
@@ -101,7 +105,7 @@ interface QueryWithSnapshots {
     vpnCountry: string | null;
     scrapedAt: string;
   }>;
-  lastRun: { startedAt: Date } | null;
+  lastRun: { startedAt: Date; status: string; error: string | null } | null;
   globalScrapeInterval: number;
 }
 
@@ -220,7 +224,7 @@ async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | 
   const lastRun = await prisma.fetchRun.findFirst({
     where: { queryId: id },
     orderBy: { startedAt: 'desc' },
-    select: { startedAt: true },
+    select: { startedAt: true, status: true, error: true },
   });
 
   const globalConfig = await prisma.extractionConfig.findFirst({
@@ -296,6 +300,13 @@ export default async function ChartPage({ params }: Props) {
   );
   const expired = allQueries.every((q) => now > q.query.expiresAt.getTime());
   const daysLeft = daysUntil(groupExpiresAt);
+  const scrapeAggregate = aggregateScrapeStatus(
+    allQueries.map((q) => ({
+      status: q.lastRun?.status ?? null,
+      error: q.lastRun?.error ?? null,
+      startedAt: q.lastRun?.startedAt.toISOString() ?? null,
+    })),
+  );
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -397,6 +408,11 @@ export default async function ChartPage({ params }: Props) {
       <div className={styles.footerMeta}>
         <div className={styles.footerRow}>
           <p className={styles.footerText}>
+            <ScrapeStatusDot
+              status={scrapeAggregate.status}
+              error={scrapeAggregate.error}
+              lastScrapedAt={scrapeAggregate.startedAt}
+            />
             Tracked since {formatDate(primary.query.createdAt)}
             {allQueries[0]?.lastRun && ` · Last checked ${timeAgo(allQueries[0].lastRun.startedAt)}`}
             {allQueries[0]?.lastRun && !expired && ` · Next check in ~${primary.query.scrapeInterval ?? primary.globalScrapeInterval}h`}
@@ -404,6 +420,9 @@ export default async function ChartPage({ params }: Props) {
           </p>
           {!expired && (
             <>
+              {primary.query.active && (
+                <ForceScrapeButton queryId={id} ariaLabel="Refresh prices now" />
+              )}
               <ScrapeInterval queryId={id} currentInterval={primary.query.scrapeInterval} />
               <DeleteTracker queryId={id} />
             </>

--- a/apps/web/src/components/ForceScrapeButton.module.css
+++ b/apps/web/src/components/ForceScrapeButton.module.css
@@ -1,0 +1,40 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border-radius: 100px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.button:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent-dim, var(--accent));
+}
+
+.button:disabled {
+  cursor: progress;
+  opacity: 0.65;
+}
+
+.pending {
+  border-color: var(--accent-dim, var(--accent));
+}
+
+.icon {
+  display: block;
+}
+
+.spinning {
+  animation: spinScrape 1s linear infinite;
+}
+
+@keyframes spinScrape {
+  to { transform: rotate(360deg); }
+}

--- a/apps/web/src/components/ForceScrapeButton.tsx
+++ b/apps/web/src/components/ForceScrapeButton.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState, type MouseEvent } from 'react';
+import styles from './ForceScrapeButton.module.css';
+
+export interface ForceScrapeResult {
+  accepted: boolean;
+  count?: number;
+  error?: string;
+}
+
+export interface ForceScrapeButtonProps {
+  queryId: string;
+  deleteToken?: string | null;
+  onScraped?: (result: ForceScrapeResult) => void;
+  ariaLabel?: string;
+}
+
+export function ForceScrapeButton({
+  queryId,
+  deleteToken,
+  onScraped,
+  ariaLabel,
+}: ForceScrapeButtonProps): React.ReactElement {
+  const [pending, setPending] = useState(false);
+  const [hint, setHint] = useState<string | null>(null);
+
+  const handleClick = async (e: MouseEvent<HTMLButtonElement>) => {
+    // Always run both: stopPropagation alone is fragile against anchor
+    // navigation when the button sits inside a <Link> row.
+    e.preventDefault();
+    e.stopPropagation();
+    if (pending) return;
+    setPending(true);
+    setHint(null);
+    try {
+      const res = await fetch(`/api/queries/${queryId}/scrape`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deleteToken: deleteToken ?? null }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data?.ok) {
+        onScraped?.({ accepted: true, count: data.data?.count });
+      } else if (res.status === 429) {
+        const msg = data?.error ?? 'Try again in a minute.';
+        setHint(msg);
+        onScraped?.({ accepted: false, error: msg });
+      } else {
+        const msg = data?.error ?? `Refresh failed (${res.status})`;
+        setHint(msg);
+        onScraped?.({ accepted: false, error: msg });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Network error';
+      setHint(msg);
+      onScraped?.({ accepted: false, error: msg });
+    } finally {
+      setPending(false);
+      // Clear the hint after a few seconds so it doesn't linger forever.
+      if (hint === null) setTimeout(() => setHint(null), 4000);
+    }
+  };
+
+  const label = ariaLabel ?? 'Refresh now';
+
+  return (
+    <button
+      type="button"
+      className={`${styles.button} ${pending ? styles.pending : ''}`}
+      onClick={handleClick}
+      disabled={pending}
+      title={hint ?? label}
+      aria-label={label}
+    >
+      <svg
+        className={`${styles.icon} ${pending ? styles.spinning : ''}`}
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M3 12a9 9 0 0 1 15.5-6.4L21 8" />
+        <path d="M21 3v5h-5" />
+        <path d="M21 12a9 9 0 0 1-15.5 6.4L3 16" />
+        <path d="M3 21v-5h5" />
+      </svg>
+    </button>
+  );
+}

--- a/apps/web/src/components/ForceScrapeButton.tsx
+++ b/apps/web/src/components/ForceScrapeButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, type MouseEvent } from 'react';
+import { getDeleteToken } from '@/lib/tracker-storage';
 import styles from './ForceScrapeButton.module.css';
 
 export interface ForceScrapeResult {
@@ -11,6 +12,9 @@ export interface ForceScrapeResult {
 
 export interface ForceScrapeButtonProps {
   queryId: string;
+  /** Optional explicit token. When omitted, the component reads it from
+   *  localStorage on click (same pattern as DeleteTracker), so hosted
+   *  tracker owners visiting /q/[id] authenticate via their saved token. */
   deleteToken?: string | null;
   onScraped?: (result: ForceScrapeResult) => void;
   ariaLabel?: string;
@@ -33,11 +37,15 @@ export function ForceScrapeButton({
     if (pending) return;
     setPending(true);
     setHint(null);
+    // Fall back to the locally-saved token so hosted tracker owners can
+    // refresh their own tracker without an admin session. Callers that
+    // already have a token (SavedTrackers, admin row) pass it explicitly.
+    const token = deleteToken ?? (typeof window !== 'undefined' ? getDeleteToken(queryId) : null);
     try {
       const res = await fetch(`/api/queries/${queryId}/scrape`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ deleteToken: deleteToken ?? null }),
+        body: JSON.stringify({ deleteToken: token }),
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok && data?.ok) {

--- a/apps/web/src/components/SavedTrackers.tsx
+++ b/apps/web/src/components/SavedTrackers.tsx
@@ -4,6 +4,9 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { getSavedTrackers, getDeleteToken, removeSavedTracker, type SavedTracker } from '@/lib/tracker-storage';
 import { groupQueries, type GroupableQuery, type QueryGroup } from '@/lib/query-grouping';
+import { aggregateScrapeStatus, type AggregatedScrape } from '@/lib/scrape-status';
+import { ScrapeStatusDot } from './ScrapeStatusDot';
+import { ForceScrapeButton } from './ForceScrapeButton';
 import styles from './SavedTrackers.module.css';
 
 interface ActiveQuery {
@@ -18,6 +21,8 @@ interface ActiveQuery {
   scrapeInterval: number;
   snapshotCount: number;
   lastScrapedAt: string | null;
+  lastScrapeStatus: string | null;
+  lastScrapeError: string | null;
   groupId: string | null;
   createdAt: string;
 }
@@ -25,12 +30,15 @@ interface ActiveQuery {
 interface DisplayQuery extends GroupableQuery {
   status: 'active' | 'paused' | 'expired' | 'deleted';
   hasDeleteToken: boolean;
+  scrapeStatus: string | null;
+  scrapeError: string | null;
 }
 
 interface DisplayGroup {
   group: QueryGroup<DisplayQuery>;
   status: 'active' | 'paused' | 'expired' | 'deleted';
   hasDeleteToken: boolean;
+  aggregate: AggregatedScrape;
 }
 
 function formatDate(iso: string): string {
@@ -66,6 +74,13 @@ function toDisplayGroups(queries: DisplayQuery[]): DisplayGroup[] {
     group,
     status: deriveGroupStatus(group),
     hasDeleteToken: group.queries.some((q) => q.hasDeleteToken),
+    aggregate: aggregateScrapeStatus(
+      group.queries.map((q) => ({
+        status: q.scrapeStatus,
+        error: q.scrapeError,
+        startedAt: q.lastScrapedAt ?? null,
+      })),
+    ),
   }));
 }
 
@@ -113,6 +128,8 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
             lastScrapedAt: q.lastScrapedAt,
             status: q.active ? 'active' : 'paused',
             hasDeleteToken: deleteTokenSet.has(q.id),
+            scrapeStatus: q.lastScrapeStatus,
+            scrapeError: q.lastScrapeError,
           }));
           setGroups(toDisplayGroups(display));
         } else {
@@ -150,6 +167,8 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
             lastScrapedAt: null,
             status: statusMap[t.id] ?? 'deleted',
             hasDeleteToken: Boolean(t.deleteToken),
+            scrapeStatus: null,
+            scrapeError: null,
           }));
           setGroups(toDisplayGroups(display));
         })
@@ -168,6 +187,8 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
             lastScrapedAt: null,
             status: 'active',
             hasDeleteToken: Boolean(t.deleteToken),
+            scrapeStatus: null,
+            scrapeError: null,
           }));
           setGroups(toDisplayGroups(display));
         });
@@ -199,6 +220,40 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
       removeSavedTracker(q.id);
     }
     setGroups((prev) => prev.filter((g) => g.group.primaryId !== group.primaryId));
+  };
+
+  const refetchActive = () => {
+    fetch('/api/queries/active')
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data.ok || !data.data?.queries) return;
+        const serverQueries: ActiveQuery[] = data.data.queries;
+        const localTokens = new Set(
+          isAuthenticated
+            ? []
+            : getSavedTrackers().filter((t) => t.deleteToken).map((t) => t.id),
+        );
+        const display: DisplayQuery[] = serverQueries.map((q) => ({
+          id: q.id,
+          origin: q.origin,
+          destination: q.destination,
+          originName: q.originName,
+          destinationName: q.destinationName,
+          dateFrom: q.dateFrom,
+          dateTo: q.dateTo,
+          groupId: q.groupId,
+          active: q.active,
+          createdAt: q.createdAt,
+          snapshotCount: q.snapshotCount,
+          lastScrapedAt: q.lastScrapedAt,
+          status: q.active ? 'active' : 'paused',
+          hasDeleteToken: localTokens.has(q.id),
+          scrapeStatus: q.lastScrapeStatus,
+          scrapeError: q.lastScrapeError,
+        }));
+        setGroups(toDisplayGroups(display));
+      })
+      .catch(() => {});
   };
 
   const handleTogglePause = async (entry: DisplayGroup) => {
@@ -252,8 +307,9 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
       <h3 className={styles.title}>Your Trackers</h3>
       <div className={styles.list}>
         {groups.map((entry) => {
-          const { group, status } = entry;
+          const { group, status, aggregate } = entry;
           const extraDestinations = group.destinations.length - 1;
+          const primaryToken = getDeleteToken(group.primaryId);
           return (
             <div key={group.primaryId} className={styles.card}>
               <button
@@ -304,6 +360,11 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
                       )}
                       {group.lastScrapedAt && (
                         <span className={styles.lastScrape}>
+                          <ScrapeStatusDot
+                            status={aggregate.status}
+                            error={aggregate.error}
+                            lastScrapedAt={aggregate.startedAt}
+                          />
                           {timeAgo(group.lastScrapedAt)}
                         </span>
                       )}
@@ -316,6 +377,14 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
                       }`}>
                         {status === 'active' ? 'Tracking' : status === 'paused' ? 'Paused' : 'Expired'}
                       </span>
+                      {status === 'active' && (
+                        <ForceScrapeButton
+                          queryId={group.primaryId}
+                          deleteToken={primaryToken}
+                          onScraped={(result) => { if (result.accepted) refetchActive(); }}
+                          ariaLabel="Refresh prices now"
+                        />
+                      )}
                       {(status === 'active' || status === 'paused') && (
                         <button
                           className={styles.pauseBtn}

--- a/apps/web/src/components/ScrapeStatusDot.module.css
+++ b/apps/web/src/components/ScrapeStatusDot.module.css
@@ -1,0 +1,35 @@
+.dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  margin: 0 0.25rem 0 0.125rem;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.success {
+  background: var(--price-down, #10b981);
+  box-shadow: 0 0 0 1px rgba(16, 185, 129, 0.25);
+}
+
+.failed {
+  background: var(--price-up, #ef4444);
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.25);
+}
+
+.partial {
+  background: var(--warning, #f59e0b);
+  box-shadow: 0 0 0 1px rgba(245, 158, 11, 0.25);
+}
+
+.in_progress {
+  background: var(--accent, #06b6d4);
+  box-shadow: 0 0 0 1px rgba(6, 182, 212, 0.25);
+  animation: scrapePulse 1.4s ease-in-out infinite;
+}
+
+@keyframes scrapePulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.75); }
+}

--- a/apps/web/src/components/ScrapeStatusDot.tsx
+++ b/apps/web/src/components/ScrapeStatusDot.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { ScrapeStatus } from '@/lib/scrape-status';
+import styles from './ScrapeStatusDot.module.css';
+
+export interface ScrapeStatusDotProps {
+  status: ScrapeStatus | null;
+  error?: string | null;
+  lastScrapedAt?: string | null;
+}
+
+function statusLabel(status: ScrapeStatus): string {
+  switch (status) {
+    case 'success': return 'success';
+    case 'failed': return 'failed';
+    case 'partial': return 'partial';
+    case 'in_progress': return 'in progress';
+  }
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < 60_000) return 'just now';
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function ScrapeStatusDot({ status, error, lastScrapedAt }: ScrapeStatusDotProps): React.ReactElement | null {
+  if (status === null) return null;
+
+  const parts: string[] = [];
+  parts.push(`Last scrape: ${statusLabel(status)}`);
+  if (error) parts.push(error);
+  if (lastScrapedAt) parts.push(timeAgo(lastScrapedAt));
+  const label = parts.join('. ');
+
+  return (
+    <span
+      className={`${styles.dot} ${styles[status]}`}
+      title={label}
+      aria-label={label}
+      role="img"
+    />
+  );
+}

--- a/apps/web/src/lib/query-auth.ts
+++ b/apps/web/src/lib/query-auth.ts
@@ -1,0 +1,62 @@
+import { isMultiUserEnabled } from '@/lib/multi-user';
+import { getCurrentUser } from '@/lib/user-auth';
+import { getSessionToken, verifySessionToken } from '@/lib/admin-auth';
+
+export interface AuthResult {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+/**
+ * Authorize a mutation on `query` for the current request. The rules:
+ *
+ *   - hosted (SELF_HOSTED unset): require a matching deleteToken, OR a valid
+ *     legacy admin HMAC session cookie (operators managing every tracker via
+ *     the admin dashboard).
+ *   - self hosted solo mode (multiUserMode off): no token check; whoever has
+ *     access to the box owns everything.
+ *   - self hosted multi user mode: admin session OR matching deleteToken OR
+ *     matching user session whose userId equals query.userId. Queries with
+ *     no owner (e.g. seeds) are admin only.
+ *
+ * Exported so the /api/queries/[id] PATCH/DELETE handlers and the new
+ * /api/queries/[id]/scrape POST handler share one auth surface.
+ */
+export async function authorizeMutation(
+  query: { deleteToken: string | null; userId?: string | null },
+  token: string | undefined | null,
+): Promise<AuthResult> {
+  const isSelfHosted = process.env.SELF_HOSTED === 'true';
+  const multiUser = isSelfHosted ? await isMultiUserEnabled() : false;
+
+  if (isSelfHosted && !multiUser) {
+    return { ok: true };
+  }
+
+  if (multiUser) {
+    const user = await getCurrentUser();
+    if (user?.isAdmin) return { ok: true };
+    if (token && query.deleteToken && query.deleteToken === token) {
+      return { ok: true };
+    }
+    if (user && query.userId && query.userId === user.id) {
+      return { ok: true };
+    }
+    return { ok: false, status: 403, error: 'Not authorized to modify this tracker' };
+  }
+
+  // hosted (non-self-hosted) — admin dashboard carries the legacy HMAC cookie.
+  const session = await getSessionToken();
+  if (session && verifySessionToken(session)) {
+    return { ok: true };
+  }
+
+  if (!token || typeof token !== 'string') {
+    return { ok: false, status: 401, error: 'Missing delete token' };
+  }
+  if (!query.deleteToken || query.deleteToken !== token) {
+    return { ok: false, status: 403, error: 'Invalid delete token' };
+  }
+  return { ok: true };
+}

--- a/apps/web/src/lib/scrape-status.test.ts
+++ b/apps/web/src/lib/scrape-status.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { aggregateScrapeStatus, type SiblingScrape } from './scrape-status';
+
+function sib(overrides: Partial<SiblingScrape>): SiblingScrape {
+  return { status: null, error: null, startedAt: null, ...overrides };
+}
+
+describe('aggregateScrapeStatus', () => {
+  it('returns nulls for empty input', () => {
+    expect(aggregateScrapeStatus([])).toEqual({
+      status: null,
+      error: null,
+      startedAt: null,
+      failingSiblings: 0,
+    });
+  });
+
+  it('returns success when every sibling succeeded', () => {
+    const result = aggregateScrapeStatus([
+      sib({ status: 'success', startedAt: '2026-05-20T10:00:00Z' }),
+      sib({ status: 'success', startedAt: '2026-05-20T11:00:00Z' }),
+    ]);
+    expect(result.status).toBe('success');
+    expect(result.failingSiblings).toBe(0);
+    expect(result.startedAt).toBe('2026-05-20T11:00:00Z');
+  });
+
+  it('surfaces failed over success and counts failing siblings', () => {
+    const result = aggregateScrapeStatus([
+      sib({ status: 'success', startedAt: '2026-05-20T10:00:00Z' }),
+      sib({ status: 'failed', error: 'rate limit', startedAt: '2026-05-20T11:00:00Z' }),
+      sib({ status: 'success', startedAt: '2026-05-20T12:00:00Z' }),
+    ]);
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('rate limit');
+    expect(result.failingSiblings).toBe(1);
+    expect(result.startedAt).toBe('2026-05-20T12:00:00Z');
+  });
+
+  it('in_progress wins over failed (active refresh masks stale failures)', () => {
+    const result = aggregateScrapeStatus([
+      sib({ status: 'failed', error: 'old error', startedAt: '2026-05-19T10:00:00Z' }),
+      sib({ status: 'in_progress', startedAt: '2026-05-20T11:00:00Z' }),
+    ]);
+    expect(result.status).toBe('in_progress');
+    expect(result.failingSiblings).toBe(1);
+  });
+
+  it('treats null status as missing and still picks success when present', () => {
+    const result = aggregateScrapeStatus([
+      sib({ status: null }),
+      sib({ status: 'success', startedAt: '2026-05-20T10:00:00Z' }),
+    ]);
+    expect(result.status).toBe('success');
+  });
+
+  it('returns null status when every sibling is null', () => {
+    const result = aggregateScrapeStatus([sib({}), sib({})]);
+    expect(result.status).toBeNull();
+  });
+
+  it('partial sits between failed and success', () => {
+    const result = aggregateScrapeStatus([
+      sib({ status: 'success', startedAt: '2026-05-20T10:00:00Z' }),
+      sib({ status: 'partial', startedAt: '2026-05-20T11:00:00Z' }),
+    ]);
+    expect(result.status).toBe('partial');
+  });
+
+  it('coerces unknown status strings to null', () => {
+    const result = aggregateScrapeStatus([
+      sib({ status: 'something_weird' as never }),
+      sib({ status: 'success', startedAt: '2026-05-20T10:00:00Z' }),
+    ]);
+    expect(result.status).toBe('success');
+  });
+});

--- a/apps/web/src/lib/scrape-status.ts
+++ b/apps/web/src/lib/scrape-status.ts
@@ -1,0 +1,64 @@
+export type ScrapeStatus = 'in_progress' | 'success' | 'partial' | 'failed';
+
+export interface SiblingScrape {
+  status: ScrapeStatus | string | null;
+  error: string | null;
+  startedAt: string | null;
+}
+
+export interface AggregatedScrape {
+  status: ScrapeStatus | null;
+  error: string | null;
+  startedAt: string | null;
+  failingSiblings: number;
+}
+
+const ORDER: ScrapeStatus[] = ['in_progress', 'failed', 'partial', 'success'];
+
+function normalize(value: ScrapeStatus | string | null): ScrapeStatus | null {
+  if (value === 'in_progress' || value === 'success' || value === 'partial' || value === 'failed') {
+    return value;
+  }
+  return null;
+}
+
+/**
+ * Pick the "most attention worthy" status across siblings.
+ *
+ * Order: in_progress > failed > partial > success > null.
+ * Rationale: an active scrape always wins so the dot pulses while the
+ * refresh is in flight; otherwise we surface the worst terminal state so a
+ * single failing sibling can't hide behind successful ones.
+ *
+ * `error` follows the picked status (first matching sibling). `startedAt`
+ * is the most recent across siblings regardless of status, so the tooltip
+ * timestamp always reflects when something last happened.
+ */
+export function aggregateScrapeStatus(siblings: SiblingScrape[]): AggregatedScrape {
+  if (siblings.length === 0) {
+    return { status: null, error: null, startedAt: null, failingSiblings: 0 };
+  }
+
+  let mostRecent: string | null = null;
+  let failingSiblings = 0;
+  for (const s of siblings) {
+    if (s.startedAt && (mostRecent === null || s.startedAt > mostRecent)) {
+      mostRecent = s.startedAt;
+    }
+    if (normalize(s.status) === 'failed') failingSiblings += 1;
+  }
+
+  for (const want of ORDER) {
+    const match = siblings.find((s) => normalize(s.status) === want);
+    if (match) {
+      return {
+        status: want,
+        error: match.error,
+        startedAt: mostRecent,
+        failingSiblings,
+      };
+    }
+  }
+
+  return { status: null, error: null, startedAt: mostRecent, failingSiblings: 0 };
+}

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -408,6 +408,7 @@ export async function runScrapeForQuery(
   queryId: string,
   vpnCountry?: string | null,
   proxyUrl?: string,
+  opts?: { fetchRunId?: string },
 ): Promise<ScrapeResult> {
   const query = await prisma.query.findUnique({ where: { id: queryId } });
   if (!query || !query.active) {
@@ -431,9 +432,14 @@ export async function runScrapeForQuery(
       }
     : { ...query, cabinClass: query.cabinClass, tripType: query.tripType, currency: effectiveCurrency, country: effectiveCountry };
 
-  const fetchRun = await prisma.fetchRun.create({
-    data: { queryId, status: 'in_progress', vpnCountry: vpnCountry ?? null },
-  });
+  // Reuse a pre-created row when the caller (e.g. the manual /scrape endpoint)
+  // already wrote an `in_progress` row so the UI dot lights up before the
+  // network IO starts. Falls back to creating a fresh row for the cron path.
+  const fetchRun = opts?.fetchRunId
+    ? { id: opts.fetchRunId }
+    : await prisma.fetchRun.create({
+        data: { queryId, status: 'in_progress', vpnCountry: vpnCountry ?? null },
+      });
 
   try {
     return await scrapeQueryForCountry(
@@ -453,8 +459,19 @@ export async function runScrapeForQuery(
   }
 }
 
-/** Scrape a single query across all its VPN countries (local + VPN passes). */
-export async function runFullScrapeForQuery(queryId: string): Promise<ScrapeResult[]> {
+/**
+ * Scrape a single query across all its VPN countries (local + VPN passes).
+ *
+ * When `opts.fetchRunId` is provided, the FIRST country pass (always the
+ * local null pass) reuses that pre-created row. Subsequent VPN passes still
+ * create their own rows via the standard runScrapeForQuery path. This lets
+ * the manual /scrape endpoint pre-create one in_progress row synchronously
+ * so the UI dot starts pulsing before the actual network IO begins.
+ */
+export async function runFullScrapeForQuery(
+  queryId: string,
+  opts?: { fetchRunId?: string },
+): Promise<ScrapeResult[]> {
   const query = await prisma.query.findUnique({ where: { id: queryId } });
   if (!query) return [];
 
@@ -486,7 +503,8 @@ export async function runFullScrapeForQuery(queryId: string): Promise<ScrapeResu
       await vpnProvider.disconnect();
     }
 
-    const result = await runScrapeForQuery(queryId, country, isVpnPass ? proxyUrl : undefined);
+    const passOpts = ci === 0 && opts?.fetchRunId ? { fetchRunId: opts.fetchRunId } : undefined;
+    const result = await runScrapeForQuery(queryId, country, isVpnPass ? proxyUrl : undefined, passOpts);
     results.push(result);
 
     if (isVpnPass && ci < countriesToScrape.length - 1) {

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -412,7 +412,17 @@ export async function runScrapeForQuery(
 ): Promise<ScrapeResult> {
   const query = await prisma.query.findUnique({ where: { id: queryId } });
   if (!query || !query.active) {
-    return { queryId, status: 'failed', snapshotsCount: 0, extractionCost: 0, error: 'Query not found or inactive' };
+    const errorMsg = 'Query not found or inactive';
+    // If the caller pre-created an in_progress row, finalize it here so
+    // the manual scrape endpoint's lock doesn't see a stuck row forever
+    // and refuse all future refreshes.
+    if (opts?.fetchRunId) {
+      await prisma.fetchRun.update({
+        where: { id: opts.fetchRunId },
+        data: { status: 'failed', error: errorMsg, completedAt: new Date() },
+      }).catch(() => {});
+    }
+    return { queryId, status: 'failed', snapshotsCount: 0, extractionCost: 0, error: errorMsg };
   }
 
   const config = await prisma.extractionConfig.findFirst({ where: { id: 'singleton' } });

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -473,10 +473,14 @@ export async function runScrapeForQuery(
  * Scrape a single query across all its VPN countries (local + VPN passes).
  *
  * When `opts.fetchRunId` is provided, the FIRST country pass (always the
- * local null pass) reuses that pre-created row. Subsequent VPN passes still
- * create their own rows via the standard runScrapeForQuery path. This lets
- * the manual /scrape endpoint pre-create one in_progress row synchronously
- * so the UI dot starts pulsing before the actual network IO begins.
+ * local null pass) reuses that pre-created row. Subsequent VPN passes
+ * each create their own row at the TOP of the loop iteration (before the
+ * VPN connect/disconnect), so the manual scrape endpoint's "any sibling
+ * has an in_progress row" lock stays held continuously across passes
+ * instead of opening a 30+ second window during the next country's VPN
+ * connect. Each row is then passed back into runScrapeForQuery via
+ * fetchRunId so the row gets finalised by the same code path that the
+ * cron uses (no double-creation).
  */
 export async function runFullScrapeForQuery(
   queryId: string,
@@ -502,10 +506,31 @@ export async function runFullScrapeForQuery(
     const country = countriesToScrape[ci]!;
     const isVpnPass = country !== null;
 
+    // Create (or reuse) this pass's FetchRun BEFORE any VPN
+    // connect/disconnect. The previous iteration's row has just been
+    // finalised by runScrapeForQuery; without this pre-creation the
+    // manual scrape endpoint could see "no in_progress rows" during the
+    // 30+ second VPN connect window and accept a second concurrent run.
+    let passFetchRunId: string;
+    if (ci === 0 && opts?.fetchRunId) {
+      passFetchRunId = opts.fetchRunId;
+    } else {
+      const row = await prisma.fetchRun.create({
+        data: { queryId, status: 'in_progress', vpnCountry: country },
+        select: { id: true },
+      });
+      passFetchRunId = row.id;
+    }
+
     if (isVpnPass) {
       const connected = await vpnProvider.connect(country);
       if (!connected) {
         console.error(`[scrape] failed to connect VPN to ${country}, skipping`);
+        // Don't leave the just-pre-created row stuck at in_progress.
+        await prisma.fetchRun.update({
+          where: { id: passFetchRunId },
+          data: { status: 'failed', error: `VPN connect to ${country} failed`, completedAt: new Date() },
+        }).catch(() => {});
         continue;
       }
       await new Promise((r) => setTimeout(r, 3000));
@@ -513,8 +538,7 @@ export async function runFullScrapeForQuery(
       await vpnProvider.disconnect();
     }
 
-    const passOpts = ci === 0 && opts?.fetchRunId ? { fetchRunId: opts.fetchRunId } : undefined;
-    const result = await runScrapeForQuery(queryId, country, isVpnPass ? proxyUrl : undefined, passOpts);
+    const result = await runScrapeForQuery(queryId, country, isVpnPass ? proxyUrl : undefined, { fetchRunId: passFetchRunId });
     results.push(result);
 
     if (isVpnPass && ci < countriesToScrape.length - 1) {


### PR DESCRIPTION
Two follow-up features from issue #78:

1. **Manual force scrape per tracker.** Refresh icon next to each tracker on the landing card, /account row, /admin/queries row, and /q/[id] footer. Click POSTs `/api/queries/[id]/scrape`. The endpoint cascades across siblings sharing a `groupId`, pre-creates one `FetchRun` row (`status=in_progress, source=manual`) per target so the dot lights up immediately, then runs the actual scrapes serially in a background IIFE so multiple siblings never race the shared VPN sidecar. Throttled at one acceptance per group per 60 seconds.
2. **Visual scrape status indicator.** Small coloured dot next to the "last checked" timestamp on every dashboard surface and on /q/[id]. Green success, red failed (tooltip surfaces the underlying error), yellow partial, pulsing blue in_progress. Aggregates across siblings with `in_progress > failed > partial > success > null` precedence, so an active refresh always pulses and a single failing sibling can't hide behind successful ones.

The same release bundles the v0.7.1 hotfix from #80 (group date bubble used the primary sibling's pinned date instead of the union).

### Server side

* New endpoint `POST /api/queries/[id]/scrape`. Auth shares one surface with PATCH and DELETE.
* `authorizeMutation` extracted into `@/lib/query-auth` and extended with the legacy admin HMAC cookie so the admin dashboard's refresh button doesn't 401 in hosted mode.
* `runFullScrapeForQuery` + `runScrapeForQuery` accept an optional `opts.fetchRunId` so the pre-created `in_progress` row gets reused on the first country pass instead of duplicating. Subsequent VPN passes still create their own rows (existing behaviour).
* `/api/queries/active` and `/api/admin/queries` widen the `fetchRuns` select with `status` and `error`, and surface `lastScrapeStatus` + `lastScrapeError` on each row.
* No schema migration; `FetchRun.status` and `FetchRun.error` already existed.

### UI

* New `ScrapeStatusDot` and `ForceScrapeButton` client components (CSS Modules, no new deps).
* `aggregateScrapeStatus` is a pure helper with 8 unit cases.
* `/account` row restructured so the existing `<Link>` becomes a child of the row container with the button as a sibling, eliminating any anchor-navigation race.
* Refresh is hidden when the (group) is paused or expired so users never race a 409.

### Cost note

A force-scrape click on an N-sibling flex group fires N×LLM extractions over the next few minutes (siblings run serially, ~30s each, so a 20-sibling group is ~10 minutes of background work). The 60s throttle caps clicks per group but a single click can still produce a non-trivial bill on a busy account.

### Test plan

* `npm run ci`: 659 passed across 47 test files.
* New: 14 cases on `scrape/route.test.ts` (auth matrix, paused/seed 409, throttle hit, Redis null/throw fallthroughs, cascade serial order, admin cookie hosted-mode).
* New: 3 cases on `active/route.test.ts` asserting `lastScrapeStatus` and `lastScrapeError` round-trip.
* New: 8 cases on `scrape-status.test.ts` covering aggregation precedence + edge cases.
* Existing tests still green (notably `[id]/route.test.ts` after the `authorizeMutation` extraction).
* [ ] Manual: click refresh on a flex group, dot pulses, sibling FetchRun rows show `in_progress` in DB within a second; status flips to terminal once the first run completes.
* [ ] Manual: click refresh twice in 30s, second click returns 429 inline tooltip.
* [ ] Manual: paused tracker shows resume button (no refresh), so the 409 path is unreachable from the UI.
