### PR TITLE
feat(registry): allow custom model ID for Google provider (#81)

### DIFF
--- a/apps/web/src/lib/scraper/ai-registry.test.ts
+++ b/apps/web/src/lib/scraper/ai-registry.test.ts
@@ -137,8 +137,9 @@ describe('ai-registry', () => {
   });
 
   describe('allowCustomModel', () => {
-    it('is enabled for openai, ollama, llamacpp, and vllm providers', () => {
+    it('is enabled for openai, google, ollama, llamacpp, and vllm providers', () => {
       expect(EXTRACTION_PROVIDERS.openai!.allowCustomModel).toBe(true);
+      expect(EXTRACTION_PROVIDERS.google!.allowCustomModel).toBe(true);
       expect(EXTRACTION_PROVIDERS.ollama!.allowCustomModel).toBe(true);
       expect(EXTRACTION_PROVIDERS.llamacpp!.allowCustomModel).toBe(true);
       expect(EXTRACTION_PROVIDERS.vllm!.allowCustomModel).toBe(true);
@@ -146,7 +147,6 @@ describe('ai-registry', () => {
 
     it('is not enabled for other providers', () => {
       expect(EXTRACTION_PROVIDERS.anthropic!.allowCustomModel).toBeUndefined();
-      expect(EXTRACTION_PROVIDERS.google!.allowCustomModel).toBeUndefined();
     });
   });
 

--- a/apps/web/src/lib/scraper/ai-registry.ts
+++ b/apps/web/src/lib/scraper/ai-registry.ts
@@ -241,6 +241,7 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
   google: {
     displayName: 'Google',
     envKey: 'GOOGLE_AI_API_KEY',
+    allowCustomModel: true,
     models: [
       {
         id: 'gemini-2.5-flash',


### PR DESCRIPTION
Flips `allowCustomModel: true` on the google entry in `ai-registry.ts`. The UI already renders the "Or type a custom model ID" text input whenever a provider sets that flag (same path OpenAI uses today), so settings, setup, and `/admin/config` all pick it up with no further changes. Closes #81.

Why it was off: the google entry shipped with one curated model (`gemini-2.5-flash`) and the flag off, on the assumption that the curated list would stay accurate. Google added lite tiers with bigger free quotas after that and the registry never caught up. Reporter hit the free tier 20 RPD cap on `gemini-2.5-flash` while running 3h cron over a flex tracker, which surfaced the gap.

Caveat: custom model IDs fall through `getModelCosts()` and report 0 input / 0 output, same as the OpenAI custom path. Admin dashboard cost line reads $0 for any extraction run on `gemini-3.1-flash-lite`. Google still bills the tokens.

### Test plan
* `ai-registry.test.ts` updated: google moved from the "not enabled" assertion into the positive `allowCustomModel === true` list alongside openai, ollama, llamacpp, and vllm.
* Full CI gate (lint + typecheck + test + build + cli build) passes locally.