### PR TITLE
feat: per-tracker aggregator override + custom tracker label (#89)

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Query {
   expiresAt       DateTime
   firstViewedAt   DateTime?
   vpnCountries    String[] @default([]) // ISO 3166-1 codes for VPN comparison
+  label           String?
   scrapeInterval  Int?     // hours, null = follow extractionConfig.scrapeInterval (global)
   userId          String?  // owner when self-hosted multi-user is enabled; null = anonymous or seed
   createdAt       DateTime @default(now())

--- a/apps/web/src/app/account/settings/SettingsForm.tsx
+++ b/apps/web/src/app/account/settings/SettingsForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { ALL_AGGREGATORS, AGGREGATOR_LABEL, EXPERIMENTAL_AGGREGATORS, type Aggregator } from '@/lib/aggregators';
 import styles from './page.module.css';
 
 interface Preferences {
@@ -14,21 +15,6 @@ interface Preferences {
 }
 
 const CABIN_CLASSES = ['economy', 'premium_economy', 'business', 'first'] as const;
-
-// All four aggregators, in the visual order shown when the user has no
-// explicit preference. Skyscanner and Kayak are flagged experimental at the
-// component level so users know what they're enabling.
-const ALL_AGGREGATORS = ['google_flights', 'airline_direct', 'skyscanner', 'kayak'] as const;
-type Aggregator = (typeof ALL_AGGREGATORS)[number];
-
-const AGGREGATOR_LABEL: Record<Aggregator, string> = {
-  google_flights: 'Google Flights',
-  airline_direct: 'Airline direct',
-  skyscanner: 'Skyscanner',
-  kayak: 'Kayak',
-};
-
-const EXPERIMENTAL_AGGREGATORS = new Set<Aggregator>(['skyscanner', 'kayak']);
 
 // Build the initial render order: the user's saved order first, then any
 // aggregators they have not explicitly placed (in the canonical order).

--- a/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
+++ b/apps/web/src/app/admin/(dashboard)/queries/QueryRow.tsx
@@ -5,12 +5,15 @@ import { type QueryGroup, type GroupableQuery } from '@/lib/query-grouping';
 import { aggregateScrapeStatus } from '@/lib/scrape-status';
 import { ScrapeStatusDot } from '@/components/ScrapeStatusDot';
 import { ForceScrapeButton } from '@/components/ForceScrapeButton';
+import { AGGREGATOR_LABEL, type Aggregator } from '@/lib/aggregators';
 import styles from './page.module.css';
 
 export interface AdminQuery extends GroupableQuery {
   active: boolean;
   expiresAt: string;
   scrapeInterval: number | null;
+  label: string | null;
+  preferredAggregators: string[];
   snapshotCount: number;
   runCount: number;
   scrapeStatus: string | null;
@@ -26,6 +29,9 @@ export function QueryGroupRow({ group }: { group: QueryGroup<AdminQuery> }) {
   const expired = group.allExpired;
   const runCount = group.queries.reduce((sum, q) => sum + q.runCount, 0);
   const extraDestinations = group.destinations.length - 1;
+  const primaryQuery = group.queries.find((q) => q.id === group.primaryId);
+  const primaryLabel = primaryQuery?.label;
+  const primaryAggregators = primaryQuery?.preferredAggregators ?? [];
   const aggregate = aggregateScrapeStatus(
     group.queries.map((q) => ({
       status: q.scrapeStatus,
@@ -76,6 +82,14 @@ export function QueryGroupRow({ group }: { group: QueryGroup<AdminQuery> }) {
         )}
         {group.routeCount > 1 && (
           <span className={styles.rowGroupTag}>{group.routeCount} charts</span>
+        )}
+        {primaryLabel && (
+          <span className={styles.rowGroupTag}>{primaryLabel}</span>
+        )}
+        {primaryAggregators.length > 0 && (
+          <span className={styles.rowGroupTag}>
+            {primaryAggregators.map((a) => AGGREGATOR_LABEL[a as Aggregator] ?? a).join(', ')}
+          </span>
         )}
       </div>
       <div className={styles.rowMeta}>

--- a/apps/web/src/app/admin/(dashboard)/queries/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/queries/page.tsx
@@ -30,6 +30,8 @@ export default async function QueriesPage() {
     active: q.active,
     expiresAt: q.expiresAt.toISOString(),
     scrapeInterval: q.scrapeInterval,
+    label: q.label,
+    preferredAggregators: q.preferredAggregators,
     snapshotCount: q._count.snapshots,
     runCount: q._count.fetchRuns,
     createdAt: q.createdAt.toISOString(),

--- a/apps/web/src/app/api/admin/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/admin/queries/[id]/route.test.ts
@@ -94,6 +94,24 @@ describe('admin PATCH /api/admin/queries/[id]', () => {
     expect(mockQueryUpdateMany).not.toHaveBeenCalled();
   });
 
+  it('updates label as single-row (no cascade)', async () => {
+    mockQueryFindUnique.mockResolvedValue({ groupId: 'g1' });
+    const res = await PATCH(...patchRequest('q1', { label: 'My tracker' }));
+    expect(res.status).toBe(200);
+    expect(mockQueryUpdate).toHaveBeenCalledWith({
+      where: { id: 'q1' },
+      data: { label: 'My tracker' },
+    });
+    expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects label longer than 60 characters', async () => {
+    mockQueryFindUnique.mockResolvedValue({ groupId: null });
+    const res = await PATCH(...patchRequest('q1', { label: 'x'.repeat(61) }));
+    expect(res.status).toBe(400);
+    expect(mockQueryUpdate).not.toHaveBeenCalled();
+  });
+
   it('keeps userId reassignment single-row even on a grouped query', async () => {
     mockQueryFindUnique.mockResolvedValue({ groupId: 'g1' });
     mockUserFindUnique.mockResolvedValue({ id: 'user_42' });

--- a/apps/web/src/app/api/admin/queries/[id]/route.ts
+++ b/apps/web/src/app/api/admin/queries/[id]/route.ts
@@ -44,6 +44,20 @@ export async function PATCH(
     data.userId = body.userId;
   }
 
+  if (Object.prototype.hasOwnProperty.call(body, 'label')) {
+    if (body.label === null) {
+      data.label = null;
+    } else if (typeof body.label === 'string') {
+      const trimmed = body.label.trim();
+      if (trimmed.length > 60) {
+        return apiError('label must be 60 characters or fewer', 400);
+      }
+      data.label = trimmed || null;
+    } else {
+      return apiError('label must be a string or null', 400);
+    }
+  }
+
   if (Array.isArray(body.preferredAggregators)) {
     for (const a of body.preferredAggregators) {
       if (!isAggregatorSource(a)) {

--- a/apps/web/src/app/api/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/route.test.ts
@@ -386,6 +386,64 @@ describe('PATCH /api/queries/[id]', () => {
     });
   });
 
+  describe('label', () => {
+    beforeEach(() => {
+      mockQueryUpdate.mockResolvedValue({});
+    });
+
+    it('updates label on the single id only (no group cascade)', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: 'g1', userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { label: 'Paris via Google' }));
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.data).toMatchObject({ label: 'Paris via Google' });
+      expect(mockQueryUpdate).toHaveBeenCalledWith({
+        where: { id: 'q1' },
+        data: { label: 'Paris via Google' },
+      });
+      expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it('clears label when set to null', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { label: null }));
+      expect(res.status).toBe(200);
+      expect(mockQueryUpdate).toHaveBeenCalledWith({
+        where: { id: 'q1' },
+        data: { label: null },
+      });
+    });
+
+    it('rejects label longer than 60 characters', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { label: 'a'.repeat(61) }));
+      expect(res.status).toBe(400);
+      expect(mockQueryUpdate).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-string non-null label', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { label: 123 }));
+      expect(res.status).toBe(400);
+      expect(mockQueryUpdate).not.toHaveBeenCalled();
+    });
+
+    it('trims whitespace and stores null for empty string', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue({ deleteToken: null, groupId: null, userId: null });
+      const res = await PATCH(...makePatchRequest('q1', { label: '   ' }));
+      expect(res.status).toBe(200);
+      expect(mockQueryUpdate).toHaveBeenCalledWith({
+        where: { id: 'q1' },
+        data: { label: null },
+      });
+    });
+  });
+
   describe('preferredAggregators', () => {
     beforeEach(() => {
       mockQueryUpdate.mockResolvedValue({});

--- a/apps/web/src/app/api/queries/[id]/route.ts
+++ b/apps/web/src/app/api/queries/[id]/route.ts
@@ -30,7 +30,7 @@ export async function PATCH(
   // Per-row fields: applied only to the single id. preferredAggregators is
   // intentionally NOT cascaded — different siblings in a flex group can sit on
   // different aggregators (e.g. one experimental, one default).
-  const singleRowData: { preferredAggregators?: string[] } = {};
+  const singleRowData: { preferredAggregators?: string[]; label?: string | null } = {};
 
   if (body && Object.prototype.hasOwnProperty.call(body, 'scrapeInterval')) {
     let interval: number | null;
@@ -50,6 +50,20 @@ export async function PATCH(
       return apiError('active must be a boolean', 400);
     }
     cascadeData.active = body.active;
+  }
+
+  if (body && Object.prototype.hasOwnProperty.call(body, 'label')) {
+    if (body.label === null) {
+      singleRowData.label = null;
+    } else if (typeof body.label === 'string') {
+      const trimmed = body.label.trim();
+      if (trimmed.length > 60) {
+        return apiError('label must be 60 characters or fewer', 400);
+      }
+      singleRowData.label = trimmed || null;
+    } else {
+      return apiError('label must be a string or null', 400);
+    }
   }
 
   if (body && Object.prototype.hasOwnProperty.call(body, 'preferredAggregators')) {

--- a/apps/web/src/app/api/queries/active/route.test.ts
+++ b/apps/web/src/app/api/queries/active/route.test.ts
@@ -26,6 +26,8 @@ function shapedRow(overrides: Record<string, unknown> = {}) {
     createdAt: new Date('2026-05-01T00:00:00Z'),
     expiresAt: new Date('2026-08-01T00:00:00Z'),
     groupId: null,
+    label: null,
+    preferredAggregators: [],
     fetchRuns: [],
     _count: { snapshots: 0 },
     ...overrides,

--- a/apps/web/src/app/api/queries/active/route.ts
+++ b/apps/web/src/app/api/queries/active/route.ts
@@ -42,6 +42,8 @@ export async function GET() {
       createdAt: true,
       expiresAt: true,
       groupId: true,
+      label: true,
+      preferredAggregators: true,
       fetchRuns: {
         orderBy: { startedAt: 'desc' },
         take: 1,
@@ -68,6 +70,8 @@ export async function GET() {
     lastScrapeStatus: q.fetchRuns[0]?.status ?? null,
     lastScrapeError: q.fetchRuns[0]?.error ?? null,
     groupId: q.groupId,
+    label: q.label,
+    preferredAggregators: q.preferredAggregators,
     createdAt: q.createdAt.toISOString(),
   }));
 

--- a/apps/web/src/app/api/queries/route.test.ts
+++ b/apps/web/src/app/api/queries/route.test.ts
@@ -280,4 +280,24 @@ describe('POST /api/queries', () => {
     const createCall = mockQueryCreate.mock.calls[0]![0] as { data: { userId: string | null } };
     expect(createCall.data.userId).toBeNull();
   });
+
+  it('stores label when provided', async () => {
+    const res = await POST(makeRequest({ ...validBody, label: 'Paris via Google' }));
+    expect(res.status).toBe(201);
+    const createCall = mockQueryCreate.mock.calls[0]![0] as { data: { label: string | null } };
+    expect(createCall.data.label).toBe('Paris via Google');
+  });
+
+  it('stores label as null when omitted', async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(201);
+    const createCall = mockQueryCreate.mock.calls[0]![0] as { data: { label: string | null } };
+    expect(createCall.data.label).toBeNull();
+  });
+
+  it('rejects label longer than 60 characters', async () => {
+    const res = await POST(makeRequest({ ...validBody, label: 'a'.repeat(61) }));
+    expect(res.status).toBe(400);
+    expect(mockQueryCreate).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/app/api/queries/route.ts
+++ b/apps/web/src/app/api/queries/route.ts
@@ -123,6 +123,15 @@ export async function POST(request: NextRequest) {
     aggregators = body.preferredAggregators;
   }
 
+  let label: string | null = null;
+  if (typeof body.label === 'string') {
+    const trimmed = body.label.trim();
+    if (trimmed.length > 60) {
+      return apiError('label must be 60 characters or fewer', 400);
+    }
+    label = trimmed || null;
+  }
+
   const groupId = crypto.randomUUID();
 
   const results: Array<{
@@ -134,6 +143,7 @@ export async function POST(request: NextRequest) {
     date?: string;
     returnDate?: string;
     deleteToken: string;
+    label: string | null;
   }> = [];
 
   for (const route of routeInputs) {
@@ -163,6 +173,7 @@ export async function POST(request: NextRequest) {
         maxDurationHours: maxDurationHoursValidated,
         preferredAirlines: airlines,
         preferredAggregators: aggregators,
+        label,
         timePreference: timePreference || 'any',
         cabinClass: cabinClass || 'economy',
         tripType: tripType === 'one_way' ? 'one_way' : 'round_trip',
@@ -201,6 +212,7 @@ export async function POST(request: NextRequest) {
       date: route.date,
       returnDate: route.returnDate,
       deleteToken,
+      label,
     });
   }
 

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -9,6 +9,7 @@ import { ThemeToggle } from '@/components/ThemeToggle';
 import { DeleteTracker } from '@/components/DeleteTracker';
 import { ScrapeInterval } from '@/components/ScrapeInterval';
 import { AggregatorPicker } from '@/components/AggregatorPicker';
+import { TrackerLabel } from '@/components/TrackerLabel';
 import { ChartActions } from '@/components/ChartActions';
 import { PriceCalendar } from '@/components/PriceCalendar';
 import { Footer } from '@/components/Footer';
@@ -386,6 +387,7 @@ export default async function ChartPage({ params }: Props) {
             </div>
           </>
         )}
+        <TrackerLabel queryId={id} currentLabel={primary.query.label} />
         <div className={styles.headerActions}>
           <div className={styles.expiry}>
             {expired ? (

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { DeleteTracker } from '@/components/DeleteTracker';
 import { ScrapeInterval } from '@/components/ScrapeInterval';
+import { AggregatorPicker } from '@/components/AggregatorPicker';
 import { ChartActions } from '@/components/ChartActions';
 import { PriceCalendar } from '@/components/PriceCalendar';
 import { Footer } from '@/components/Footer';
@@ -85,6 +86,8 @@ interface QueryWithSnapshots {
     currency: string | null;
     scrapeInterval: number | null;
     vpnCountries: string[];
+    preferredAggregators: string[];
+    label: string | null;
   };
   snapshots: Array<{
     id: string;
@@ -247,8 +250,16 @@ async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | 
 export default async function ChartPage({ params }: Props) {
   const { id } = await params;
 
-  const primary = await loadQueryWithSnapshots(id);
+  const [primary, adminConfig] = await Promise.all([
+    loadQueryWithSnapshots(id),
+    prisma.extractionConfig.findFirst({
+      where: { id: 'singleton' },
+      select: { aggregatorsEnabled: true },
+    }),
+  ]);
   if (!primary) notFound();
+
+  const adminEnabledAggregators = adminConfig?.aggregatorsEnabled ?? ['google_flights', 'airline_direct'];
 
   // Mark first view for 24h auto-cleanup
   if (!primary.query.firstViewedAt) {
@@ -424,6 +435,11 @@ export default async function ChartPage({ params }: Props) {
                 <ForceScrapeButton queryId={id} ariaLabel="Refresh prices now" />
               )}
               <ScrapeInterval queryId={id} currentInterval={primary.query.scrapeInterval} />
+              <AggregatorPicker
+                queryId={id}
+                currentAggregators={primary.query.preferredAggregators}
+                adminEnabledAggregators={adminEnabledAggregators}
+              />
               <DeleteTracker queryId={id} />
             </>
           )}

--- a/apps/web/src/components/AggregatorPicker.module.css
+++ b/apps/web/src/components/AggregatorPicker.module.css
@@ -1,0 +1,77 @@
+.root {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.options {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  overflow: hidden;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--muted);
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--border);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+
+.option:last-child {
+  border-right: none;
+}
+
+.option:hover:not(.disabled) {
+  color: var(--text-primary);
+  background: var(--surface);
+}
+
+.option.active {
+  color: var(--accent);
+  background: var(--surface);
+}
+
+.option.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.check {
+  width: 0.625rem;
+  height: 0.625rem;
+  border: 1px solid var(--muted);
+  border-radius: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.check.checked {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--bg);
+}
+
+.experimental {
+  font-size: 0.5625rem;
+  color: var(--muted);
+  opacity: 0.7;
+}

--- a/apps/web/src/components/AggregatorPicker.tsx
+++ b/apps/web/src/components/AggregatorPicker.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+import { getDeleteToken } from '@/lib/tracker-storage';
+import { ALL_AGGREGATORS, AGGREGATOR_LABEL, EXPERIMENTAL_AGGREGATORS, type Aggregator } from '@/lib/aggregators';
+import styles from './AggregatorPicker.module.css';
+
+interface Props {
+  queryId: string;
+  currentAggregators: string[];
+  adminEnabledAggregators: string[];
+}
+
+export function AggregatorPicker({ queryId, currentAggregators, adminEnabledAggregators }: Props) {
+  const [selected, setSelected] = useState<Set<Aggregator>>(
+    () => new Set(
+      currentAggregators.filter((s): s is Aggregator =>
+        (ALL_AGGREGATORS as readonly string[]).includes(s),
+      ),
+    ),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const token = typeof window !== 'undefined' ? getDeleteToken(queryId) : null;
+
+  if (!token) return null;
+
+  const adminAllowed = new Set(adminEnabledAggregators);
+
+  const toggle = async (source: Aggregator) => {
+    if (!adminAllowed.has(source) || saving) return;
+
+    const next = new Set(selected);
+    if (next.has(source)) next.delete(source);
+    else next.add(source);
+
+    const ordered = ALL_AGGREGATORS.filter((a) => next.has(a));
+
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/queries/${queryId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deleteToken: token, preferredAggregators: ordered }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setSelected(next);
+      }
+    } catch {
+      // keep previous state
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={styles.root}>
+      <span className={styles.label}>Sources</span>
+      <div className={styles.options}>
+        {ALL_AGGREGATORS.map((source) => {
+          const allowed = adminAllowed.has(source);
+          const checked = selected.has(source);
+          const experimental = EXPERIMENTAL_AGGREGATORS.has(source);
+          return (
+            <button
+              key={source}
+              className={`${styles.option} ${checked ? styles.active : ''} ${!allowed ? styles.disabled : ''}`}
+              onClick={() => toggle(source)}
+              disabled={!allowed || saving}
+              title={!allowed ? 'Disabled by admin' : AGGREGATOR_LABEL[source]}
+            >
+              <span className={`${styles.check} ${checked ? styles.checked : ''}`}>
+                {checked ? '✓' : ''}
+              </span>
+              {AGGREGATOR_LABEL[source]}
+              {experimental && <span className={styles.experimental}>β</span>}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/SavedTrackers.module.css
+++ b/apps/web/src/components/SavedTrackers.module.css
@@ -83,6 +83,12 @@
   gap: 0.375rem;
 }
 
+.label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--muted);
+}
+
 .route {
   display: flex;
   align-items: center;

--- a/apps/web/src/components/SavedTrackers.tsx
+++ b/apps/web/src/components/SavedTrackers.tsx
@@ -24,6 +24,8 @@ interface ActiveQuery {
   lastScrapeStatus: string | null;
   lastScrapeError: string | null;
   groupId: string | null;
+  label: string | null;
+  preferredAggregators: string[];
   createdAt: string;
 }
 
@@ -32,6 +34,7 @@ interface DisplayQuery extends GroupableQuery {
   hasDeleteToken: boolean;
   scrapeStatus: string | null;
   scrapeError: string | null;
+  label?: string | null;
 }
 
 interface DisplayGroup {
@@ -126,6 +129,7 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
             createdAt: q.createdAt,
             snapshotCount: q.snapshotCount,
             lastScrapedAt: q.lastScrapedAt,
+            label: q.label,
             status: q.active ? 'active' : 'paused',
             hasDeleteToken: deleteTokenSet.has(q.id),
             scrapeStatus: q.lastScrapeStatus,
@@ -310,6 +314,7 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
           const { group, status, aggregate } = entry;
           const extraDestinations = group.destinations.length - 1;
           const primaryToken = getDeleteToken(group.primaryId);
+          const primaryLabel = group.queries.find((q) => q.id === group.primaryId)?.label;
           return (
             <div key={group.primaryId} className={styles.card}>
               <button
@@ -336,6 +341,9 @@ export function SavedTrackers({ isAuthenticated = false }: { isAuthenticated?: b
               ) : (
                 <Link href={`/q/${group.primaryId}`} className={styles.link}>
                   <div className={styles.content}>
+                    {primaryLabel && (
+                      <span className={styles.label}>{primaryLabel}</span>
+                    )}
                     <div className={styles.route}>
                       <span className={styles.code}>{group.origin}</span>
                       <span className={styles.arrow}>&rarr;</span>

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -404,6 +404,7 @@ export function SearchBar({
         date?: string;
         returnDate?: string;
         deleteToken: string;
+        label: string | null;
       }> = data.data.queries;
 
       for (const trackedQuery of queries) {
@@ -417,6 +418,7 @@ export function SearchBar({
           dateTo: trackedQuery.returnDate || parsed.dateTo,
           createdAt: new Date().toISOString(),
           deleteToken: trackedQuery.deleteToken,
+          label: trackedQuery.label ?? undefined,
         });
       }
 

--- a/apps/web/src/components/TrackerLabel.module.css
+++ b/apps/web/src/components/TrackerLabel.module.css
@@ -1,0 +1,52 @@
+.root {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-height: 1.5rem;
+}
+
+.display {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.display:hover {
+  border-color: var(--border);
+  color: var(--text-primary);
+}
+
+.addButton {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--muted);
+  background: transparent;
+  border: 1px dashed var(--border);
+  border-radius: 4px;
+  padding: 0.125rem 0.5rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.addButton:hover {
+  color: var(--text-primary);
+  border-color: var(--text-primary);
+}
+
+.input {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  background: var(--surface);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 0.125rem 0.375rem;
+  outline: none;
+  width: 16rem;
+  max-width: 100%;
+}

--- a/apps/web/src/components/TrackerLabel.tsx
+++ b/apps/web/src/components/TrackerLabel.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { getDeleteToken } from '@/lib/tracker-storage';
+import styles from './TrackerLabel.module.css';
+
+interface Props {
+  queryId: string;
+  currentLabel: string | null;
+}
+
+export function TrackerLabel({ queryId, currentLabel }: Props) {
+  const [label, setLabel] = useState(currentLabel);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(currentLabel ?? '');
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const token = typeof window !== 'undefined' ? getDeleteToken(queryId) : null;
+
+  const save = async (value: string) => {
+    const trimmed = value.trim();
+    const newLabel = trimmed || null;
+    if (newLabel === label) {
+      setEditing(false);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/queries/${queryId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deleteToken: token, label: newLabel }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setLabel(newLabel);
+      }
+    } catch {
+      // keep previous state
+    } finally {
+      setSaving(false);
+      setEditing(false);
+    }
+  };
+
+  const startEditing = () => {
+    setDraft(label ?? '');
+    setEditing(true);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  if (!token) {
+    if (!label) return null;
+    return (
+      <div className={styles.root}>
+        <span className={styles.display} style={{ cursor: 'default' }}>{label}</span>
+      </div>
+    );
+  }
+
+  if (editing) {
+    return (
+      <div className={styles.root}>
+        <input
+          ref={inputRef}
+          className={styles.input}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => save(draft)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') save(draft);
+            if (e.key === 'Escape') setEditing(false);
+          }}
+          maxLength={60}
+          placeholder="e.g. Paris via Skyscanner"
+          disabled={saving}
+        />
+      </div>
+    );
+  }
+
+  if (label) {
+    return (
+      <div className={styles.root}>
+        <span className={styles.display} onClick={startEditing} title="Click to edit label">
+          {label}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.root}>
+      <button className={styles.addButton} onClick={startEditing} type="button">
+        + Add label
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/lib/aggregators.ts
+++ b/apps/web/src/lib/aggregators.ts
@@ -1,0 +1,12 @@
+export const ALL_AGGREGATORS = ['google_flights', 'airline_direct', 'skyscanner', 'kayak'] as const;
+
+export type Aggregator = (typeof ALL_AGGREGATORS)[number];
+
+export const AGGREGATOR_LABEL: Record<Aggregator, string> = {
+  google_flights: 'Google Flights',
+  airline_direct: 'Airline direct',
+  skyscanner: 'Skyscanner',
+  kayak: 'Kayak',
+};
+
+export const EXPERIMENTAL_AGGREGATORS = new Set<Aggregator>(['skyscanner', 'kayak']);

--- a/apps/web/src/lib/tracker-storage.ts
+++ b/apps/web/src/lib/tracker-storage.ts
@@ -8,6 +8,7 @@ export interface SavedTracker {
   dateTo: string;
   createdAt: string;
   deleteToken?: string;
+  label?: string;
 }
 
 export function getDeleteToken(id: string): string | null {


### PR DESCRIPTION
Addresses the follow-up asks from #89.

## Per-tracker aggregator override
Backend already supported `Query.preferredAggregators` but had no UI. New `AggregatorPicker` component on `/q/[id]` detail page lets users toggle which sources to scrape per tracker. Checkboxes respect admin-enabled allowlist. Empty selection inherits user/account defaults.

Shared aggregator constants (`ALL_AGGREGATORS`, `AGGREGATOR_LABEL`, `EXPERIMENTAL_AGGREGATORS`) extracted to `lib/aggregators.ts` to avoid duplication between `SettingsForm` and `AggregatorPicker`.

## Custom tracker label
New nullable `label` field on `Query` (max 60 chars, not cascaded across flex group siblings). `TrackerLabel` component on the detail page header shows an inline editable text input. Click to edit, blur/Enter to save, Escape to cancel. Read-only for anonymous visitors.

Labels surface in the SavedTrackers dashboard cards and the admin queries page. Aggregator overrides show as badges in admin.

## Files changed

| Area | Files | What |
|------|-------|------|
| Schema | `schema.prisma` | `label String?` on Query |
| API | `queries/route.ts`, `queries/[id]/route.ts`, `admin/queries/[id]/route.ts` | Accept label in POST/PATCH |
| Shared | `lib/aggregators.ts` | Extracted aggregator constants |
| Components | `AggregatorPicker.tsx`, `TrackerLabel.tsx` | New inline controls |
| Detail page | `q/[id]/page.tsx` | Wire both components, fetch aggregatorsEnabled |
| Dashboard | `SavedTrackers.tsx`, `SearchBar.tsx`, `tracker-storage.ts` | Thread label |
| Admin | `queries/page.tsx`, `QueryRow.tsx` | Surface label + aggregator badges |
| Tests | 4 test files | Label PATCH/POST tests, active route shape |

## Test plan
- [x] `npm run ci` passes (lint + typecheck + build)
- [x] All 760 tests pass
- [x] Create a tracker, visit `/q/[id]`, verify AggregatorPicker renders
- [x] Toggle aggregator checkboxes, refresh, confirm they persist
- [x] Click "Add label", type a name, blur to save, refresh to confirm
- [x] Check SavedTrackers dashboard shows label on card
- [x] Check admin `/admin/queries` shows label tag + aggregator badges
