### PR TITLE
feat: configurable max flights per date extraction (#92)

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -119,6 +119,7 @@ model ExtractionConfig {
   multiUserMode        Boolean   @default(false) // self-hosted only; admin manages User table for households
   updatedAt            DateTime  @updatedAt
   extractTimeoutSeconds Int @default(90)
+  maxFlightsPerDate     Int @default(10) // max flights the LLM extracts per date pair; raise for busy routes
   aggregatorsEnabled    String[] @default(["google_flights", "airline_direct"]) // sources allowed in the fallback chain; skyscanner/kayak opt-in
 }
 

--- a/apps/web/src/app/admin/(dashboard)/config/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/config/page.tsx
@@ -41,6 +41,7 @@ export default function ConfigPage() {
   const [customModel, setCustomModel] = useState('');
   const [scrapeInterval, setScrapeInterval] = useState(3);
   const [extractTimeoutSeconds, setExtractTimeoutSeconds] = useState(90);
+  const [maxFlightsPerDate, setMaxFlightsPerDate] = useState(10);
   const [theme, setTheme] = useState<ThemeId>('default');
   const [defaultCurrency, setDefaultCurrency] = useState('');
   const [defaultCountry, setDefaultCountry] = useState('');
@@ -95,6 +96,7 @@ export default function ConfigPage() {
           setProvider(d.data.provider);
           setScrapeInterval(d.data.scrapeInterval);
           setExtractTimeoutSeconds(d.data.extractTimeoutSeconds ?? 90);
+          setMaxFlightsPerDate(d.data.maxFlightsPerDate ?? 10);
           setTheme(d.data.theme || 'default');
           applyTheme(d.data.theme || 'default');
           setDefaultCurrency(d.data.defaultCurrency || '');
@@ -153,6 +155,7 @@ export default function ConfigPage() {
         model: effectiveModel,
         scrapeIntervalHours: scrapeInterval,
         extractTimeoutSeconds,
+        maxFlightsPerDate,
         theme,
         defaultCurrency: defaultCurrency.trim().toUpperCase() || null,
         defaultCountry: defaultCountry.trim().toUpperCase() || null,
@@ -313,6 +316,22 @@ export default function ConfigPage() {
           />
           <span className={styles.toggleHint}>
             Default 90. Raise this for slow CPU bound local models that exceed the default and time out.
+          </span>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label}>Max flights per date</label>
+          <input
+            type="number"
+            className={styles.input}
+            min={5}
+            max={50}
+            step={1}
+            value={maxFlightsPerDate}
+            onChange={(e) => setMaxFlightsPerDate(Number(e.target.value))}
+          />
+          <span className={styles.toggleHint}>
+            Default 10. Raise to 20-30 for busy routes (JFK-LAX, LHR-CDG) where 10 flights may miss afternoon or budget options. Higher values use more LLM output tokens per scrape.
           </span>
         </div>
 

--- a/apps/web/src/app/api/admin/config/route.ts
+++ b/apps/web/src/app/api/admin/config/route.ts
@@ -73,6 +73,9 @@ export async function PATCH(request: NextRequest) {
   if (typeof body.extractTimeoutSeconds === 'number' && Number.isFinite(body.extractTimeoutSeconds)) {
     data.extractTimeoutSeconds = Math.max(30, Math.min(600, Math.round(body.extractTimeoutSeconds)));
   }
+  if (typeof body.maxFlightsPerDate === 'number' && Number.isFinite(body.maxFlightsPerDate)) {
+    data.maxFlightsPerDate = Math.max(5, Math.min(50, Math.round(body.maxFlightsPerDate)));
+  }
   if (body.defaultSearchMethod !== undefined) {
     if (body.defaultSearchMethod !== 'ai' && body.defaultSearchMethod !== 'manual') {
       return apiError('defaultSearchMethod must be "ai" or "manual"', 400);

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -155,6 +155,7 @@ export interface ExtractionConfigOverride {
   model: string;
   customBaseUrl: string | null;
   extractTimeoutSeconds?: number | null;
+  maxFlightsPerDate?: number | null;
 }
 
 export async function extractPrices(
@@ -182,8 +183,11 @@ export async function extractPrices(
         model: configOverride.model,
         customBaseUrl: configOverride.customBaseUrl,
         extractTimeoutSeconds: configOverride.extractTimeoutSeconds ?? null,
+        maxFlightsPerDate: configOverride.maxFlightsPerDate ?? null,
       }
     : await prisma.extractionConfig.findFirst({ where: { id: 'singleton' } });
+
+  const effectiveMaxResults = config?.maxFlightsPerDate ?? maxResults;
 
   const provider = config?.provider ?? 'anthropic';
   const model = config?.model ?? 'claude-haiku-4-5-20251001';
@@ -211,7 +215,7 @@ Default travel date (if not visible per result): ${travelDateFallback}
 Page content:
 ${html}`;
 
-  const systemPrompt = buildSystemPrompt(filters, maxResults, source, currency);
+  const systemPrompt = buildSystemPrompt(filters, effectiveMaxResults, source, currency);
   // Block briefly when the rolling per minute window for this provider
   // is full. Audit finding D3: PREVIEW_CONCURRENCY=3 plus llm_error
   // retries can otherwise burst past free tier RPM caps and trip

--- a/apps/web/src/lib/scraper/settings-parity.test.ts
+++ b/apps/web/src/lib/scraper/settings-parity.test.ts
@@ -74,7 +74,7 @@ describe('settings page parity with admin config', () => {
     // aggregator allowlist that only an admin should configure). Core
     // data fields must exist in both.
     const coreFields = adminFields.filter(
-      (f) => !['hasAdminPassword', 'extractTimeoutSeconds', 'aggregatorsEnabled'].includes(f)
+      (f) => !['hasAdminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'aggregatorsEnabled'].includes(f)
     );
 
     for (const field of coreFields) {
@@ -93,7 +93,7 @@ describe('settings page parity with admin config', () => {
     // extract timeout, the aggregator allowlist) that settings doesn't
     // surface. All other extraction-related fields should be in both.
     const extractionFields = adminSaveFields.filter(
-      (f) => !['adminPassword', 'extractTimeoutSeconds', 'aggregatorsEnabled'].includes(f)
+      (f) => !['adminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'aggregatorsEnabled'].includes(f)
     );
 
     for (const field of extractionFields) {


### PR DESCRIPTION
Addresses #92.

## Tracking logic clarification (answered in issue comment)
The scraper does not pin flights. Each re-scrape is fully independent: Playwright captures a fresh Google Flights page, the LLM extracts up to N cheapest flights, then diffs against previous snapshots to detect sold-out flights. No previous flight data constrains what gets extracted.

## Configurable max flights per date
New `maxFlightsPerDate` field on `ExtractionConfig` (default 10, clamped 5-50). On busy routes like JFK-LAX with 30+ daily flights, the default 10 can miss afternoon or budget options. Raising to 20-30 gives full coverage at the cost of more LLM output tokens per scrape.

The setting flows through both code paths:
- **DB fallback** (production scrape via `run-scrape.ts`): `extractPrices` reads it from ExtractionConfig singleton
- **Config override** (preview-runner): `ExtractionConfigOverride.maxFlightsPerDate` threads it through

Exposed in `/admin/config` as a number input alongside the existing extraction timeout control.

## Test plan
- [x] `npm run ci` passes (lint + typecheck + build)
- [x] All 760 tests pass (including settings parity test updated for new admin-only field)
- [x] CI green (ci, install-smoke, integration)
