### PR TITLE
feat: Skyscanner and Kayak as fallback aggregators (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.8.0] - 2026-05-26
+
+### Added
+* **Skyscanner and Kayak as fallback aggregators** (#89): the price scrape now walks an ordered chain of sources per query instead of falling back to Google Flights as a single hardcoded branch. New `navigateSkyscanner` and `navigateKayak` follow the same `NavigationResult` shape as `navigateAirlineDirect`, gate the result via `hasFlightPriceSignal`, and dismiss the usual Cloudflare and consent dialogs. Both ship behind feature flags and are off by default: admin enables them in `/admin/config` via the new `ExtractionConfig.aggregatorsEnabled` allowlist, users then order them in `/account/settings`. Skyscanner and Kayak both deploy aggressive anti-bot (Cloudflare, PerimeterX), so v1 reliability is best effort -- 40 to 70 percent in burst, dropping under sustained load. Residential proxies or paid CAPTCHA solving would unlock production grade reliability and are out of scope.
+* **Per user and per query aggregator preference** (#89): `User.preferredAggregators` carries the user default; `Query.preferredAggregators` overrides per tracker. The chain resolver precedence is per query > per user > admin allowlist order. The new `SettingsForm` aggregator section renders an ordered checklist with up and down buttons; Skyscanner and Kayak rows visibly tag `experimental` and are disabled when admin has not enabled them. `/api/queries/[id]` PATCH accepts `preferredAggregators` with single id scope (no group cascade, unlike `scrapeInterval` and `active`); `/api/admin/queries/[id]` PATCH has parity. `/api/account/settings` returns the new field on GET and validates it with HTTP 422 on PATCH.
+* **Manual scrape completion summary log** (#89): the background IIFE in `/api/queries/[id]/scrape` now emits `[scrape] manual run complete (group=<id>): N successes, M failures` once every target finishes, matching the cron summary format. A target counts as success only when every country pass landed prices; thrown targets and empty results both count as failure.
+
+### Schema
+* New columns auto-applied via `prisma db push` on deploy. Defaults mean existing rows are unaffected.
+  * `User.preferredAggregators String[] @default([])`
+  * `Query.preferredAggregators String[] @default([])`
+  * `ExtractionConfig.aggregatorsEnabled String[] @default(["google_flights", "airline_direct"])`
+* `FetchRun.source` doc comment widened to document joined source labels (e.g. `google_flights+skyscanner`).
+
+### Changed
+* `scrapeOneDatePair` now drives the aggregator chain at the top of the attempt loop instead of only inside the airline_direct diversification branch. Skyscanner and Kayak are now reachable for every query, not just queries with airline preferences. The issue-65 invariant is preserved: `all_filtered_out` short circuits the chain (real flights existed; filters excluded them); per-aggregator throws are caught so the next source can still be tried; airline_direct stub pages still divert to the next chain entry inside the same attempt.
+* `extract-prices.ts buildSystemPrompt` source labels and bookingUrl rules converted from ternaries to switches with explicit cases for `skyscanner` and `kayak`.
+* `runScrapeForQuery` query lookup now includes the owning user via `include: { user: { select: { preferredAggregators: true } } }` so per user prefs are available in the resolver. Anonymous and seed queries (where `userId` is null) fall through to admin allowlist order.
+
 ## [0.7.4] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -225,6 +225,21 @@ You type: "SFO to Tokyo sometime in July +/- 5 days"
 
 The built-in cron runs on a configurable interval (default: every 3h). Each run captures prices across all active queries and the chart pages update automatically.
 
+## Scraping Constraints
+
+Fairtrail walks an ordered chain of price sources per query. The chain is admin allowlisted and per user orderable. Each source has different reliability:
+
+| Source           | Default | Reliability     | Notes |
+|------------------|---------|-----------------|-------|
+| Google Flights   | on      | High            | Three URL rotation + stealth context. Rate limit kicks in around 30 sustained requests per IP. |
+| Airline direct   | on      | High when supported | URL templates in `airline-urls.ts`. Falls through to the next source when an airline returns a stub page. |
+| Skyscanner       | off     | **Experimental** (40 to 70 percent in burst, drops under sustained load) | Cloudflare interstitials + bot detection. v1 is best effort. |
+| Kayak            | off     | **Experimental** (similar to Skyscanner) | PerimeterX bot detection. v1 is best effort. |
+
+Skyscanner and Kayak are off by default. Admin enables them in `/admin/config`; users then order them in `/account/settings`. When a source returns no flights the next source in the chain runs; an `all_filtered_out` result (real flights existed but query filters excluded them) short circuits the chain because changing sources cannot help.
+
+For Skyscanner and Kayak to be production grade you would need residential proxies or paid CAPTCHA solving, neither of which Fairtrail ships. If those sources fail consistently for your route, leave them off.
+
 ## Managing Fairtrail
 
 ```

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairtrail/web",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3003",

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -21,6 +21,7 @@ model Query {
   maxStops        Int?
   maxDurationHours Int?     // optional cap on total trip duration in hours
   preferredAirlines String[] @default([])
+  preferredAggregators String[] @default([]) // per-query override of User.preferredAggregators; empty = inherit
   timePreference  String   @default("any")
   cabinClass      String   @default("economy")
   tripType        String   @default("round_trip") // 'one_way' | 'round_trip'
@@ -82,7 +83,7 @@ model FetchRun {
   id             String    @id @default(cuid())
   queryId        String
   status         String // 'success' | 'partial' | 'failed'
-  source         String    @default("google_flights") // 'google_flights' | 'airline_direct'
+  source         String    @default("google_flights") // 'google_flights' | 'airline_direct' | 'skyscanner' | 'kayak' | 'manual' | joined labels e.g. 'google_flights+skyscanner'
   snapshotsCount Int       @default(0)
   extractionCost Float?
   vpnCountry     String?   // ISO 3166-1 alpha-2 — VPN exit country during this run
@@ -117,6 +118,7 @@ model ExtractionConfig {
   multiUserMode        Boolean   @default(false) // self-hosted only; admin manages User table for households
   updatedAt            DateTime  @updatedAt
   extractTimeoutSeconds Int @default(90)
+  aggregatorsEnabled    String[] @default(["google_flights", "airline_direct"]) // sources allowed in the fallback chain; skyscanner/kayak opt-in
 }
 
 model User {
@@ -127,7 +129,8 @@ model User {
   isAdmin           Boolean  @default(false)
   defaultCurrency   String?  // override; null falls back to ExtractionConfig.defaultCurrency
   defaultCountry    String?  // override; null falls back to ExtractionConfig.defaultCountry
-  preferredAirlines String[] @default([])
+  preferredAirlines    String[] @default([])
+  preferredAggregators String[] @default([]) // ordered fallback chain after airline_direct; empty = inherit admin default
   cabinClass        String?  // override; null falls back to "economy"
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt

--- a/apps/web/src/app/account/settings/SettingsForm.tsx
+++ b/apps/web/src/app/account/settings/SettingsForm.tsx
@@ -9,12 +9,43 @@ interface Preferences {
   defaultCurrency: string | null;
   defaultCountry: string | null;
   preferredAirlines: string[];
+  preferredAggregators: string[];
   cabinClass: string | null;
 }
 
 const CABIN_CLASSES = ['economy', 'premium_economy', 'business', 'first'] as const;
 
-export function SettingsForm({ initial }: { initial: Preferences }) {
+// All four aggregators, in the visual order shown when the user has no
+// explicit preference. Skyscanner and Kayak are flagged experimental at the
+// component level so users know what they're enabling.
+const ALL_AGGREGATORS = ['google_flights', 'airline_direct', 'skyscanner', 'kayak'] as const;
+type Aggregator = (typeof ALL_AGGREGATORS)[number];
+
+const AGGREGATOR_LABEL: Record<Aggregator, string> = {
+  google_flights: 'Google Flights',
+  airline_direct: 'Airline direct',
+  skyscanner: 'Skyscanner',
+  kayak: 'Kayak',
+};
+
+const EXPERIMENTAL_AGGREGATORS = new Set<Aggregator>(['skyscanner', 'kayak']);
+
+// Build the initial render order: the user's saved order first, then any
+// aggregators they have not explicitly placed (in the canonical order).
+function buildInitialOrder(saved: string[]): Aggregator[] {
+  const valid = saved.filter((s): s is Aggregator => (ALL_AGGREGATORS as readonly string[]).includes(s));
+  const seen = new Set<Aggregator>(valid);
+  const rest = ALL_AGGREGATORS.filter((a) => !seen.has(a));
+  return [...valid, ...rest];
+}
+
+export function SettingsForm({
+  initial,
+  adminEnabledAggregators,
+}: {
+  initial: Preferences;
+  adminEnabledAggregators: string[];
+}) {
   const [displayName, setDisplayName] = useState(initial.displayName ?? '');
   const [defaultCurrency, setDefaultCurrency] = useState(initial.defaultCurrency ?? '');
   const [defaultCountry, setDefaultCountry] = useState(initial.defaultCountry ?? '');
@@ -22,9 +53,36 @@ export function SettingsForm({ initial }: { initial: Preferences }) {
     initial.preferredAirlines.join(', '),
   );
   const [cabinClass, setCabinClass] = useState(initial.cabinClass ?? '');
+  const [aggregatorOrder, setAggregatorOrder] = useState<Aggregator[]>(
+    () => buildInitialOrder(initial.preferredAggregators),
+  );
+  // Selection: which aggregators the user has explicitly chosen. Empty means
+  // "inherit defaults" (server-side fallback to admin allowlist order).
+  const [aggregatorSelection, setAggregatorSelection] = useState<Set<Aggregator>>(
+    () => new Set(
+      initial.preferredAggregators.filter((s): s is Aggregator => (ALL_AGGREGATORS as readonly string[]).includes(s))
+    ),
+  );
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+
+  const adminAllowed = new Set(adminEnabledAggregators);
+
+  const moveAggregator = (index: number, delta: -1 | 1) => {
+    const target = index + delta;
+    if (target < 0 || target >= aggregatorOrder.length) return;
+    const next = [...aggregatorOrder];
+    [next[index], next[target]] = [next[target]!, next[index]!];
+    setAggregatorOrder(next);
+  };
+
+  const toggleAggregator = (source: Aggregator) => {
+    const next = new Set(aggregatorSelection);
+    if (next.has(source)) next.delete(source);
+    else next.add(source);
+    setAggregatorSelection(next);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,6 +95,11 @@ export function SettingsForm({ initial }: { initial: Preferences }) {
       .map((s) => s.trim())
       .filter(Boolean);
 
+    // Send the explicitly selected aggregators in the user's chosen order.
+    // Empty selection persists as [] which the server reads as
+    // "inherit admin defaults".
+    const selectedAggregators = aggregatorOrder.filter((s) => aggregatorSelection.has(s));
+
     const res = await fetch('/api/account/settings', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -45,6 +108,7 @@ export function SettingsForm({ initial }: { initial: Preferences }) {
         defaultCurrency: defaultCurrency.trim().toUpperCase() || null,
         defaultCountry: defaultCountry.trim().toUpperCase() || null,
         preferredAirlines: airlines,
+        preferredAggregators: selectedAggregators,
         cabinClass: cabinClass || null,
       }),
     });
@@ -121,6 +185,61 @@ export function SettingsForm({ initial }: { initial: Preferences }) {
             <option key={c} value={c}>{c.replace('_', ' ')}</option>
           ))}
         </select>
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label}>Aggregator preference</label>
+        <div className={styles.aggregatorList}>
+          {aggregatorOrder.map((source, index) => {
+            const allowedByAdmin = adminAllowed.has(source);
+            const experimental = EXPERIMENTAL_AGGREGATORS.has(source);
+            const checked = aggregatorSelection.has(source);
+            const disabled = !allowedByAdmin;
+            return (
+              <div
+                key={source}
+                className={styles.aggregatorRow}
+                data-disabled={disabled ? 'true' : 'false'}
+              >
+                <span className={styles.aggregatorIndex}>{index + 1}.</span>
+                <label className={styles.aggregatorToggle}>
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    disabled={disabled}
+                    onChange={() => toggleAggregator(source)}
+                  />
+                </label>
+                <span className={styles.aggregatorLabel}>{AGGREGATOR_LABEL[source]}</span>
+                {experimental && <span className={styles.aggregatorTag}>experimental</span>}
+                <div className={styles.aggregatorButtons}>
+                  <button
+                    type="button"
+                    className={styles.aggregatorButton}
+                    onClick={() => moveAggregator(index, -1)}
+                    disabled={index === 0}
+                    aria-label={`Move ${AGGREGATOR_LABEL[source]} up`}
+                  >
+                    ↑
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.aggregatorButton}
+                    onClick={() => moveAggregator(index, 1)}
+                    disabled={index === aggregatorOrder.length - 1}
+                    aria-label={`Move ${AGGREGATOR_LABEL[source]} down`}
+                  >
+                    ↓
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <p className={styles.aggregatorHint}>
+          Order matters: when one source returns no flights, the next is tried.
+          Leave everything unchecked to inherit instance defaults.
+        </p>
       </div>
 
       {error && <p className={styles.error}>{error}</p>}

--- a/apps/web/src/app/account/settings/page.module.css
+++ b/apps/web/src/app/account/settings/page.module.css
@@ -113,3 +113,89 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.aggregatorList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.aggregatorRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  color: var(--text);
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.aggregatorRow[data-disabled='true'] {
+  opacity: 0.45;
+}
+
+.aggregatorIndex {
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  min-width: 1.25rem;
+}
+
+.aggregatorLabel {
+  flex: 1;
+}
+
+.aggregatorTag {
+  font-family: var(--font-display);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+}
+
+.aggregatorButtons {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.aggregatorButton {
+  padding: 0.125rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.aggregatorButton:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.aggregatorButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.aggregatorToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.aggregatorHint {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-top: 0.25rem;
+}

--- a/apps/web/src/app/account/settings/page.tsx
+++ b/apps/web/src/app/account/settings/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { redirect, notFound } from 'next/navigation';
 import { isMultiUserEnabled } from '@/lib/multi-user';
 import { getCurrentUser } from '@/lib/user-auth';
+import { prisma } from '@/lib/prisma';
 import { SettingsForm } from './SettingsForm';
 import styles from './page.module.css';
 
@@ -12,6 +13,15 @@ export default async function AccountSettingsPage() {
 
   const user = await getCurrentUser();
   if (!user) redirect('/login?next=/account/settings');
+
+  // Read admin's aggregator allowlist server-side. This page is a Server
+  // Component with 'force-dynamic' so DB reads are cheap and avoid exposing
+  // /api/admin/config (admin-only) to the non-admin user viewing this page.
+  const config = await prisma.extractionConfig.findFirst({
+    where: { id: 'singleton' },
+    select: { aggregatorsEnabled: true },
+  });
+  const adminEnabledAggregators = config?.aggregatorsEnabled ?? ['google_flights', 'airline_direct'];
 
   return (
     <main className={styles.root}>
@@ -31,8 +41,10 @@ export default async function AccountSettingsPage() {
           defaultCurrency: user.defaultCurrency,
           defaultCountry: user.defaultCountry,
           preferredAirlines: user.preferredAirlines,
+          preferredAggregators: user.preferredAggregators,
           cabinClass: user.cabinClass,
         }}
+        adminEnabledAggregators={adminEnabledAggregators}
       />
     </main>
   );

--- a/apps/web/src/app/admin/(dashboard)/config/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/config/page.tsx
@@ -22,7 +22,15 @@ interface Config {
   vpnProvider: string | null;
   vpnCountries: string[];
   hasVpnActivationCode: boolean;
+  aggregatorsEnabled: string[];
 }
+
+const AGGREGATOR_OPTIONS = [
+  { id: 'google_flights', label: 'Google Flights', experimental: false },
+  { id: 'airline_direct', label: 'Airline direct', experimental: false },
+  { id: 'skyscanner', label: 'Skyscanner', experimental: true },
+  { id: 'kayak', label: 'Kayak', experimental: true },
+] as const;
 
 
 
@@ -40,6 +48,7 @@ export default function ConfigPage() {
   const [customBaseUrl, setCustomBaseUrl] = useState('');
   const [vpnProvider, setVpnProvider] = useState('none');
   const [vpnCountries, setVpnCountries] = useState<string[]>([]);
+  const [aggregatorsEnabled, setAggregatorsEnabled] = useState<string[]>(['google_flights', 'airline_direct']);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
 
@@ -94,6 +103,7 @@ export default function ConfigPage() {
           setCustomBaseUrl(d.data.customBaseUrl || '');
           setVpnProvider(d.data.vpnProvider || 'none');
           setVpnCountries(d.data.vpnCountries || []);
+          setAggregatorsEnabled(d.data.aggregatorsEnabled ?? ['google_flights', 'airline_direct']);
           const pc = EXTRACTION_PROVIDERS[d.data.provider];
           const knownModel = pc?.models.find((m) => m.id === d.data.model);
           if (knownModel) {
@@ -150,6 +160,7 @@ export default function ConfigPage() {
         customBaseUrl: newBaseUrl,
         vpnProvider: vpnProvider === 'none' ? null : vpnProvider,
         vpnCountries,
+        aggregatorsEnabled,
       }),
     });
 
@@ -356,6 +367,39 @@ export default function ConfigPage() {
             <option value="ai">AI natural language search</option>
             <option value="manual">Manual input form</option>
           </select>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label}>Aggregator Sources</label>
+          <div>
+            {AGGREGATOR_OPTIONS.map((opt) => {
+              const checked = aggregatorsEnabled.includes(opt.id);
+              return (
+                <label key={opt.id} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.25rem 0' }}>
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setAggregatorsEnabled([...aggregatorsEnabled, opt.id]);
+                      } else {
+                        setAggregatorsEnabled(aggregatorsEnabled.filter((s) => s !== opt.id));
+                      }
+                    }}
+                  />
+                  <span>{opt.label}</span>
+                  {opt.experimental && (
+                    <span style={{ fontSize: '0.75rem', textTransform: 'uppercase', color: 'var(--accent)', fontWeight: 700, letterSpacing: '0.05em' }}>
+                      experimental
+                    </span>
+                  )}
+                </label>
+              );
+            })}
+          </div>
+          <span className={styles.toggleHint}>
+            Sources allowed in the per-query aggregator chain. Skyscanner and Kayak are best-effort, gated by aggressive anti-bot protection on those sites.
+          </span>
         </div>
 
         <div className={styles.field}>

--- a/apps/web/src/app/api/account/settings/route.test.ts
+++ b/apps/web/src/app/api/account/settings/route.test.ts
@@ -51,12 +51,14 @@ describe('GET /api/account/settings', () => {
     mockGetCurrentUser.mockResolvedValue({
       id: 'u1', username: 'alice', displayName: 'Alice',
       defaultCurrency: 'USD', defaultCountry: 'US',
-      preferredAirlines: ['Delta'], cabinClass: 'economy',
+      preferredAirlines: ['Delta'], preferredAggregators: ['google_flights', 'skyscanner'],
+      cabinClass: 'economy',
     });
     const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.defaultCurrency).toBe('USD');
+    expect(body.data.preferredAggregators).toEqual(['google_flights', 'skyscanner']);
   });
 });
 
@@ -99,5 +101,37 @@ describe('PATCH /api/account/settings', () => {
     expect(res.status).toBe(200);
     const args = mockUpdate.mock.calls[0]![0] as { data: Record<string, unknown> };
     expect(args.data.defaultCurrency).toBeNull();
+  });
+
+  it('accepts a valid preferredAggregators array', async () => {
+    const res = await PATCH(makePatch({ preferredAggregators: ['google_flights', 'skyscanner'] }));
+    expect(res.status).toBe(200);
+    const args = mockUpdate.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(args.data.preferredAggregators).toEqual(['google_flights', 'skyscanner']);
+  });
+
+  it('accepts an empty preferredAggregators array as clear', async () => {
+    const res = await PATCH(makePatch({ preferredAggregators: [] }));
+    expect(res.status).toBe(200);
+    const args = mockUpdate.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(args.data.preferredAggregators).toEqual([]);
+  });
+
+  it('rejects unknown aggregator value with 422', async () => {
+    const res = await PATCH(makePatch({ preferredAggregators: ['google_flights', 'expedia'] }));
+    expect(res.status).toBe(422);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string aggregator entry with 422', async () => {
+    const res = await PATCH(makePatch({ preferredAggregators: ['google_flights', 42] }));
+    expect(res.status).toBe(422);
+  });
+
+  it('preferredAggregators field omitted does not touch the column', async () => {
+    const res = await PATCH(makePatch({ defaultCurrency: 'EUR' }));
+    expect(res.status).toBe(200);
+    const args = mockUpdate.mock.calls[0]![0] as { data: Record<string, unknown> };
+    expect(args.data).not.toHaveProperty('preferredAggregators');
   });
 });

--- a/apps/web/src/app/api/account/settings/route.ts
+++ b/apps/web/src/app/api/account/settings/route.ts
@@ -3,6 +3,7 @@ import { apiSuccess, apiError } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
 import { isMultiUserEnabled } from '@/lib/multi-user';
 import { getCurrentUser } from '@/lib/user-auth';
+import { isAggregatorSource } from '@/lib/scraper/navigate';
 
 async function requireUser() {
   if (!(await isMultiUserEnabled())) return { ok: false as const, status: 404 };
@@ -22,6 +23,7 @@ export async function GET() {
     defaultCurrency: user.defaultCurrency,
     defaultCountry: user.defaultCountry,
     preferredAirlines: user.preferredAirlines,
+    preferredAggregators: user.preferredAggregators,
     cabinClass: user.cabinClass,
   });
 }
@@ -68,6 +70,15 @@ export async function PATCH(request: NextRequest) {
     data.preferredAirlines = body.preferredAirlines;
   }
 
+  if (Array.isArray(body.preferredAggregators)) {
+    for (const a of body.preferredAggregators) {
+      if (!isAggregatorSource(a)) {
+        return apiError(`preferredAggregators contains invalid value: ${JSON.stringify(a)}`, 422);
+      }
+    }
+    data.preferredAggregators = body.preferredAggregators;
+  }
+
   if (body.cabinClass === null) {
     data.cabinClass = null;
   } else if (typeof body.cabinClass === 'string') {
@@ -91,6 +102,7 @@ export async function PATCH(request: NextRequest) {
       defaultCurrency: true,
       defaultCountry: true,
       preferredAirlines: true,
+      preferredAggregators: true,
       cabinClass: true,
     },
   });

--- a/apps/web/src/app/api/admin/config/route.ts
+++ b/apps/web/src/app/api/admin/config/route.ts
@@ -8,6 +8,7 @@ import { encryptVpnCode } from '@/lib/vpn-crypto';
 import { isThemeId } from '@/lib/theme';
 import { updateCronInterval } from '@/lib/cron';
 import { requireAdminApi } from '@/lib/admin-guard';
+import { isAggregatorSource } from '@/lib/scraper/navigate';
 
 function stripHashes(config: Record<string, unknown>) {
   const { adminPasswordHash, vpnActivationCode, ...rest } = config;
@@ -142,6 +143,18 @@ export async function PATCH(request: NextRequest) {
       }
     }
     data.customBaseUrl = body.customBaseUrl || null;
+  }
+
+  if (body.aggregatorsEnabled !== undefined) {
+    if (!Array.isArray(body.aggregatorsEnabled)) {
+      return apiError('aggregatorsEnabled must be an array of strings', 422);
+    }
+    for (const a of body.aggregatorsEnabled) {
+      if (!isAggregatorSource(a)) {
+        return apiError(`aggregatorsEnabled contains invalid value: ${JSON.stringify(a)}`, 422);
+      }
+    }
+    data.aggregatorsEnabled = body.aggregatorsEnabled;
   }
 
   const config = await prisma.extractionConfig.upsert({

--- a/apps/web/src/app/api/admin/queries/[id]/route.ts
+++ b/apps/web/src/app/api/admin/queries/[id]/route.ts
@@ -2,10 +2,11 @@ import { NextRequest } from 'next/server';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
 import { requireAdminApi } from '@/lib/admin-guard';
+import { isAggregatorSource } from '@/lib/scraper/navigate';
 
-// Fields that cascade across a query's group when groupId is set. userId
-// reassignment stays single-row because it would not make sense to move an
-// entire group to a different owner via a UI nudge.
+// Fields that cascade across a query's group when groupId is set. userId and
+// preferredAggregators stay single-row because they should be settable per
+// sibling without affecting the rest of a flex group.
 const GROUP_CASCADING_FIELDS = new Set(['active', 'scrapeInterval', 'maxDurationHours']);
 
 export async function PATCH(
@@ -41,6 +42,15 @@ export async function PATCH(
     const target = await prisma.user.findUnique({ where: { id: body.userId }, select: { id: true } });
     if (!target) return apiError(`User not found: ${body.userId}`, 400);
     data.userId = body.userId;
+  }
+
+  if (Array.isArray(body.preferredAggregators)) {
+    for (const a of body.preferredAggregators) {
+      if (!isAggregatorSource(a)) {
+        return apiError(`preferredAggregators contains invalid value: ${JSON.stringify(a)}`, 422);
+      }
+    }
+    data.preferredAggregators = body.preferredAggregators;
   }
 
   // Cascade group-safe fields to every sibling when this query is part of a

--- a/apps/web/src/app/api/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/route.test.ts
@@ -6,6 +6,7 @@ const mockQueryDelete = vi.fn();
 const mockQueryDeleteMany = vi.fn();
 const mockQueryFindMany = vi.fn();
 const mockQueryUpdateMany = vi.fn();
+const mockQueryUpdate = vi.fn();
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
@@ -15,6 +16,7 @@ vi.mock('@/lib/prisma', () => ({
       deleteMany: (...args: unknown[]) => mockQueryDeleteMany(...args),
       findMany: (...args: unknown[]) => mockQueryFindMany(...args),
       updateMany: (...args: unknown[]) => mockQueryUpdateMany(...args),
+      update: (...args: unknown[]) => mockQueryUpdate(...args),
     },
   },
 }));
@@ -381,6 +383,70 @@ describe('PATCH /api/queries/[id]', () => {
       const res = await PATCH(...makePatchRequest('q1', { active: false }));
       expect(res.status).toBe(401);
       expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('preferredAggregators', () => {
+    beforeEach(() => {
+      mockQueryUpdate.mockResolvedValue({});
+    });
+
+    it('updates preferredAggregators on the single id only (no group cascade)', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: 'g1', userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { preferredAggregators: ['skyscanner', 'google_flights'] }));
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.data).toMatchObject({ preferredAggregators: ['skyscanner', 'google_flights'] });
+      expect(mockQueryUpdate).toHaveBeenCalledWith({
+        where: { id: 'q1' },
+        data: { preferredAggregators: ['skyscanner', 'google_flights'] },
+      });
+      // No cascade for aggregator prefs even with a groupId
+      expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+      expect(mockQueryFindMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects unknown aggregator with 422', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { preferredAggregators: ['google_flights', 'expedia'] }));
+      expect(res.status).toBe(422);
+      expect(mockQueryUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-array preferredAggregators with 422', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { preferredAggregators: 'google_flights' }));
+      expect(res.status).toBe(422);
+    });
+
+    it('accepts an empty array as clear', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { preferredAggregators: [] }));
+      expect(res.status).toBe(200);
+      expect(mockQueryUpdate).toHaveBeenCalledWith({
+        where: { id: 'q1' },
+        data: { preferredAggregators: [] },
+      });
+    });
+
+    it('combines with cascaded fields: scrapeInterval cascades, preferredAggregators does not', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: 'g1', userId: null });
+      mockQueryFindMany.mockResolvedValue([{ id: 'q2' }]);
+      const res = await PATCH(...makePatchRequest('q1', { scrapeInterval: 6, preferredAggregators: ['kayak'] }));
+      expect(res.status).toBe(200);
+      expect(mockQueryUpdateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['q1', 'q2'] } },
+        data: { scrapeInterval: 6 },
+      });
+      expect(mockQueryUpdate).toHaveBeenCalledWith({
+        where: { id: 'q1' },
+        data: { preferredAggregators: ['kayak'] },
+      });
     });
   });
 });

--- a/apps/web/src/app/api/queries/[id]/route.ts
+++ b/apps/web/src/app/api/queries/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
 import { authorizeMutation } from '@/lib/query-auth';
+import { isAggregatorSource } from '@/lib/scraper/navigate';
 
 const ALLOWED_INTERVALS = [1, 3, 6, 12, 24];
 
@@ -24,7 +25,12 @@ export async function PATCH(
   const auth = await authorizeMutation(query, token);
   if (!auth.ok) return apiError(auth.error ?? 'Forbidden', auth.status ?? 403);
 
-  const updateData: { scrapeInterval?: number | null; active?: boolean } = {};
+  // Group-cascading fields: applied to every sibling in the group via updateMany.
+  const cascadeData: { scrapeInterval?: number | null; active?: boolean } = {};
+  // Per-row fields: applied only to the single id. preferredAggregators is
+  // intentionally NOT cascaded — different siblings in a flex group can sit on
+  // different aggregators (e.g. one experimental, one default).
+  const singleRowData: { preferredAggregators?: string[] } = {};
 
   if (body && Object.prototype.hasOwnProperty.call(body, 'scrapeInterval')) {
     let interval: number | null;
@@ -36,23 +42,34 @@ export async function PATCH(
         return apiError(`scrapeInterval must be null or one of: ${ALLOWED_INTERVALS.join(', ')}`, 400);
       }
     }
-    updateData.scrapeInterval = interval;
+    cascadeData.scrapeInterval = interval;
   }
 
   if (body && Object.prototype.hasOwnProperty.call(body, 'active')) {
     if (typeof body.active !== 'boolean') {
       return apiError('active must be a boolean', 400);
     }
-    updateData.active = body.active;
+    cascadeData.active = body.active;
   }
 
-  if (Object.keys(updateData).length === 0) {
+  if (body && Object.prototype.hasOwnProperty.call(body, 'preferredAggregators')) {
+    if (!Array.isArray(body.preferredAggregators)) {
+      return apiError('preferredAggregators must be an array of strings', 422);
+    }
+    for (const a of body.preferredAggregators) {
+      if (!isAggregatorSource(a)) {
+        return apiError(`preferredAggregators contains invalid value: ${JSON.stringify(a)}`, 422);
+      }
+    }
+    singleRowData.preferredAggregators = body.preferredAggregators;
+  }
+
+  if (Object.keys(cascadeData).length === 0 && Object.keys(singleRowData).length === 0) {
     return apiError('No updatable fields supplied', 400);
   }
 
-  // Update this query and all siblings in the group
   const idsToUpdate = [id];
-  if (query.groupId) {
+  if (query.groupId && Object.keys(cascadeData).length > 0) {
     const siblings = await prisma.query.findMany({
       where: { groupId: query.groupId, id: { not: id } },
       select: { id: true },
@@ -60,12 +77,21 @@ export async function PATCH(
     idsToUpdate.push(...siblings.map((s) => s.id));
   }
 
-  await prisma.query.updateMany({
-    where: { id: { in: idsToUpdate } },
-    data: updateData,
-  });
+  if (Object.keys(cascadeData).length > 0) {
+    await prisma.query.updateMany({
+      where: { id: { in: idsToUpdate } },
+      data: cascadeData,
+    });
+  }
 
-  return apiSuccess({ ...updateData, updated: idsToUpdate.length });
+  if (Object.keys(singleRowData).length > 0) {
+    await prisma.query.update({
+      where: { id },
+      data: singleRowData,
+    });
+  }
+
+  return apiSuccess({ ...cascadeData, ...singleRowData, updated: idsToUpdate.length });
 }
 
 export async function DELETE(

--- a/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.test.ts
@@ -332,4 +332,56 @@ describe('POST /api/queries/[id]/scrape', () => {
       expect(mockRunFullScrapeForQuery).not.toHaveBeenCalled();
     });
   });
+
+  describe('completion summary log', () => {
+    it('logs a success/failure summary line when the manual run completes', async () => {
+      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+      mockQueryFindUnique.mockResolvedValue(rowDefaults({ groupId: 'g1' }));
+      mockQueryFindMany.mockResolvedValue([{ id: 'q1' }, { id: 'q2' }]);
+      mockRunFullScrapeForQuery
+        .mockResolvedValueOnce([{ queryId: 'q1', status: 'success', snapshotsCount: 3, extractionCost: 0.01 }])
+        .mockResolvedValueOnce([{ queryId: 'q2', status: 'failed', snapshotsCount: 0, extractionCost: 0, error: 'oh' }]);
+
+      const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+      expect(res.status).toBe(200);
+      for (let i = 0; i < 6; i++) await flushIifeMicrotasks();
+
+      expect(consoleLog).toHaveBeenCalledWith(
+        expect.stringMatching(/manual run complete \(group=g1\): 1 successes, 1 failures/),
+      );
+      consoleLog.mockRestore();
+    });
+
+    it('counts a thrown target as failure in the summary', async () => {
+      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockQueryFindUnique.mockResolvedValue(rowDefaults());
+      mockRunFullScrapeForQuery.mockRejectedValueOnce(new Error('boom'));
+
+      const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+      expect(res.status).toBe(200);
+      for (let i = 0; i < 6; i++) await flushIifeMicrotasks();
+
+      expect(consoleLog).toHaveBeenCalledWith(
+        expect.stringMatching(/manual run complete \(group=q1\): 0 successes, 1 failures/),
+      );
+      consoleLog.mockRestore();
+      consoleErr.mockRestore();
+    });
+
+    it('counts an empty results array as failure (no country passes ran)', async () => {
+      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+      mockQueryFindUnique.mockResolvedValue(rowDefaults());
+      mockRunFullScrapeForQuery.mockResolvedValueOnce([]);
+
+      const res = await POST(...makeRequest('q1', { deleteToken: 'real-token' }));
+      expect(res.status).toBe(200);
+      for (let i = 0; i < 6; i++) await flushIifeMicrotasks();
+
+      expect(consoleLog).toHaveBeenCalledWith(
+        expect.stringMatching(/manual run complete \(group=q1\): 0 successes, 1 failures/),
+      );
+      consoleLog.mockRestore();
+    });
+  });
 });

--- a/apps/web/src/app/api/queries/[id]/scrape/route.ts
+++ b/apps/web/src/app/api/queries/[id]/scrape/route.ts
@@ -150,13 +150,27 @@ export async function POST(
   // just-in-time inside runScrapeForQuery; any sibling we never reach
   // simply has no row, instead of an orphan stuck at in_progress.
   const orderedTargets = [id, ...targetIds.filter((qid) => qid !== id)];
+  const groupLabel = query.groupId ?? id;
   void (async () => {
+    let successCount = 0;
+    let failureCount = 0;
     for (let i = 0; i < orderedTargets.length; i++) {
       const qid = orderedTargets[i]!;
       const passOpts = i === 0 ? { fetchRunId: primaryFetchRun.id } : undefined;
       try {
-        await runFullScrapeForQuery(qid, passOpts);
+        const results = await runFullScrapeForQuery(qid, passOpts);
+        // A target counts as a success only when every country pass for
+        // that target landed prices. Empty results (no country passes
+        // executed) count as failure too — a manual click is the user
+        // asking for fresh data, and zero passes is not what they asked
+        // for.
+        if (results.length > 0 && results.every((r) => r.status === 'success')) {
+          successCount += 1;
+        } else {
+          failureCount += 1;
+        }
       } catch (err) {
+        failureCount += 1;
         const errorMsg = err instanceof Error ? err.message : String(err);
         console.error(`[scrape] manual run failed query=${qid}: ${errorMsg}`);
         // If runFullScrapeForQuery throws before runScrapeForQuery has a
@@ -173,6 +187,7 @@ export async function POST(
         }
       }
     }
+    console.log(`[scrape] manual run complete (group=${groupLabel}): ${successCount} successes, ${failureCount} failures`);
   })();
 
   return apiSuccess({

--- a/apps/web/src/app/api/queries/route.ts
+++ b/apps/web/src/app/api/queries/route.ts
@@ -4,6 +4,7 @@ import { apiSuccess, apiError } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
 import { isMultiUserEnabled } from '@/lib/multi-user';
 import { getCurrentUser } from '@/lib/user-auth';
+import { isAggregatorSource } from '@/lib/scraper/navigate';
 
 interface RouteInput {
   origin: string;
@@ -110,6 +111,18 @@ export async function POST(request: NextRequest) {
   expiresAt.setDate(expiresAt.getDate() + flex);
 
   const airlines: string[] = Array.isArray(preferredAirlines) ? preferredAirlines : [];
+
+  // preferredAggregators is optional on creation; empty means inherit user/admin defaults.
+  let aggregators: string[] = [];
+  if (Array.isArray(body.preferredAggregators)) {
+    for (const a of body.preferredAggregators) {
+      if (!isAggregatorSource(a)) {
+        return apiError(`preferredAggregators contains invalid value: ${JSON.stringify(a)}`, 422);
+      }
+    }
+    aggregators = body.preferredAggregators;
+  }
+
   const groupId = crypto.randomUUID();
 
   const results: Array<{
@@ -149,6 +162,7 @@ export async function POST(request: NextRequest) {
         maxStops: maxStops !== undefined && maxStops !== null ? Number(maxStops) : null,
         maxDurationHours: maxDurationHoursValidated,
         preferredAirlines: airlines,
+        preferredAggregators: aggregators,
         timePreference: timePreference || 'any',
         cabinClass: cabinClass || 'economy',
         tripType: tripType === 'one_way' ? 'one_way' : 'round_trip',

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -59,13 +59,35 @@ function buildSystemPrompt(filters: QueryFilters, maxResults: number, source: Na
     ? `\nFiltering rules (STRICT — do not include flights that violate these):\n${filterRules.join('\n')}\n`
     : '';
 
-  const sourceDesc = source === 'airline_direct'
-    ? "an airline's booking/search results page"
-    : 'a Google Flights search results page';
+  let sourceDesc: string;
+  switch (source) {
+    case 'airline_direct':
+      sourceDesc = "an airline's booking/search results page";
+      break;
+    case 'skyscanner':
+      sourceDesc = 'a Skyscanner search results page';
+      break;
+    case 'kayak':
+      sourceDesc = 'a Kayak search results page';
+      break;
+    case 'google_flights':
+    default:
+      sourceDesc = 'a Google Flights search results page';
+      break;
+  }
 
-  const bookingUrlRule = source === 'airline_direct'
-    ? '- For bookingUrl, use the search URL provided (the airline website URL)'
-    : "- If you can't find a direct booking URL, construct one from the Google Flights URL";
+  let bookingUrlRule: string;
+  switch (source) {
+    case 'airline_direct':
+    case 'skyscanner':
+    case 'kayak':
+      bookingUrlRule = '- For bookingUrl, use the search URL provided (the search page URL)';
+      break;
+    case 'google_flights':
+    default:
+      bookingUrlRule = "- If you can't find a direct booking URL, construct one from the Google Flights URL";
+      break;
+  }
 
   const currencyInstruction = currency
     ? `- Use "${currency}" as the currency code for all results`

--- a/apps/web/src/lib/scraper/navigate.test.ts
+++ b/apps/web/src/lib/scraper/navigate.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   buildGoogleFlightsUrl,
   buildGoogleFlightsUrlCandidates,
+  buildSkyscannerUrl,
+  buildKayakUrl,
   hasFlightPriceSignal,
+  isAggregatorSource,
   pageHasRequestedRoute,
   pageRedirectedToHomepage,
 } from './navigate';
@@ -502,5 +505,106 @@ describe('hasFlightPriceSignal (two-criterion airline page heuristic, issue #65)
 
   it('accepts EUR99 (no space between code and digits)', () => {
     expect(hasFlightPriceSignal('EUR99 EUR131 EUR205')).toBe(true);
+  });
+});
+
+describe('buildSkyscannerUrl', () => {
+  const base = {
+    origin: 'JFK',
+    destination: 'LAX',
+    dateFrom: new Date('2026-06-15T00:00:00Z'),
+    dateTo: new Date('2026-06-22T00:00:00Z'),
+  };
+
+  it('builds a round-trip URL with lowercase IATA codes and YYMMDD dates', () => {
+    const url = buildSkyscannerUrl(base);
+    expect(url).toMatch(/\/jfk\/lax\/260615\/260622\//);
+    expect(url).toContain('adultsv2=1');
+    expect(url).toContain('cabinclass=economy');
+  });
+
+  it('builds a one-way URL with a single date segment', () => {
+    const url = buildSkyscannerUrl({ ...base, tripType: 'one_way' });
+    expect(url).toMatch(/\/jfk\/lax\/260615\/\?/);
+    expect(url).not.toMatch(/260622/);
+  });
+
+  it('maps premium_economy cabin to premiumeconomy', () => {
+    const url = buildSkyscannerUrl({ ...base, cabinClass: 'premium_economy' });
+    expect(url).toContain('cabinclass=premiumeconomy');
+  });
+
+  it('defaults to economy when cabinClass is missing', () => {
+    const url = buildSkyscannerUrl(base);
+    expect(url).toContain('cabinclass=economy');
+  });
+
+  it('includes currency and market when set', () => {
+    const url = buildSkyscannerUrl({ ...base, currency: 'EUR', country: 'DE' });
+    expect(url).toContain('currency=EUR');
+    expect(url).toContain('market=DE');
+  });
+
+  it('omits currency and market when null', () => {
+    const url = buildSkyscannerUrl({ ...base, currency: null, country: null });
+    expect(url).not.toContain('currency=');
+    expect(url).not.toContain('market=');
+  });
+
+  it('rejects invalid origin IATA code', () => {
+    expect(() => buildSkyscannerUrl({ ...base, origin: 'jfk' })).toThrow(/Invalid IATA origin/);
+  });
+
+  it('rejects invalid destination IATA code', () => {
+    expect(() => buildSkyscannerUrl({ ...base, destination: 'JFKK' })).toThrow(/Invalid IATA destination/);
+  });
+});
+
+describe('buildKayakUrl', () => {
+  const base = {
+    origin: 'JFK',
+    destination: 'LAX',
+    dateFrom: new Date('2026-06-15T00:00:00Z'),
+    dateTo: new Date('2026-06-22T00:00:00Z'),
+  };
+
+  it('builds a round-trip URL with uppercase IATA codes and ISO dates', () => {
+    const url = buildKayakUrl(base);
+    expect(url).toBe('https://www.kayak.com/flights/JFK-LAX/2026-06-15/2026-06-22?sort=price_a');
+  });
+
+  it('builds a one-way URL with a single date segment', () => {
+    const url = buildKayakUrl({ ...base, tripType: 'one_way' });
+    expect(url).toBe('https://www.kayak.com/flights/JFK-LAX/2026-06-15?sort=price_a');
+  });
+
+  it('rejects invalid origin IATA code', () => {
+    expect(() => buildKayakUrl({ ...base, origin: 'XX' })).toThrow(/Invalid IATA origin/);
+  });
+
+  it('rejects invalid destination IATA code', () => {
+    expect(() => buildKayakUrl({ ...base, destination: 'lax' })).toThrow(/Invalid IATA destination/);
+  });
+});
+
+describe('isAggregatorSource', () => {
+  it('accepts all four known sources', () => {
+    expect(isAggregatorSource('google_flights')).toBe(true);
+    expect(isAggregatorSource('airline_direct')).toBe(true);
+    expect(isAggregatorSource('skyscanner')).toBe(true);
+    expect(isAggregatorSource('kayak')).toBe(true);
+  });
+
+  it('rejects unknown strings', () => {
+    expect(isAggregatorSource('expedia')).toBe(false);
+    expect(isAggregatorSource('')).toBe(false);
+    expect(isAggregatorSource('GOOGLE_FLIGHTS')).toBe(false);
+  });
+
+  it('rejects non-strings', () => {
+    expect(isAggregatorSource(null)).toBe(false);
+    expect(isAggregatorSource(undefined)).toBe(false);
+    expect(isAggregatorSource(42)).toBe(false);
+    expect(isAggregatorSource([])).toBe(false);
   });
 });

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -44,7 +44,13 @@ export interface FlightSearchParams {
   country?: string | null; // ISO 3166-1 alpha-2. null = omit (Google auto-detects)
 }
 
-export type NavigationSource = 'google_flights' | 'airline_direct';
+export type NavigationSource = 'google_flights' | 'airline_direct' | 'skyscanner' | 'kayak';
+
+export const AGGREGATOR_SOURCES = ['google_flights', 'airline_direct', 'skyscanner', 'kayak'] as const;
+
+export function isAggregatorSource(value: unknown): value is NavigationSource {
+  return typeof value === 'string' && (AGGREGATOR_SOURCES as readonly string[]).includes(value);
+}
 
 export interface NavigationResult {
   html: string;

--- a/apps/web/src/lib/scraper/navigate.ts
+++ b/apps/web/src/lib/scraper/navigate.ts
@@ -637,3 +637,150 @@ export async function navigateAirlineDirect(
     await browser.close().catch(() => {});
   }
 }
+
+// Skyscanner uses lowercase 3-letter IATA codes in the path. The site accepts
+// uppercase via redirect, but the canonical form is lowercase.
+function isoDateShort(d: Date): string {
+  const iso = isoDate(d); // YYYY-MM-DD
+  return iso.slice(2, 4) + iso.slice(5, 7) + iso.slice(8, 10); // YYMMDD
+}
+
+// Skyscanner cabin slugs — mapping is the same set our app uses elsewhere.
+const SKYSCANNER_CABIN: Record<string, string> = {
+  economy: 'economy',
+  premium_economy: 'premiumeconomy',
+  business: 'business',
+  first: 'first',
+};
+
+export function buildSkyscannerUrl(params: FlightSearchParams): string {
+  assertValidIataCode(params.origin, 'origin');
+  assertValidIataCode(params.destination, 'destination');
+
+  const ori = params.origin.toLowerCase();
+  const dst = params.destination.toLowerCase();
+  const oneWay = params.tripType === 'one_way';
+  const datePath = oneWay
+    ? `${isoDateShort(params.dateFrom)}/`
+    : `${isoDateShort(params.dateFrom)}/${isoDateShort(params.dateTo)}/`;
+
+  const cabin = SKYSCANNER_CABIN[params.cabinClass ?? 'economy'] ?? 'economy';
+  const qs = new URLSearchParams();
+  qs.set('adultsv2', '1');
+  qs.set('cabinclass', cabin);
+  if (params.currency) qs.set('currency', params.currency);
+  if (params.country) qs.set('market', params.country);
+
+  return `https://www.skyscanner.com/transport/flights/${ori}/${dst}/${datePath}?${qs.toString()}`;
+}
+
+export function buildKayakUrl(params: FlightSearchParams): string {
+  assertValidIataCode(params.origin, 'origin');
+  assertValidIataCode(params.destination, 'destination');
+
+  const ori = params.origin;
+  const dst = params.destination;
+  const oneWay = params.tripType === 'one_way';
+  const datePath = oneWay
+    ? isoDate(params.dateFrom)
+    : `${isoDate(params.dateFrom)}/${isoDate(params.dateTo)}`;
+
+  return `https://www.kayak.com/flights/${ori}-${dst}/${datePath}?sort=price_a`;
+}
+
+/**
+ * Shared navigation helper for Skyscanner and Kayak. Both deploy aggressive
+ * anti-bot (Cloudflare, PerimeterX) so reliability is best-effort, not
+ * production grade. The 45s goto timeout matches navigateAirlineDirect because
+ * Cloudflare interstitials regularly take 20-40s to clear.
+ *
+ * Caller passes a stable `source` label and a `tag` for log lines. Returns the
+ * standard NavigationResult; resultsFound is gated by hasFlightPriceSignal so a
+ * blocked or interstitial page returns resultsFound=false and the caller can
+ * walk to the next aggregator in the chain.
+ */
+async function navigateAggregatorPage(
+  url: string,
+  source: NavigationSource,
+  tag: string,
+  countryProfile?: CountryProfile,
+  proxyUrl?: string,
+): Promise<NavigationResult> {
+  const browser = await launchBrowser({ proxyUrl });
+  const start = Date.now();
+
+  try {
+    const context = await createStealthContext(browser, { countryProfile, proxyUrl });
+    const page = await context.newPage();
+    console.log(`[navigate:${tag}] → ${url}`);
+
+    const gotoStart = Date.now();
+    await page.goto(url, { waitUntil: 'load', timeout: 45_000 });
+    console.log(`[navigate:${tag}] goto resolved in ${Date.now() - gotoStart}ms`);
+
+    // Heavier post-goto wait than airline_direct — Cloudflare interstitials on
+    // Skyscanner and Kayak commonly delay real content by 4-8 seconds.
+    await randomDelay(4000, 8000);
+    await simulateHumanBehavior(page);
+
+    try {
+      for (const label of ['Accept all', 'I agree', 'OK, got it', 'Got it', 'Allow all', 'Accept cookies']) {
+        const btn = page.locator(`button:has-text("${label}")`).first();
+        if (await btn.isVisible({ timeout: 1000 })) {
+          await btn.click();
+          await randomDelay(1500, 3000);
+          break;
+        }
+      }
+    } catch {
+      // No consent dialog visible.
+    }
+
+    let resultsFound = false;
+    try {
+      await page.waitForFunction(
+        (p: { mention: string; token: string; min: number }) => {
+          const text = document.body?.innerText ?? '';
+          const mentions = (text.match(new RegExp(p.mention, 'g')) || []).length;
+          if (mentions < p.min) return false;
+          return new RegExp(p.token).test(text);
+        },
+        { mention: CURRENCY_MENTION_PATTERN, token: PRICE_TOKEN_PATTERN, min: MIN_CURRENCY_MENTIONS },
+        { timeout: 15_000 },
+      );
+      resultsFound = true;
+    } catch {
+      // No price signal — most likely Cloudflare challenge, PerimeterX, or empty results.
+    }
+
+    const html = await page.evaluate(() => document.body.innerText);
+    console.log(`[navigate:${tag}] resultsFound=${resultsFound}, textLength=${html.length}, elapsed=${Date.now() - start}ms`);
+
+    await context.close();
+    return { html, url, resultsFound, source };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[navigate:${tag}] failed (elapsed=${Date.now() - start}ms): ${message}`);
+    throw error;
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+export async function navigateSkyscanner(
+  params: FlightSearchParams,
+  countryProfile?: CountryProfile,
+  proxyUrl?: string,
+): Promise<NavigationResult> {
+  const url = buildSkyscannerUrl(params);
+  return navigateAggregatorPage(url, 'skyscanner', 'skyscanner', countryProfile, proxyUrl);
+}
+
+export async function navigateKayak(
+  params: FlightSearchParams,
+  countryProfile?: CountryProfile,
+  proxyUrl?: string,
+): Promise<NavigationResult> {
+  const url = buildKayakUrl(params);
+  return navigateAggregatorPage(url, 'kayak', 'kayak', countryProfile, proxyUrl);
+}

--- a/apps/web/src/lib/scraper/run-scrape.test.ts
+++ b/apps/web/src/lib/scraper/run-scrape.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
-const { mockPrisma, mockNavigateGoogleFlights, mockNavigateAirlineDirect, mockExtractPrices, mockIsKnownAirline } = vi.hoisted(() => {
+const { mockPrisma, mockNavigateGoogleFlights, mockNavigateAirlineDirect, mockNavigateSkyscanner, mockNavigateKayak, mockExtractPrices, mockIsKnownAirline } = vi.hoisted(() => {
   const mockPrisma = {
     query: { findUnique: vi.fn() },
     fetchRun: { create: vi.fn(), update: vi.fn() },
@@ -12,9 +12,11 @@ const { mockPrisma, mockNavigateGoogleFlights, mockNavigateAirlineDirect, mockEx
   };
   const mockNavigateGoogleFlights = vi.fn();
   const mockNavigateAirlineDirect = vi.fn();
+  const mockNavigateSkyscanner = vi.fn();
+  const mockNavigateKayak = vi.fn();
   const mockExtractPrices = vi.fn();
   const mockIsKnownAirline = vi.fn();
-  return { mockPrisma, mockNavigateGoogleFlights, mockNavigateAirlineDirect, mockExtractPrices, mockIsKnownAirline };
+  return { mockPrisma, mockNavigateGoogleFlights, mockNavigateAirlineDirect, mockNavigateSkyscanner, mockNavigateKayak, mockExtractPrices, mockIsKnownAirline };
 });
 
 vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }));
@@ -22,6 +24,8 @@ vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }));
 vi.mock('./navigate', () => ({
   navigateGoogleFlights: (...args: unknown[]) => mockNavigateGoogleFlights(...args),
   navigateAirlineDirect: (...args: unknown[]) => mockNavigateAirlineDirect(...args),
+  navigateSkyscanner: (...args: unknown[]) => mockNavigateSkyscanner(...args),
+  navigateKayak: (...args: unknown[]) => mockNavigateKayak(...args),
 }));
 
 vi.mock('./extract-prices', () => ({
@@ -70,6 +74,7 @@ const BASE_QUERY = {
   tripType: 'round_trip',
   currency: null,
   preferredAirlines: [],
+  preferredAggregators: [] as string[],
   maxPrice: null,
   maxStops: null,
   maxDurationHours: null,
@@ -78,6 +83,7 @@ const BASE_QUERY = {
   lookAheadDays: 14,
   expiresAt: new Date('2027-01-01'),
   vpnCountries: [],
+  user: null as { preferredAggregators: string[] } | null,
 };
 
 describe('runScrapeForQuery', () => {
@@ -579,15 +585,18 @@ describe('runScrapeForQuery extraction failure surfacing (issue #65)', () => {
     mockPrisma.apiUsageLog.create.mockResolvedValue({});
   });
 
-  it('logs to console.error at the pair boundary when navigate throws (silent-catch fix)', async () => {
+  it('logs to console.error inside the chain walk when an aggregator throws (silent-catch fix)', async () => {
     const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockNavigateGoogleFlights.mockRejectedValue(new Error('browser crashed'));
 
     const result = await runScrapeForQuery('q1');
 
     expect(result.status).toBe('failed');
+    // After the aggregator chain refactor, individual source throws are caught
+    // inside the chain loop so the next aggregator can still be tried. The
+    // failure surfaces here, not as a bubbled pair-level throw.
     expect(consoleErr).toHaveBeenCalledWith(
-      expect.stringMatching(/pair=\S+ threw err=.*browser crashed/),
+      expect.stringMatching(/aggregator=google_flights threw err=.*browser crashed/),
     );
     consoleErr.mockRestore();
   });
@@ -666,8 +675,11 @@ describe('runScrapeForQuery extraction failure surfacing (issue #65)', () => {
     const result = await runScrapeForQuery('q1');
 
     expect(result.status).toBe('success');
+    // Chain-walk catch logs the per-aggregator throw rather than letting the
+    // pair bubble up; subsequent pairs still run because the chain returns
+    // normally with empty prices.
     expect(consoleErr).toHaveBeenCalledWith(
-      expect.stringMatching(/pair=2026-11-07 threw/),
+      expect.stringMatching(/aggregator=google_flights threw err=.*browser crashed/),
     );
     consoleErr.mockRestore();
   });
@@ -917,5 +929,290 @@ describe('PriceSnapshot schema', () => {
     expect(match).not.toBeNull();
     const model = match![0];
     expect(model).toMatch(/bookingUrl\s+String\?/);
+  });
+});
+
+import { resolveAggregatorChain } from './run-scrape';
+
+describe('resolveAggregatorChain', () => {
+  const ALL_ENABLED = ['google_flights', 'airline_direct', 'skyscanner', 'kayak'];
+  const DEFAULT_ENABLED = ['google_flights', 'airline_direct'];
+
+  it('returns google_flights only when no prefs and default admin allowlist', () => {
+    expect(resolveAggregatorChain([], [], DEFAULT_ENABLED)).toEqual(['google_flights']);
+  });
+
+  it('falls back to admin allowlist order when query and user prefs are empty', () => {
+    expect(resolveAggregatorChain([], [], ALL_ENABLED)).toEqual(['google_flights', 'skyscanner', 'kayak']);
+  });
+
+  it('uses user prefs when query prefs are empty', () => {
+    expect(resolveAggregatorChain([], ['kayak', 'google_flights'], ALL_ENABLED)).toEqual(['kayak', 'google_flights']);
+  });
+
+  it('per-query prefs override per-user prefs', () => {
+    const chain = resolveAggregatorChain(['skyscanner'], ['kayak', 'google_flights'], ALL_ENABLED);
+    expect(chain).toEqual(['skyscanner', 'google_flights']);
+  });
+
+  it('filters out aggregators not allowed by admin', () => {
+    const chain = resolveAggregatorChain(['skyscanner', 'kayak'], [], DEFAULT_ENABLED);
+    expect(chain).toEqual(['google_flights']);
+  });
+
+  it('drops airline_direct from the chain (handled separately)', () => {
+    const chain = resolveAggregatorChain(['airline_direct', 'skyscanner'], [], ALL_ENABLED);
+    expect(chain).toEqual(['skyscanner', 'google_flights']);
+  });
+
+  it('dedupes when google_flights is already in user prefs', () => {
+    const chain = resolveAggregatorChain([], ['google_flights', 'skyscanner', 'google_flights'], ALL_ENABLED);
+    expect(chain).toEqual(['google_flights', 'skyscanner']);
+  });
+
+  it('forces google_flights as terminal fallback when only kayak is requested', () => {
+    expect(resolveAggregatorChain(['kayak'], [], ALL_ENABLED)).toEqual(['kayak', 'google_flights']);
+  });
+
+  it('does NOT append google_flights when admin disabled it', () => {
+    const chain = resolveAggregatorChain(['skyscanner'], [], ['skyscanner', 'kayak']);
+    expect(chain).toEqual(['skyscanner']);
+  });
+
+  it('forces google_flights when admin misconfigured everything off', () => {
+    const chain = resolveAggregatorChain([], [], []);
+    expect(chain).toEqual(['google_flights']);
+  });
+
+  it('ignores unknown strings in any source', () => {
+    const chain = resolveAggregatorChain(['expedia', 'skyscanner'], [], ALL_ENABLED);
+    expect(chain).toEqual(['skyscanner', 'google_flights']);
+  });
+});
+
+describe('runScrapeForQuery aggregator chain walk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsKnownAirline.mockReturnValue(false);
+    mockPrisma.query.findUnique.mockResolvedValue(BASE_QUERY);
+    mockPrisma.fetchRun.create.mockResolvedValue({ id: 'run1' });
+    mockPrisma.fetchRun.update.mockResolvedValue({});
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+    });
+    mockPrisma.priceSnapshot.findMany.mockResolvedValue([]);
+    mockPrisma.priceSnapshot.createMany.mockResolvedValue({ count: 1 });
+    mockPrisma.apiUsageLog.create.mockResolvedValue({});
+  });
+
+  it('walks google_flights for a no-airline-pref query with default admin allowlist', async () => {
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html/>', url: 'https://g', resultsFound: true, source: 'google_flights',
+    });
+    mockExtractPrices.mockResolvedValue({
+      prices: [{
+        travelDate: '2026-06-15', price: 350, currency: 'USD', airline: 'Delta',
+        bookingUrl: 'https://g', stops: 0, duration: '5h',
+        departureTime: null, arrivalTime: null, seatsLeft: null,
+      }],
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('success');
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(1);
+    expect(mockNavigateSkyscanner).not.toHaveBeenCalled();
+    expect(mockNavigateKayak).not.toHaveBeenCalled();
+  });
+
+  it('falls through to skyscanner when google_flights returns empty extraction', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      user: { preferredAggregators: ['google_flights', 'skyscanner'] },
+    });
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+      aggregatorsEnabled: ['google_flights', 'skyscanner'],
+    });
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html/>', url: 'https://g', resultsFound: true, source: 'google_flights',
+    });
+    mockNavigateSkyscanner.mockResolvedValue({
+      html: '<html/>', url: 'https://s', resultsFound: true, source: 'skyscanner',
+    });
+    mockExtractPrices
+      .mockResolvedValueOnce({
+        prices: [],
+        usage: { inputTokens: 100, outputTokens: 20 },
+        failureReason: 'empty_extraction',
+      })
+      .mockResolvedValueOnce({
+        prices: [{
+          travelDate: '2026-06-15', price: 290, currency: 'USD', airline: 'JetBlue',
+          bookingUrl: 'https://s', stops: 0, duration: '5h',
+          departureTime: null, arrivalTime: null, seatsLeft: null,
+        }],
+        usage: { inputTokens: 110, outputTokens: 25 },
+      });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('success');
+    expect(result.snapshotsCount).toBe(1);
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(1);
+    expect(mockNavigateSkyscanner).toHaveBeenCalledTimes(1);
+  });
+
+  it('short-circuits the chain on all_filtered_out (does not call skyscanner)', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      user: { preferredAggregators: ['google_flights', 'skyscanner'] },
+    });
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+      aggregatorsEnabled: ['google_flights', 'skyscanner'],
+    });
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html/>', url: 'https://g', resultsFound: true, source: 'google_flights',
+    });
+    mockExtractPrices.mockResolvedValue({
+      prices: [],
+      usage: { inputTokens: 100, outputTokens: 20 },
+      failureReason: 'all_filtered_out',
+    });
+
+    await runScrapeForQuery('q1');
+
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(2); // two extract attempts
+    expect(mockNavigateSkyscanner).not.toHaveBeenCalled();
+    expect(mockNavigateKayak).not.toHaveBeenCalled();
+  });
+
+  it('admin disabled skyscanner -> user pref [skyscanner, kayak] resolves to [kayak]', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      user: { preferredAggregators: ['skyscanner', 'kayak'] },
+    });
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+      aggregatorsEnabled: ['google_flights', 'kayak'],
+    });
+    mockNavigateKayak.mockResolvedValue({
+      html: '<html/>', url: 'https://k', resultsFound: true, source: 'kayak',
+    });
+    mockExtractPrices.mockResolvedValue({
+      prices: [{
+        travelDate: '2026-06-15', price: 310, currency: 'USD', airline: 'Spirit',
+        bookingUrl: 'https://k', stops: 0, duration: '5h',
+        departureTime: null, arrivalTime: null, seatsLeft: null,
+      }],
+      usage: { inputTokens: 90, outputTokens: 20 },
+    });
+
+    const result = await runScrapeForQuery('q1');
+
+    expect(result.status).toBe('success');
+    expect(mockNavigateKayak).toHaveBeenCalledTimes(1);
+    expect(mockNavigateSkyscanner).not.toHaveBeenCalled();
+  });
+
+  it('per-query prefs override per-user prefs in the resolved chain', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      preferredAggregators: ['skyscanner'],
+      user: { preferredAggregators: ['kayak', 'google_flights'] },
+    });
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+      aggregatorsEnabled: ['google_flights', 'skyscanner', 'kayak'],
+    });
+    mockNavigateSkyscanner.mockResolvedValue({
+      html: '<html/>', url: 'https://s', resultsFound: true, source: 'skyscanner',
+    });
+    mockExtractPrices.mockResolvedValue({
+      prices: [{
+        travelDate: '2026-06-15', price: 280, currency: 'USD', airline: 'British Airways',
+        bookingUrl: 'https://s', stops: 0, duration: '5h',
+        departureTime: null, arrivalTime: null, seatsLeft: null,
+      }],
+      usage: { inputTokens: 95, outputTokens: 22 },
+    });
+
+    await runScrapeForQuery('q1');
+
+    expect(mockNavigateSkyscanner).toHaveBeenCalledTimes(1);
+    expect(mockNavigateKayak).not.toHaveBeenCalled();
+  });
+
+  it('anonymous query (user null) falls back to admin allowlist order', async () => {
+    mockPrisma.query.findUnique.mockResolvedValue({
+      ...BASE_QUERY,
+      user: null,
+    });
+    mockPrisma.extractionConfig.findFirst.mockResolvedValue({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      scrapeInterval: 3,
+      defaultCurrency: null,
+      defaultCountry: null,
+      vpnProvider: null,
+      vpnCountries: [],
+      aggregatorsEnabled: ['google_flights', 'kayak'],
+    });
+    // google_flights returns empty -> chain walks kayak
+    mockNavigateGoogleFlights.mockResolvedValue({
+      html: '<html/>', url: 'https://g', resultsFound: true, source: 'google_flights',
+    });
+    mockNavigateKayak.mockResolvedValue({
+      html: '<html/>', url: 'https://k', resultsFound: true, source: 'kayak',
+    });
+    mockExtractPrices
+      .mockResolvedValueOnce({
+        prices: [], usage: { inputTokens: 80, outputTokens: 10 }, failureReason: 'empty_extraction',
+      })
+      .mockResolvedValueOnce({
+        prices: [{
+          travelDate: '2026-06-15', price: 415, currency: 'USD', airline: 'Frontier',
+          bookingUrl: 'https://k', stops: 0, duration: '5h',
+          departureTime: null, arrivalTime: null, seatsLeft: null,
+        }],
+        usage: { inputTokens: 100, outputTokens: 18 },
+      });
+
+    const result = await runScrapeForQuery('q1');
+    expect(result.status).toBe('success');
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(1);
+    expect(mockNavigateKayak).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -1,6 +1,13 @@
 import { mkdir, writeFile } from 'fs/promises';
 import { prisma } from '@/lib/prisma';
-import { navigateGoogleFlights, navigateAirlineDirect, type NavigationResult } from './navigate';
+import {
+  navigateGoogleFlights,
+  navigateAirlineDirect,
+  navigateSkyscanner,
+  navigateKayak,
+  type NavigationResult,
+  type NavigationSource,
+} from './navigate';
 import { extractPrices, type ExtractionFailureReason } from './extract-prices';
 import { getModelCosts } from './ai-registry';
 import { isKnownAirline } from './airline-urls';
@@ -15,9 +22,68 @@ const RETRYABLE_FAILURES: ExtractionFailureReason[] = [
   'llm_error',
   'json_parse_error',
 ];
+// Diversifiable failures move on to the next aggregator in the chain. The
+// existing issue-65 invariant: all_filtered_out is NOT diversifiable (real
+// flights existed; user filters excluded them) and json_parse_error is
+// retryable but not diversifiable (same LLM is likely to error on the next
+// source too).
+const DIVERSIFIABLE_FAILURES: ExtractionFailureReason[] = [
+  'empty_extraction',
+  'no_json_in_response',
+  'page_not_loaded',
+  'llm_error',
+];
 const MAX_EXTRACT_ATTEMPTS = 2;
 const DEBUG_DIR = '/tmp/fairtrail-debug';
 const VPN_INTER_COUNTRY_DELAY_MS = 12000;
+const DEFAULT_AGGREGATORS_ENABLED: NavigationSource[] = ['google_flights', 'airline_direct'];
+
+/**
+ * Resolve the ordered aggregator fallback chain for a single query.
+ *
+ * Precedence: per-query override > per-user preference > admin allowlist
+ * order. The chain always excludes 'airline_direct' (handled separately
+ * before the chain walk) and is filtered against the admin allowlist so a
+ * disabled aggregator is never invoked regardless of user preference. The
+ * terminal element is always 'google_flights' when admin allows it, with a
+ * final safety net forcing google_flights even if the admin misconfigured
+ * everything away.
+ */
+export function resolveAggregatorChain(
+  queryPrefs: readonly string[],
+  userPrefs: readonly string[],
+  adminEnabled: readonly string[],
+): NavigationSource[] {
+  const enabled = adminEnabled.length > 0 ? adminEnabled : DEFAULT_AGGREGATORS_ENABLED;
+  const requested: readonly string[] =
+    queryPrefs.length > 0 ? queryPrefs :
+    userPrefs.length > 0 ? userPrefs :
+    enabled;
+
+  const chain = requested
+    .filter((s): s is NavigationSource =>
+      s === 'google_flights' || s === 'skyscanner' || s === 'kayak'
+    )
+    .filter((s) => enabled.includes(s));
+
+  // Dedupe while preserving order
+  const seen = new Set<NavigationSource>();
+  const deduped: NavigationSource[] = [];
+  for (const s of chain) {
+    if (!seen.has(s)) {
+      seen.add(s);
+      deduped.push(s);
+    }
+  }
+
+  if (!deduped.includes('google_flights') && enabled.includes('google_flights')) {
+    deduped.push('google_flights');
+  }
+  if (deduped.length === 0) {
+    deduped.push('google_flights');
+  }
+  return deduped;
+}
 
 async function saveDebugHtml(queryId: string, html: string, attempt: number): Promise<void> {
   try {
@@ -47,13 +113,33 @@ interface PairScrapeResult {
   lastFailureReason: string | undefined;
 }
 
-/** Scrape a single (outbound, return) date pair, with extract retries. */
+/**
+ * Scrape a single (outbound, return) date pair, with extract retries.
+ *
+ * Flow per attempt:
+ *   1. If `useAirlineDirect`, fan out across `directAirlines` in parallel. Any
+ *      airline page that passes the price-signal gate yields a NavigationResult
+ *      we extract from. Failures here surface a `lastFailureReason`.
+ *   2. If step 1 produced no prices AND the failure reason is diversifiable
+ *      (or step 1 was skipped entirely), walk the `aggregatorChain` in order
+ *      (google_flights / skyscanner / kayak). Stop the walk as soon as prices
+ *      land or `all_filtered_out` is seen (filters, not the source, are the
+ *      cause — moving on cannot help).
+ *   3. If still no prices and the failure is retryable, sleep + retry the
+ *      whole attempt.
+ *
+ * Preserves the issue-65 invariant: an airline page that returns stub HTML
+ * (passes hasFlightPriceSignal but extracts to 0 flights) falls through to
+ * google_flights inside the same attempt rather than retrying the same broken
+ * page.
+ */
 async function scrapeOneDatePair(
   queryId: string,
   pairParams: import('./navigate').FlightSearchParams,
   filters: import('./extract-prices').QueryFilters,
   directAirlines: string[],
   useAirlineDirect: boolean,
+  aggregatorChain: NavigationSource[],
   countryProfile: ReturnType<typeof getCountryProfile> | undefined,
   proxyUrl: string | undefined,
   vpnCountry: string | null,
@@ -66,86 +152,88 @@ async function scrapeOneDatePair(
   let inputTokens = 0;
   let outputTokens = 0;
   let lastFailureReason: string | undefined;
-  // Hoisted so the diversification block (issue 65) can flip airline-direct off
-  // for the retry: once we know a route returns a stub on the airline site, the
-  // attempt-2 retry must skip the broken Playwright launch and go straight to
-  // Google Flights.
-  let attemptUseAirlineDirect = useAirlineDirect;
 
-  async function navigateAll(): Promise<NavigationResult[]> {
-    if (attemptUseAirlineDirect) {
-      const results = await Promise.all(
-        directAirlines.map(async (airline) => {
-          try {
-            const result = await navigateAirlineDirect(pairParams, airline, countryProfile, proxyUrl);
-            if (!result.resultsFound) return null;
-            return result;
-          } catch {
-            return null;
-          }
-        })
-      );
-      const valid = results.filter((r): r is NavigationResult => r !== null);
-      if (valid.length === 0) {
-        return [await navigateGoogleFlights(pairParams, countryProfile, proxyUrl)];
-      }
-      return valid;
+  async function extractFromNav(nav: NavigationResult, attempt: number): Promise<void> {
+    sources.add(nav.source);
+    const result = await extractPrices(
+      nav.html, nav.url, travelDateFallback, filters, undefined, nav.resultsFound, nav.source, effectiveCurrency,
+    );
+    prices = prices.concat(result.prices);
+    inputTokens += result.usage.inputTokens;
+    outputTokens += result.usage.outputTokens;
+    if (result.failureReason) {
+      lastFailureReason = result.failureReason;
+      await saveDebugHtml(queryId, nav.html, attempt);
+    } else {
+      lastFailureReason = undefined;
     }
-    return [await navigateGoogleFlights(pairParams, countryProfile, proxyUrl)];
   }
 
   for (let attempt = 1; attempt <= MAX_EXTRACT_ATTEMPTS; attempt++) {
     const vpnLabel = vpnCountry ? ` vpn=${vpnCountry}` : '';
     console.log(`[scrape] query=${queryId}${vpnLabel} pair=${travelDateFallback} extract attempt ${attempt}/${MAX_EXTRACT_ATTEMPTS}`);
 
-    const navResults = await navigateAll();
-
-    for (const nav of navResults) {
-      sources.add(nav.source);
-      const result = await extractPrices(
-        nav.html, nav.url, travelDateFallback, filters, undefined, nav.resultsFound, nav.source, effectiveCurrency,
+    // Step 1 — airline_direct fan-out (when applicable).
+    let triedAirlineDirect = false;
+    if (useAirlineDirect) {
+      triedAirlineDirect = true;
+      const results = await Promise.all(
+        directAirlines.map(async (airline) => {
+          try {
+            const result = await navigateAirlineDirect(pairParams, airline, countryProfile, proxyUrl);
+            return result.resultsFound ? result : null;
+          } catch {
+            return null;
+          }
+        })
       );
-      prices = prices.concat(result.prices);
-      inputTokens += result.usage.inputTokens;
-      outputTokens += result.usage.outputTokens;
-      if (result.failureReason) {
-        lastFailureReason = result.failureReason;
-        await saveDebugHtml(queryId, nav.html, attempt);
+      const valid = results.filter((r): r is NavigationResult => r !== null);
+      for (const nav of valid) {
+        await extractFromNav(nav, attempt);
       }
     }
 
-    // Issue 65: when airline-direct navigation succeeds (stub page passes
-    // hasFlightPriceSignal) but extraction yields zero prices, fall back to
-    // Google Flights in the same attempt rather than retrying the same broken
-    // airline page. all_filtered_out is not diversifiable: that means real
-    // flights existed and the user filters excluded them.
-    const usedAirlineDirect = navResults.some((n) => n.source === 'airline_direct');
-    const usedGoogleFlights = navResults.some((n) => n.source === 'google_flights');
-    const diversifiableReasons: ExtractionFailureReason[] = ['empty_extraction', 'no_json_in_response', 'page_not_loaded', 'llm_error'];
-    const shouldDiversify =
-      usedAirlineDirect && !usedGoogleFlights && prices.length === 0 &&
-      lastFailureReason !== undefined &&
-      diversifiableReasons.includes(lastFailureReason as ExtractionFailureReason);
-    if (shouldDiversify) {
-      console.log(`[scrape] query=${queryId} pair=${travelDateFallback} diversifying airline_direct -> google_flights (reason: ${lastFailureReason})`);
-      try {
-        const gNav = await navigateGoogleFlights(pairParams, countryProfile, proxyUrl);
-        sources.add(gNav.source);
-        const gResult = await extractPrices(
-          gNav.html, gNav.url, travelDateFallback, filters, undefined, gNav.resultsFound, gNav.source, effectiveCurrency,
-        );
-        prices = prices.concat(gResult.prices);
-        inputTokens += gResult.usage.inputTokens;
-        outputTokens += gResult.usage.outputTokens;
-        if (gResult.failureReason) {
-          lastFailureReason = gResult.failureReason;
-          await saveDebugHtml(queryId, gNav.html, attempt);
-        } else {
-          lastFailureReason = undefined;
+    // Step 2 — walk the aggregator chain when step 1 produced nothing AND the
+    // failure is diversifiable (or step 1 was skipped). all_filtered_out
+    // short-circuits the entire chain — same invariant as the pre-refactor
+    // diversification block: real flights existed, filters excluded them, so
+    // changing sources cannot help.
+    const shouldWalkChain =
+      prices.length === 0 &&
+      (
+        !triedAirlineDirect ||
+        lastFailureReason === undefined ||
+        DIVERSIFIABLE_FAILURES.includes(lastFailureReason as ExtractionFailureReason)
+      );
+
+    if (shouldWalkChain) {
+      if (triedAirlineDirect) {
+        console.log(`[scrape] query=${queryId} pair=${travelDateFallback} diversifying airline_direct -> chain=${aggregatorChain.join(',')} (reason: ${lastFailureReason ?? 'no-extraction'})`);
+      }
+      for (const source of aggregatorChain) {
+        if (prices.length > 0) break;
+        let nav: NavigationResult;
+        try {
+          switch (source) {
+            case 'google_flights':
+              nav = await navigateGoogleFlights(pairParams, countryProfile, proxyUrl);
+              break;
+            case 'skyscanner':
+              nav = await navigateSkyscanner(pairParams, countryProfile, proxyUrl);
+              break;
+            case 'kayak':
+              nav = await navigateKayak(pairParams, countryProfile, proxyUrl);
+              break;
+            default:
+              continue;
+          }
+        } catch (err) {
+          console.error(`[scrape] query=${queryId} pair=${travelDateFallback} aggregator=${source} threw err=${err instanceof Error ? err.message : err}`);
+          continue;
         }
-        attemptUseAirlineDirect = false;
-      } catch (err) {
-        console.error(`[scrape] query=${queryId} pair=${travelDateFallback} google_flights diversification threw err=${err instanceof Error ? err.message : err}`);
+        await extractFromNav(nav, attempt);
+        // all_filtered_out short-circuits — real flights existed, filters excluded them
+        if (lastFailureReason === 'all_filtered_out') break;
       }
     }
 
@@ -164,9 +252,21 @@ async function scrapeOneDatePair(
 /** Scrape a single query for a single country pass (local or VPN). */
 async function scrapeQueryForCountry(
   queryId: string,
-  query: { origin: string; destination: string; preferredAirlines: string[]; maxPrice: number | null; maxStops: number | null; maxDurationHours: number | null; timePreference: string; cabinClass: string; flexibility: number },
+  query: {
+    origin: string;
+    destination: string;
+    preferredAirlines: string[];
+    preferredAggregators: string[];
+    maxPrice: number | null;
+    maxStops: number | null;
+    maxDurationHours: number | null;
+    timePreference: string;
+    cabinClass: string;
+    flexibility: number;
+    user: { preferredAggregators: string[] } | null;
+  },
   searchParams: import('./navigate').FlightSearchParams,
-  config: { provider?: string; model?: string } | null,
+  config: { provider?: string; model?: string; aggregatorsEnabled?: string[] } | null,
   vpnCountry: string | null,
   proxyUrl: string | undefined,
   fetchRunId: string,
@@ -175,6 +275,14 @@ async function scrapeQueryForCountry(
 
   const directAirlines = query.preferredAirlines.filter(isKnownAirline);
   const useAirlineDirect = directAirlines.length > 0;
+
+  const adminEnabled = config?.aggregatorsEnabled ?? DEFAULT_AGGREGATORS_ENABLED;
+  const aggregatorChain = resolveAggregatorChain(
+    query.preferredAggregators ?? [],
+    query.user?.preferredAggregators ?? [],
+    adminEnabled,
+  );
+  console.log(`[scrape] query=${queryId} aggregator chain=${aggregatorChain.join(',')} (admin enabled=${adminEnabled.join(',')})`);
 
   const filters = {
     maxPrice: query.maxPrice,
@@ -224,7 +332,7 @@ async function scrapeQueryForCountry(
     let pairResult: PairScrapeResult;
     try {
       pairResult = await scrapeOneDatePair(
-        queryId, pairParams, filters, directAirlines, useAirlineDirect, countryProfile, proxyUrl, vpnCountry,
+        queryId, pairParams, filters, directAirlines, useAirlineDirect, aggregatorChain, countryProfile, proxyUrl, vpnCountry,
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -410,7 +518,10 @@ export async function runScrapeForQuery(
   proxyUrl?: string,
   opts?: { fetchRunId?: string },
 ): Promise<ScrapeResult> {
-  const query = await prisma.query.findUnique({ where: { id: queryId } });
+  const query = await prisma.query.findUnique({
+    where: { id: queryId },
+    include: { user: { select: { preferredAggregators: true } } },
+  });
   if (!query || !query.active) {
     const errorMsg = 'Query not found or inactive';
     // If the caller pre-created an in_progress row, finalize it here so

--- a/apps/web/src/lib/scraper/settings-parity.test.ts
+++ b/apps/web/src/lib/scraper/settings-parity.test.ts
@@ -70,10 +70,11 @@ describe('settings page parity with admin config', () => {
     const adminFields = extractConfigFields(ADMIN_CONFIG_PAGE);
 
     // Settings page is a subset of admin (admin has extra fields like
-    // hasAdminPassword and the ops-only LLM extract timeout). Core data
-    // fields must exist in both.
+    // hasAdminPassword, the ops-only LLM extract timeout, and the
+    // aggregator allowlist that only an admin should configure). Core
+    // data fields must exist in both.
     const coreFields = adminFields.filter(
-      (f) => !['hasAdminPassword', 'extractTimeoutSeconds'].includes(f)
+      (f) => !['hasAdminPassword', 'extractTimeoutSeconds', 'aggregatorsEnabled'].includes(f)
     );
 
     for (const field of coreFields) {
@@ -89,10 +90,10 @@ describe('settings page parity with admin config', () => {
     const adminSaveFields = extractSaveBodyFields(ADMIN_CONFIG_PAGE);
 
     // Admin page may send additional fields (adminPassword, the LLM
-    // extract timeout) that settings doesn't surface. All other extraction
-    // related fields should be in both.
+    // extract timeout, the aggregator allowlist) that settings doesn't
+    // surface. All other extraction-related fields should be in both.
     const extractionFields = adminSaveFields.filter(
-      (f) => !['adminPassword', 'extractTimeoutSeconds'].includes(f)
+      (f) => !['adminPassword', 'extractTimeoutSeconds', 'aggregatorsEnabled'].includes(f)
     );
 
     for (const field of extractionFields) {


### PR DESCRIPTION
Addresses #89.

Adds Skyscanner and Kayak as opt-in fallback aggregators alongside `google_flights` and `airline_direct`. Per-query overrides per-user overrides admin allowlist. Off by default — admin enables in `/admin/config`, users order in `/account/settings`.

## What's in here

**Scraper**
- `navigateSkyscanner` / `navigateKayak`: same `NavigationResult` shape as `navigateAirlineDirect`, 45s goto, Cloudflare/PerimeterX-friendly consent dismissal, gated by `hasFlightPriceSignal`.
- `scrapeOneDatePair` now drives an ordered chain at the top of the attempt loop instead of only inside the airline_direct diversification branch. Skyscanner/Kayak are reachable for every query, not just airline-direct ones (the bug the plan critique caught on the prior shape).
- Issue #65 invariants preserved: `all_filtered_out` short-circuits the chain; per-aggregator throws are caught so the next source runs; airline_direct stub pages still divert mid-attempt.

**Schema** (auto-applied via `prisma db push`):
- `User.preferredAggregators`, `Query.preferredAggregators`, `ExtractionConfig.aggregatorsEnabled`.
- `FetchRun.source` comment widened.

**UI**
- `SettingsForm` aggregator section: ordered checklist, ↑/↓ buttons, `experimental` tag on Skyscanner/Kayak, dimmed when admin hasn't enabled.
- Admin config gains an "Aggregator Sources" section with the four checkboxes + disclaimer.
- `adminEnabledAggregators` is read server-side in the account settings Server Component to avoid exposing the admin-only `/api/admin/config` GET to non-admin users.

**API**
- `/api/account/settings` GET returns the new field; PATCH validates with 422.
- `/api/queries` POST and `/api/queries/[id]` PATCH accept `preferredAggregators` with single-id scope (NOT cascaded across the group — different siblings can sit on different aggregators).
- `/api/admin/queries/[id]` PATCH has parity.
- `/api/admin/config` PATCH validates `aggregatorsEnabled` with 422.

**Manual scrape summary log** (the small QoL ask in #89): the background IIFE now emits `[scrape] manual run complete (group=<id>): N successes, M failures` so the terminal stops going silent on completion.

## Reliability

Skyscanner and Kayak both deploy aggressive anti-bot (Cloudflare, PerimeterX). Expected v1 reliability: 40–70% in burst, dropping under sustained load. Stable production scraping for these sites typically needs residential proxies or paid CAPTCHA solving, neither of which are in scope. Users who hit consistent failures should leave them off.

## Test plan

- [x] `npm run ci` (745 tests, 0 failures)
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` produces all routes including the new validation paths
- [x] Manual API round-trip: PATCH `/api/account/settings` with `preferredAggregators: ['skyscanner','google_flights','kayak']` → GET returns the same array; `['expedia']` returns 422; `[]` clears
- [x] Manual UI: account settings shows the ordered checklist with experimental tags; admin config shows the four checkboxes; dimming works when admin disables Skyscanner/Kayak
- [ ] Pre-release smoke gate (`docker-smoke-test.sh`, `install-flow-test.sh`, `cli-runtime-test.sh`) before tagging v0.8.0

