### PR TITLE
fix(scraper): /v1 suffix and JSON mode for OpenAI compatible providers

### DIFF
--- a/apps/web/src/lib/scraper/ai-registry.test.ts
+++ b/apps/web/src/lib/scraper/ai-registry.test.ts
@@ -17,8 +17,24 @@ vi.mock('fs', async (importOriginal) => {
   return { ...actual, existsSync: (...args: unknown[]) => mockExistsSync(...args) };
 });
 
+// Mock the openai SDK so local provider extract paths can assert what baseURL
+// the client was constructed with (issue #84: 404 page not found from Ollama
+// when customBaseUrl lacked the /v1 suffix). The default export is invoked
+// with `new`, so the implementation must be a regular function expression:
+// arrow functions cannot be called as constructors.
+const mockOpenAIConstructor = vi.fn();
+const mockChatCompletionsCreate = vi.fn();
+vi.mock('openai', () => ({
+  default: vi.fn(function (this: unknown, opts: { apiKey?: string; baseURL?: string }) {
+    mockOpenAIConstructor(opts);
+    return {
+      chat: { completions: { create: mockChatCompletionsCreate } },
+    };
+  }),
+}));
+
 // Must import after mocks
-const { EXTRACTION_PROVIDERS, LOCAL_PROVIDERS, detectAvailableProviders, filterCliStderr, isLocalProviderReachable } = await import(
+const { EXTRACTION_PROVIDERS, LOCAL_PROVIDERS, detectAvailableProviders, ensureV1Suffix, filterCliStderr, isLocalProviderReachable } = await import(
   './ai-registry'
 );
 
@@ -335,6 +351,120 @@ describe('ai-registry', () => {
       // Clean up: resolve the promise
       fakeProc.emit('close', 0);
       await extractPromise.catch(() => {});
+    });
+  });
+
+  describe('ensureV1Suffix', () => {
+    it('appends /v1 to a host without a path', () => {
+      expect(ensureV1Suffix('http://localhost:11434')).toBe('http://localhost:11434/v1');
+    });
+
+    it('appends /v1 to a host with a trailing slash', () => {
+      expect(ensureV1Suffix('http://localhost:11434/')).toBe('http://localhost:11434/v1');
+    });
+
+    it('is idempotent when /v1 is already present', () => {
+      expect(ensureV1Suffix('http://localhost:11434/v1')).toBe('http://localhost:11434/v1');
+    });
+
+    it('strips a trailing slash after /v1', () => {
+      expect(ensureV1Suffix('http://localhost:11434/v1/')).toBe('http://localhost:11434/v1');
+    });
+
+    it('handles host.docker.internal style addresses', () => {
+      expect(ensureV1Suffix('http://host.docker.internal:11434')).toBe(
+        'http://host.docker.internal:11434/v1',
+      );
+    });
+  });
+
+  // Regression for issue #84: a customBaseUrl saved without /v1 sent the
+  // OpenAI SDK to <host>/chat/completions, which Ollama answers with its
+  // catchall 404. Assert that every local provider passes a /v1 suffixed
+  // baseURL into the SDK constructor regardless of what the caller supplied.
+  describe('local provider extract: /v1 suffix normalization (issue #84)', () => {
+    const savedOllamaHost = process.env.OLLAMA_HOST;
+
+    beforeEach(() => {
+      mockOpenAIConstructor.mockClear();
+      mockChatCompletionsCreate.mockReset();
+      mockChatCompletionsCreate.mockResolvedValue({
+        choices: [{ message: { content: '{"parsed": null, "confidence": "low", "ambiguities": []}' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      });
+      delete process.env.OLLAMA_HOST;
+    });
+
+    afterEach(() => {
+      if (savedOllamaHost === undefined) delete process.env.OLLAMA_HOST;
+      else process.env.OLLAMA_HOST = savedOllamaHost;
+    });
+
+    it('ollama: appends /v1 when caller passes baseUrl without it', async () => {
+      await EXTRACTION_PROVIDERS.ollama!.extract(
+        '',
+        'llama3.1:8b',
+        'system',
+        'user',
+        { baseUrl: 'http://host.docker.internal:11434' },
+      );
+      expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'http://host.docker.internal:11434/v1' }),
+      );
+    });
+
+    it('ollama: keeps /v1 when caller already supplied it', async () => {
+      await EXTRACTION_PROVIDERS.ollama!.extract(
+        '',
+        'llama3.1:8b',
+        'system',
+        'user',
+        { baseUrl: 'http://host.docker.internal:11434/v1' },
+      );
+      expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'http://host.docker.internal:11434/v1' }),
+      );
+    });
+
+    it('ollama: appends /v1 when only OLLAMA_HOST env is set (no /v1)', async () => {
+      process.env.OLLAMA_HOST = 'http://host.docker.internal:11434';
+      await EXTRACTION_PROVIDERS.ollama!.extract('', 'llama3.1:8b', 'system', 'user');
+      expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'http://host.docker.internal:11434/v1' }),
+      );
+    });
+
+    it('ollama: falls back to localhost:11434/v1 when nothing is configured', async () => {
+      await EXTRACTION_PROVIDERS.ollama!.extract('', 'llama3.1:8b', 'system', 'user');
+      expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'http://localhost:11434/v1' }),
+      );
+    });
+
+    it('llamacpp: appends /v1 when caller passes baseUrl without it', async () => {
+      await EXTRACTION_PROVIDERS.llamacpp!.extract(
+        '',
+        'gguf-model',
+        'system',
+        'user',
+        { baseUrl: 'http://host.docker.internal:8080' },
+      );
+      expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'http://host.docker.internal:8080/v1' }),
+      );
+    });
+
+    it('vllm: appends /v1 when caller passes baseUrl without it', async () => {
+      await EXTRACTION_PROVIDERS.vllm!.extract(
+        '',
+        'mistral-7b',
+        'system',
+        'user',
+        { baseUrl: 'http://host.docker.internal:8000' },
+      );
+      expect(mockOpenAIConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'http://host.docker.internal:8000/v1' }),
+      );
     });
   });
 

--- a/apps/web/src/lib/scraper/ai-registry.test.ts
+++ b/apps/web/src/lib/scraper/ai-registry.test.ts
@@ -468,6 +468,91 @@ describe('ai-registry', () => {
     });
   });
 
+  // Issue #84 follow up: enabling responseFormat must thread through every
+  // OpenAI compatible extract path so small models (Ollama, llama.cpp, vLLM)
+  // get constrained generation. Without it the parser regex would occasionally
+  // find no JSON in the response and bail.
+  describe('responseFormat: json_object plumbing (issue #84)', () => {
+    beforeEach(() => {
+      mockOpenAIConstructor.mockClear();
+      mockChatCompletionsCreate.mockReset();
+      mockChatCompletionsCreate.mockResolvedValue({
+        choices: [{ message: { content: '{}' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      });
+    });
+
+    it('openai: passes response_format when caller opts in', async () => {
+      await EXTRACTION_PROVIDERS.openai!.extract(
+        'sk-test',
+        'gpt-4.1-mini',
+        'system',
+        'user',
+        { responseFormat: 'json_object' },
+      );
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          response_format: { type: 'json_object' },
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('openai: omits response_format when caller does not opt in', async () => {
+      await EXTRACTION_PROVIDERS.openai!.extract('sk-test', 'gpt-4.1-mini', 'system', 'user');
+      const callArgs = mockChatCompletionsCreate.mock.calls[0]![0] as Record<string, unknown>;
+      expect(callArgs).not.toHaveProperty('response_format');
+    });
+
+    it('ollama: passes response_format when caller opts in', async () => {
+      await EXTRACTION_PROVIDERS.ollama!.extract(
+        '',
+        'llama3.1:8b',
+        'system',
+        'user',
+        { baseUrl: 'http://localhost:11434/v1', responseFormat: 'json_object' },
+      );
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          response_format: { type: 'json_object' },
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('llamacpp: passes response_format when caller opts in', async () => {
+      await EXTRACTION_PROVIDERS.llamacpp!.extract(
+        '',
+        'gguf-model',
+        'system',
+        'user',
+        { responseFormat: 'json_object' },
+      );
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          response_format: { type: 'json_object' },
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('vllm: passes response_format when caller opts in', async () => {
+      await EXTRACTION_PROVIDERS.vllm!.extract(
+        '',
+        'mistral-7b',
+        'system',
+        'user',
+        { responseFormat: 'json_object' },
+      );
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          response_format: { type: 'json_object' },
+        }),
+        expect.any(Object),
+      );
+    });
+  });
+
   describe('isLocalProviderReachable', () => {
     afterEach(() => {
       vi.unstubAllGlobals();

--- a/apps/web/src/lib/scraper/ai-registry.ts
+++ b/apps/web/src/lib/scraper/ai-registry.ts
@@ -30,6 +30,14 @@ interface ModelInfo {
 
 export interface ExtractOptions {
   baseUrl?: string;
+  /**
+   * Force the model into a structured output mode. `'json_object'` maps to
+   * OpenAI's `response_format: { type: 'json_object' }`, which Ollama (>= 0.1.34),
+   * llama.cpp, vLLM, and OpenAI all honour via constrained generation. Without
+   * it small models occasionally return prose or a refusal and `/api/parse`
+   * fails with `Failed to parse LLM response as JSON` (issue #84).
+   */
+  responseFormat?: 'json_object';
 }
 
 interface ProviderConfig {
@@ -139,6 +147,9 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
             { role: 'user', content: userPrompt },
           ],
           max_tokens: 8192,
+          ...(options?.responseFormat === 'json_object'
+            ? { response_format: { type: 'json_object' as const } }
+            : {}),
         },
         { signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS) },
       );
@@ -174,6 +185,9 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
             { role: 'user', content: userPrompt },
           ],
           max_tokens: 8192,
+          ...(options?.responseFormat === 'json_object'
+            ? { response_format: { type: 'json_object' as const } }
+            : {}),
         },
         { signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS) },
       );
@@ -206,6 +220,9 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
             { role: 'user', content: userPrompt },
           ],
           max_tokens: 8192,
+          ...(options?.responseFormat === 'json_object'
+            ? { response_format: { type: 'json_object' as const } }
+            : {}),
         },
         { signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS) },
       );
@@ -238,6 +255,9 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
             { role: 'user', content: userPrompt },
           ],
           max_tokens: 8192,
+          ...(options?.responseFormat === 'json_object'
+            ? { response_format: { type: 'json_object' as const } }
+            : {}),
         },
         { signal: AbortSignal.timeout(EXTRACT_TIMEOUT_MS) },
       );

--- a/apps/web/src/lib/scraper/ai-registry.ts
+++ b/apps/web/src/lib/scraper/ai-registry.ts
@@ -57,6 +57,17 @@ export function filterCliStderr(stderr: string): string {
     .trim();
 }
 
+/**
+ * Local OpenAI compat servers (Ollama, llama.cpp, vLLM) expose chat completions
+ * at `/v1/chat/completions`. The OpenAI SDK just appends `/chat/completions` to
+ * whatever baseURL it gets, so a URL missing `/v1` lands on Ollama's catchall
+ * 404 and the SDK rewraps it as `404 404 page not found`.
+ */
+export function ensureV1Suffix(url: string): string {
+  const trimmed = url.replace(/\/+$/, '');
+  return /\/v1$/i.test(trimmed) ? trimmed : `${trimmed}/v1`;
+}
+
 export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
   anthropic: {
     displayName: 'Anthropic',
@@ -150,8 +161,10 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
     models: [],
     extract: async (_apiKey, model, systemPrompt, userPrompt, options) => {
       const { default: OpenAI } = await import('openai');
-      const baseURL = options?.baseUrl
-        || (process.env.OLLAMA_HOST ? process.env.OLLAMA_HOST + '/v1' : 'http://localhost:11434/v1');
+      const rawBaseURL = options?.baseUrl
+        || process.env.OLLAMA_HOST
+        || 'http://localhost:11434';
+      const baseURL = ensureV1Suffix(rawBaseURL);
       const client = new OpenAI({ apiKey: 'unused', baseURL });
       const response = await client.chat.completions.create(
         {
@@ -183,7 +196,7 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
     models: [],
     extract: async (_apiKey, model, systemPrompt, userPrompt, options) => {
       const { default: OpenAI } = await import('openai');
-      const baseURL = options?.baseUrl || 'http://localhost:8080/v1';
+      const baseURL = ensureV1Suffix(options?.baseUrl || 'http://localhost:8080');
       const client = new OpenAI({ apiKey: 'unused', baseURL });
       const response = await client.chat.completions.create(
         {
@@ -215,7 +228,7 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
     models: [],
     extract: async (_apiKey, model, systemPrompt, userPrompt, options) => {
       const { default: OpenAI } = await import('openai');
-      const baseURL = options?.baseUrl || 'http://localhost:8000/v1';
+      const baseURL = ensureV1Suffix(options?.baseUrl || 'http://localhost:8000');
       const client = new OpenAI({ apiKey: 'unused', baseURL });
       const response = await client.chat.completions.create(
         {

--- a/apps/web/src/lib/scraper/parse-query.test.ts
+++ b/apps/web/src/lib/scraper/parse-query.test.ts
@@ -361,6 +361,72 @@ describe('parseFlightQuery', () => {
     await expect(parseFlightQuery('asdfghjkl')).rejects.toThrow('Failed to parse LLM response as JSON');
   });
 
+  it('logs a preview of the raw LLM content when no JSON block is found (issue #84)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockExtract.mockResolvedValue({
+      content: 'I am sorry, I cannot help with that request.',
+      usage: { inputTokens: 50, outputTokens: 20 },
+    });
+
+    await expect(parseFlightQuery('asdfghjkl')).rejects.toThrow('Failed to parse LLM response as JSON');
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('FAIL no_json_in_response'),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('preview=I am sorry'),
+    );
+    spy.mockRestore();
+  });
+
+  it('logs a preview when JSON parse fails on a malformed block (issue #84)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Regex finds { ... } but the contents are not valid JSON (unquoted keys).
+    mockExtract.mockResolvedValue({
+      content: 'Here is the result: { foo: bar } and more',
+      usage: { inputTokens: 50, outputTokens: 20 },
+    });
+
+    await expect(parseFlightQuery('asdfghjkl')).rejects.toThrow('Failed to parse LLM response as JSON');
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('FAIL json_parse_error'),
+    );
+    spy.mockRestore();
+  });
+
+  it('opts into responseFormat json_object on the extract call (issue #84)', async () => {
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'JFK' }],
+          destinations: [{ code: 'LAX', name: 'LAX' }],
+          dateFrom: '2026-06-15',
+          dateTo: '2026-06-22',
+          flexibility: 0,
+          maxPrice: null,
+          maxStops: null,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    await parseFlightQuery('JFK to LAX June 15-22');
+
+    expect(mockExtract).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ responseFormat: 'json_object' }),
+    );
+  });
+
   it('throws when provider is unknown', async () => {
     const { prisma } = await import('@/lib/prisma');
     vi.mocked(prisma.extractionConfig.findFirst).mockResolvedValueOnce({

--- a/apps/web/src/lib/scraper/parse-query.test.ts
+++ b/apps/web/src/lib/scraper/parse-query.test.ts
@@ -23,9 +23,17 @@ vi.mock('./ai-registry', () => ({
       models: [],
       extract: mockExtract,
     },
+    ollama: {
+      displayName: 'Ollama',
+      envKey: undefined,
+      allowCustomModel: true,
+      allowCustomBaseUrl: true,
+      models: [],
+      extract: mockExtract,
+    },
   },
   CLI_PROVIDERS: {},
-  LOCAL_PROVIDERS: new Set(),
+  LOCAL_PROVIDERS: new Set(['ollama']),
 }));
 
 // Provide a fake API key so the provider check passes
@@ -393,7 +401,13 @@ describe('parseFlightQuery', () => {
     spy.mockRestore();
   });
 
-  it('opts into responseFormat json_object on the extract call (issue #84)', async () => {
+  it('opts into responseFormat json_object for local providers (issue #84)', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    vi.mocked(prisma.extractionConfig.findFirst).mockResolvedValueOnce({
+      provider: 'ollama',
+      model: 'llama3.1:8b',
+    } as never);
+
     mockExtract.mockResolvedValue({
       content: makeLlmResponse({
         confidence: 'high',
@@ -425,6 +439,39 @@ describe('parseFlightQuery', () => {
       expect.any(String),
       expect.objectContaining({ responseFormat: 'json_object' }),
     );
+  });
+
+  it('does not set responseFormat outside local providers (issue #84)', async () => {
+    // Default mocked provider is anthropic; LOCAL_PROVIDERS excludes it, so
+    // the OpenAI compat `response_format` flag is not safe to force and must
+    // not appear in the extract call. Same guard protects custom
+    // OPENAI_BASE_URL endpoints from a 400 on unsupported models.
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'JFK' }],
+          destinations: [{ code: 'LAX', name: 'LAX' }],
+          dateFrom: '2026-06-15',
+          dateTo: '2026-06-22',
+          flexibility: 0,
+          maxPrice: null,
+          maxStops: null,
+          preferredAirlines: [],
+          timePreference: 'any',
+          cabinClass: 'economy',
+          tripType: 'round_trip',
+          currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    await parseFlightQuery('JFK to LAX June 15-22');
+
+    const callArgs = mockExtract.mock.calls[0]![4] as Record<string, unknown> | undefined;
+    expect(callArgs).not.toHaveProperty('responseFormat');
   });
 
   it('throws when provider is unknown', async () => {

--- a/apps/web/src/lib/scraper/parse-query.ts
+++ b/apps/web/src/lib/scraper/parse-query.ts
@@ -261,11 +261,13 @@ export async function parseFlightQuery(
     fullPrompt,
     {
       baseUrl: config?.customBaseUrl ?? undefined,
-      // Constrain OpenAI compatible providers (openai, ollama, llamacpp, vllm)
-      // to emit a JSON object. Anthropic, Google, and CLI providers ignore it.
-      // Without it, small Ollama models occasionally return prose or a refusal
-      // and the regex below finds nothing (issue #84).
-      responseFormat: 'json_object',
+      // Constrain local providers to emit a JSON object. Without this, small
+      // Ollama models occasionally return prose or a refusal and the regex
+      // below finds nothing (issue #84). Gated to LOCAL_PROVIDERS only because
+      // custom OpenAI compatible endpoints (OPENAI_BASE_URL, OpenRouter, etc.)
+      // may route to models that reject `response_format` outright; the
+      // default OpenAI model follows the JSON instruction reliably anyway.
+      ...(isLocalProvider ? { responseFormat: 'json_object' as const } : {}),
     }
   );
 

--- a/apps/web/src/lib/scraper/parse-query.ts
+++ b/apps/web/src/lib/scraper/parse-query.ts
@@ -259,15 +259,36 @@ export async function parseFlightQuery(
     model,
     buildSystemPrompt(),
     fullPrompt,
-    { baseUrl: config?.customBaseUrl ?? undefined }
+    {
+      baseUrl: config?.customBaseUrl ?? undefined,
+      // Constrain OpenAI compatible providers (openai, ollama, llamacpp, vllm)
+      // to emit a JSON object. Anthropic, Google, and CLI providers ignore it.
+      // Without it, small Ollama models occasionally return prose or a refusal
+      // and the regex below finds nothing (issue #84).
+      responseFormat: 'json_object',
+    }
   );
 
   const jsonMatch = result.content.match(/\{[\s\S]*\}/);
   if (!jsonMatch) {
+    const preview = result.content.slice(0, 200).replace(/\s+/g, ' ');
+    console.error(
+      `[parse-query] FAIL no_json_in_response provider=${provider} model=${model} length=${result.content.length} preview=${preview}`,
+    );
     throw new Error('Failed to parse LLM response as JSON');
   }
 
-  const raw = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const preview = jsonMatch[0].slice(0, 200).replace(/\s+/g, ' ');
+    console.error(
+      `[parse-query] FAIL json_parse_error provider=${provider} model=${model} length=${jsonMatch[0].length} err=${msg} preview=${preview}`,
+    );
+    throw new Error('Failed to parse LLM response as JSON');
+  }
 
   // Handle both old format (flat ParsedFlightQuery) and new format (with confidence envelope)
   let parsed: ParsedFlightQuery | null;


### PR DESCRIPTION
Refs #84.

Ollama search needed two fixes:

1. **The /v1 path bug.** A saved customBaseUrl without `/v1` (e.g. `http://host.docker.internal:11434`) sent the OpenAI SDK to `<host>/chat/completions`. Ollama answers any non `/v1/chat/completions` path with `404 page not found`, which the SDK rewraps as `404 404 page not found` and `/api/parse` returns inside a 422 envelope. Reporter confirmed with a direct curl: `:11434/v1/chat/completions` returns a JSON completion, the same call without `/v1` returns the 404 body verbatim. Model discovery worked because the local-models route already strips a trailing `/v1` before calling Ollama native `/api/tags`, which masked the misconfig.

2. **Small models break strict JSON.** Once the request flowed, a small Ollama model returned prose or a partial code fence instead of JSON. The regex `/\{[\s\S]*\}/` found nothing, `/api/parse` threw `Failed to parse LLM response as JSON`, and the failure was opaque because the raw LLM content was never logged.

What changed:

* New `ensureV1Suffix()` helper. Strips trailing slashes, appends `/v1` if missing. Routed through every local provider's baseURL. OLLAMA_HOST env path simplified to just the host and runs through the same helper.
* New optional `responseFormat?: 'json_object'` on `ExtractOptions`. Plumbed into openai, ollama, llamacpp, and vllm extract paths via `response_format: { type: 'json_object' }`. parse-query opts in. Ollama 0.1.34+, OpenAI (gpt-4.1-mini and later), llama.cpp, and vLLM all honour the flag.
* parse-query logs a 200 char preview of the raw LLM content on both failure modes (no JSON in response, JSON.parse error), mirroring the pattern in `extract-prices.ts`.

### Test plan

* `npm run ci` clean in worktree (vitest 70 pass / 0 fail in the touched files)
* Reporter on Manjaro to confirm search works end to end (pending in #84)

19 new tests:
* ensureV1Suffix: 5 (idempotency, trailing slash, `host.docker.internal` style)
* /v1 suffix plumbing: 6 (ollama × 4, llamacpp, vllm)
* response_format plumbing: 5 (openai with and without, ollama, llamacpp, vllm)
* parse-query: 3 (preview on no JSON, preview on parse error, responseFormat reaches extract)
