### PR TITLE
Fix tracker edit controls, theme flash, and the preview combo cap (#89)

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -120,6 +120,7 @@ model ExtractionConfig {
   updatedAt            DateTime  @updatedAt
   extractTimeoutSeconds Int @default(90)
   maxFlightsPerDate     Int @default(10) // max flights the LLM extracts per date pair; raise for busy routes
+  previewMaxCombos      Int @default(24) // max (routes x dates) the create-time preview scrape fans out; cron does the full grid
   aggregatorsEnabled    String[] @default(["google_flights", "airline_direct"]) // sources allowed in the fallback chain; skyscanner/kayak opt-in
 }
 

--- a/apps/web/src/app/admin/(dashboard)/config/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/config/page.tsx
@@ -42,6 +42,7 @@ export default function ConfigPage() {
   const [scrapeInterval, setScrapeInterval] = useState(3);
   const [extractTimeoutSeconds, setExtractTimeoutSeconds] = useState(90);
   const [maxFlightsPerDate, setMaxFlightsPerDate] = useState(10);
+  const [previewMaxCombos, setPreviewMaxCombos] = useState(24);
   const [theme, setTheme] = useState<ThemeId>('default');
   const [defaultCurrency, setDefaultCurrency] = useState('');
   const [defaultCountry, setDefaultCountry] = useState('');
@@ -97,6 +98,7 @@ export default function ConfigPage() {
           setScrapeInterval(d.data.scrapeInterval);
           setExtractTimeoutSeconds(d.data.extractTimeoutSeconds ?? 90);
           setMaxFlightsPerDate(d.data.maxFlightsPerDate ?? 10);
+          setPreviewMaxCombos(d.data.previewMaxCombos ?? 24);
           setTheme(d.data.theme || 'default');
           applyTheme(d.data.theme || 'default');
           setDefaultCurrency(d.data.defaultCurrency || '');
@@ -156,6 +158,7 @@ export default function ConfigPage() {
         scrapeIntervalHours: scrapeInterval,
         extractTimeoutSeconds,
         maxFlightsPerDate,
+        previewMaxCombos,
         theme,
         defaultCurrency: defaultCurrency.trim().toUpperCase() || null,
         defaultCountry: defaultCountry.trim().toUpperCase() || null,
@@ -332,6 +335,22 @@ export default function ConfigPage() {
           />
           <span className={styles.toggleHint}>
             Default 10. Raise to 20-30 for busy routes (JFK-LAX, LHR-CDG) where 10 flights may miss afternoon or budget options. Higher values use more LLM output tokens per scrape.
+          </span>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label}>Max preview combinations</label>
+          <input
+            type="number"
+            className={styles.input}
+            min={6}
+            max={96}
+            step={1}
+            value={previewMaxCombos}
+            onChange={(e) => setPreviewMaxCombos(Number(e.target.value))}
+          />
+          <span className={styles.toggleHint}>
+            Default 24. Caps routes x dates for the create-time preview scrape only; the recurring cron always covers the full grid. Raise it for wide multi-airport flex searches, but each combination is a live page load, so higher values make creating a tracker slower.
           </span>
         </div>
 

--- a/apps/web/src/app/api/admin/config/route.ts
+++ b/apps/web/src/app/api/admin/config/route.ts
@@ -76,6 +76,9 @@ export async function PATCH(request: NextRequest) {
   if (typeof body.maxFlightsPerDate === 'number' && Number.isFinite(body.maxFlightsPerDate)) {
     data.maxFlightsPerDate = Math.max(5, Math.min(50, Math.round(body.maxFlightsPerDate)));
   }
+  if (typeof body.previewMaxCombos === 'number' && Number.isFinite(body.previewMaxCombos)) {
+    data.previewMaxCombos = Math.max(6, Math.min(96, Math.round(body.previewMaxCombos)));
+  }
   if (body.defaultSearchMethod !== undefined) {
     if (body.defaultSearchMethod !== 'ai' && body.defaultSearchMethod !== 'manual') {
       return apiError('defaultSearchMethod must be "ai" or "manual"', 400);

--- a/apps/web/src/app/api/preview/route.test.ts
+++ b/apps/web/src/app/api/preview/route.test.ts
@@ -16,6 +16,7 @@ const {
   mockRunPreview,
   mockValidatePreviewPayload,
   mockUpdate,
+  mockExtractionConfigFindFirst,
 } = vi.hoisted(() => ({
   mockFindFirst: vi.fn(),
   mockCreate: vi.fn(),
@@ -25,6 +26,7 @@ const {
   mockUpdate: vi.fn().mockResolvedValue({}),
   mockRunPreview: vi.fn().mockResolvedValue({ routes: [] }),
   mockValidatePreviewPayload: vi.fn().mockReturnValue({ origins: [], destinations: [], isOneWay: false }),
+  mockExtractionConfigFindFirst: vi.fn().mockResolvedValue({ previewMaxCombos: 24 }),
 }));
 
 vi.mock('@/lib/prisma', () => ({
@@ -36,6 +38,9 @@ vi.mock('@/lib/prisma', () => ({
       deleteMany: mockDeleteMany,
       updateMany: mockUpdateMany,
       update: mockUpdate,
+    },
+    extractionConfig: {
+      findFirst: mockExtractionConfigFindFirst,
     },
   },
 }));

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -178,8 +178,13 @@ export async function POST(request: NextRequest) {
 
   const payload = toPreviewRequestPayload(body as Record<string, unknown>);
 
+  const config = await prisma.extractionConfig.findFirst({
+    where: { id: 'singleton' },
+    select: { previewMaxCombos: true },
+  });
+
   try {
-    validatePreviewPayload(payload);
+    validatePreviewPayload(payload, config?.previewMaxCombos ?? 24);
   } catch (error) {
     return apiError(error instanceof Error ? error.message : 'Invalid preview request', 400);
   }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import '@/styles/globals.css';
 import { ClientBeacon } from '@/components/analytics/ClientBeacon';
 import { prisma } from '@/lib/prisma';
-import { getThemeMode, isThemeId } from '@/lib/theme';
+import { THEME_OPTIONS, getThemeMode, isThemeId } from '@/lib/theme';
 
 const isSelfHosted = process.env.SELF_HOSTED === 'true';
 
@@ -58,6 +58,24 @@ const swScript = `
   }
 `;
 
+// Apply the visitor's locally-saved theme before first paint so /q/[id] and
+// other cold renders don't flash the server-rendered default. The id->mode
+// map is derived from THEME_OPTIONS so it never drifts from theme.ts.
+const themeModeMap = JSON.stringify(
+  Object.fromEntries(THEME_OPTIONS.map((t) => [t.id, t.mode])),
+);
+const themeBootstrapScript = `
+  try {
+    var t = localStorage.getItem('ft-theme');
+    var m = ${themeModeMap};
+    if (t && m[t]) {
+      var e = document.documentElement;
+      e.setAttribute('data-theme', t);
+      e.setAttribute('data-theme-mode', m[t]);
+    }
+  } catch (e) {}
+`;
+
 export default async function RootLayout({
   children,
 }: {
@@ -72,6 +90,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning data-theme={theme} data-theme-mode={getThemeMode(theme)}>
       <head>
+        <script dangerouslySetInnerHTML={{ __html: themeBootstrapScript }} />
         <script dangerouslySetInnerHTML={{ __html: swScript }} />
       </head>
       <body>

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -17,6 +17,7 @@ import { StackedSortControls, type StackedItem } from '@/components/StackedSortC
 import { ScrapeStatusDot } from '@/components/ScrapeStatusDot';
 import { ForceScrapeButton } from '@/components/ForceScrapeButton';
 import { aggregateScrapeStatus } from '@/lib/scrape-status';
+import { canManageQueryWithoutToken } from '@/lib/query-auth';
 import { groupDateRange } from './group-date-range';
 import styles from './page.module.css';
 
@@ -89,6 +90,7 @@ interface QueryWithSnapshots {
     vpnCountries: string[];
     preferredAggregators: string[];
     label: string | null;
+    userId: string | null;
   };
   snapshots: Array<{
     id: string;
@@ -262,6 +264,11 @@ export default async function ChartPage({ params }: Props) {
 
   const adminEnabledAggregators = adminConfig?.aggregatorsEnabled ?? ['google_flights', 'airline_direct'];
 
+  // Whether to surface the per-tracker edit controls when this browser has no
+  // saved delete token (e.g. after a machine migration). The backend already
+  // authorizes solo/admin/owner mutations tokenless; this keeps the UI in step.
+  const canEdit = await canManageQueryWithoutToken(primary.query);
+
   // Mark first view for 24h auto-cleanup
   if (!primary.query.firstViewedAt) {
     await prisma.query.update({
@@ -387,7 +394,7 @@ export default async function ChartPage({ params }: Props) {
             </div>
           </>
         )}
-        <TrackerLabel queryId={id} currentLabel={primary.query.label} />
+        <TrackerLabel queryId={id} currentLabel={primary.query.label} canEdit={canEdit} />
         <div className={styles.headerActions}>
           <div className={styles.expiry}>
             {expired ? (
@@ -436,11 +443,12 @@ export default async function ChartPage({ params }: Props) {
               {primary.query.active && (
                 <ForceScrapeButton queryId={id} ariaLabel="Refresh prices now" />
               )}
-              <ScrapeInterval queryId={id} currentInterval={primary.query.scrapeInterval} />
+              <ScrapeInterval queryId={id} currentInterval={primary.query.scrapeInterval} canEdit={canEdit} />
               <AggregatorPicker
                 queryId={id}
                 currentAggregators={primary.query.preferredAggregators}
                 adminEnabledAggregators={adminEnabledAggregators}
+                canEdit={canEdit}
               />
               <DeleteTracker queryId={id} />
             </>

--- a/apps/web/src/components/AggregatorPicker.tsx
+++ b/apps/web/src/components/AggregatorPicker.tsx
@@ -9,9 +9,12 @@ interface Props {
   queryId: string;
   currentAggregators: string[];
   adminEnabledAggregators: string[];
+  // Server-resolved: this viewer may edit even without a local delete token
+  // (self-hosted solo, admin, or owner). See canManageQueryWithoutToken.
+  canEdit?: boolean;
 }
 
-export function AggregatorPicker({ queryId, currentAggregators, adminEnabledAggregators }: Props) {
+export function AggregatorPicker({ queryId, currentAggregators, adminEnabledAggregators, canEdit = false }: Props) {
   const [selected, setSelected] = useState<Set<Aggregator>>(
     () => new Set(
       currentAggregators.filter((s): s is Aggregator =>
@@ -23,7 +26,7 @@ export function AggregatorPicker({ queryId, currentAggregators, adminEnabledAggr
 
   const token = typeof window !== 'undefined' ? getDeleteToken(queryId) : null;
 
-  if (!token) return null;
+  if (!token && !canEdit) return null;
 
   const adminAllowed = new Set(adminEnabledAggregators);
 

--- a/apps/web/src/components/ScrapeInterval.tsx
+++ b/apps/web/src/components/ScrapeInterval.tsx
@@ -15,15 +15,18 @@ const INTERVALS = [
 interface Props {
   queryId: string;
   currentInterval: number | null;
+  // Server-resolved: this viewer may edit even without a local delete token
+  // (self-hosted solo, admin, or owner). See canManageQueryWithoutToken.
+  canEdit?: boolean;
 }
 
-export function ScrapeInterval({ queryId, currentInterval }: Props) {
+export function ScrapeInterval({ queryId, currentInterval, canEdit = false }: Props) {
   const [interval, setInterval] = useState<number | null>(currentInterval);
   const [saving, setSaving] = useState(false);
 
   const token = typeof window !== 'undefined' ? getDeleteToken(queryId) : null;
 
-  if (!token) return null;
+  if (!token && !canEdit) return null;
 
   const handleChange = async (value: number | null) => {
     if (value === interval) return;

--- a/apps/web/src/components/TrackerLabel.test.tsx
+++ b/apps/web/src/components/TrackerLabel.test.tsx
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TrackerLabel } from './TrackerLabel';
+
+// No tracker is ever saved here, so getDeleteToken returns null — mirroring a
+// browser that lost its localStorage delete token after a machine migration
+// (issue #89). The canEdit prop is what gates the affordance in that case.
+describe('TrackerLabel — edit affordance without a delete token', () => {
+  it('shows the Add label button when canEdit is true even without a token', () => {
+    render(<TrackerLabel queryId="q1" currentLabel={null} canEdit />);
+    expect(screen.getByRole('button', { name: /add label/i })).toBeInTheDocument();
+  });
+
+  it('lets an authorized viewer edit an existing label without a token', () => {
+    render(<TrackerLabel queryId="q1" currentLabel="Paris via Skyscanner" canEdit />);
+    const label = screen.getByTitle(/click to edit/i);
+    expect(label).toHaveTextContent('Paris via Skyscanner');
+  });
+
+  it('renders a read-only label (no edit button) when not authorized and no token', () => {
+    render(<TrackerLabel queryId="q1" currentLabel="Paris via Google" canEdit={false} />);
+    expect(screen.getByText('Paris via Google')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add label/i })).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/click to edit/i)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when unauthorized, tokenless, and unlabeled', () => {
+    const { container } = render(<TrackerLabel queryId="q1" currentLabel={null} canEdit={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/TrackerLabel.tsx
+++ b/apps/web/src/components/TrackerLabel.tsx
@@ -7,9 +7,12 @@ import styles from './TrackerLabel.module.css';
 interface Props {
   queryId: string;
   currentLabel: string | null;
+  // Server-resolved: this viewer may edit even without a local delete token
+  // (self-hosted solo, admin, or owner). See canManageQueryWithoutToken.
+  canEdit?: boolean;
 }
 
-export function TrackerLabel({ queryId, currentLabel }: Props) {
+export function TrackerLabel({ queryId, currentLabel, canEdit = false }: Props) {
   const [label, setLabel] = useState(currentLabel);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(currentLabel ?? '');
@@ -51,7 +54,7 @@ export function TrackerLabel({ queryId, currentLabel }: Props) {
     requestAnimationFrame(() => inputRef.current?.focus());
   };
 
-  if (!token) {
+  if (!token && !canEdit) {
     if (!label) return null;
     return (
       <div className={styles.root}>

--- a/apps/web/src/lib/preview-runner.test.ts
+++ b/apps/web/src/lib/preview-runner.test.ts
@@ -57,7 +57,7 @@ vi.mock('@/lib/scraper/airline-urls', () => ({
   isKnownAirline: () => false,
 }));
 
-import { runPreview, parsePreviewConcurrency } from './preview-runner';
+import { runPreview, parsePreviewConcurrency, validatePreviewPayload } from './preview-runner';
 
 function makePayload(overrides: Partial<PreviewRequestPayload> = {}): PreviewRequestPayload {
   return {
@@ -343,6 +343,37 @@ describe('parsePreviewConcurrency (audit D1)', () => {
     expect(parsePreviewConcurrency('0')).toBe(3);
     expect(parsePreviewConcurrency('-5')).toBe(3);
     expect(parsePreviewConcurrency('')).toBe(3);
+  });
+});
+
+describe('validatePreviewPayload combo cap (issue #89, configurable)', () => {
+  // 5 origins x 6 destinations x 1 date = 30 combos.
+  const wideFlexPayload = makePayload({
+    tripType: 'one_way',
+    dateFrom: '2026-11-09',
+    dateTo: '2026-11-09',
+    origins: [
+      { code: 'JFK', name: 'A' }, { code: 'EWR', name: 'B' }, { code: 'BOS', name: 'C' },
+      { code: 'PHL', name: 'D' }, { code: 'BWI', name: 'E' },
+    ],
+    destinations: [
+      { code: 'LAX', name: 'F' }, { code: 'SFO', name: 'G' }, { code: 'SAN', name: 'H' },
+      { code: 'SEA', name: 'I' }, { code: 'PDX', name: 'J' }, { code: 'LAS', name: 'K' },
+    ],
+  });
+
+  it('rejects a 30-combo search under the default cap of 24', () => {
+    expect(() => validatePreviewPayload(wideFlexPayload)).toThrow(
+      'Too many date/route combinations (30). Cap is 24 (combos x dates).',
+    );
+  });
+
+  it('accepts the same 30-combo search when the admin raises the cap to 30', () => {
+    expect(() => validatePreviewPayload(wideFlexPayload, 30)).not.toThrow();
+  });
+
+  it('reports the configured cap in the error message, not a hardcoded 24', () => {
+    expect(() => validatePreviewPayload(wideFlexPayload, 12)).toThrow(/Cap is 12/);
   });
 });
 

--- a/apps/web/src/lib/preview-runner.ts
+++ b/apps/web/src/lib/preview-runner.ts
@@ -127,7 +127,10 @@ export function buildCacheKey(
   return `preview:${hash}`;
 }
 
-export function validatePreviewPayload(payload: PreviewRequestPayload): PreviewValidationResult {
+export function validatePreviewPayload(
+  payload: PreviewRequestPayload,
+  maxCombos = 24,
+): PreviewValidationResult {
   const { dateFrom, dateTo, outboundDates, returnDates, origins, destinations, tripType } = payload;
 
   if (origins.length === 0 || destinations.length === 0 || !dateFrom || !dateTo) {
@@ -162,8 +165,8 @@ export function validatePreviewPayload(payload: PreviewRequestPayload): PreviewV
     : [dateFrom]);
   const totalTasks = combos * datesToScrape.length;
 
-  if (totalTasks > 24) {
-    throw new Error(`Too many date/route combinations (${totalTasks}). Cap is 24 (combos x dates).`);
+  if (totalTasks > maxCombos) {
+    throw new Error(`Too many date/route combinations (${totalTasks}). Cap is ${maxCombos} (combos x dates).`);
   }
 
   if (returnDates && outboundDates && !isOneWay && returnDates.length !== outboundDates.length) {
@@ -308,9 +311,9 @@ export async function runPreview(
   payload: PreviewRequestPayload,
   options: RunPreviewOptions = {}
 ): Promise<PreviewResultPayload> {
-  const { origins, destinations, isOneWay } = validatePreviewPayload(payload);
-  const { dateFrom, dateTo, maxPrice, maxStops, maxDurationHours, preferredAirlines, timePreference, cabinClass, tripType, currency: bodyCurrency } = payload;
   const config = await prisma.extractionConfig.findFirst({ where: { id: 'singleton' } });
+  const { origins, destinations, isOneWay } = validatePreviewPayload(payload, config?.previewMaxCombos ?? 24);
+  const { dateFrom, dateTo, maxPrice, maxStops, maxDurationHours, preferredAirlines, timePreference, cabinClass, tripType, currency: bodyCurrency } = payload;
   const currency: string | null = config?.defaultCurrency ?? bodyCurrency;
   const provider = config?.provider ?? 'anthropic';
   const model = config?.model ?? 'claude-haiku-4-5-20251001';

--- a/apps/web/src/lib/query-auth.test.ts
+++ b/apps/web/src/lib/query-auth.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockIsMultiUserEnabled = vi.fn().mockResolvedValue(false);
+const mockGetCurrentUser = vi.fn().mockResolvedValue(null);
+
+vi.mock('@/lib/multi-user', () => ({
+  isMultiUserEnabled: () => mockIsMultiUserEnabled(),
+}));
+
+vi.mock('@/lib/user-auth', () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+// canManageQueryWithoutToken never touches admin-auth, but the module imports
+// it for authorizeMutation, so stub it to keep the import graph headless-safe.
+vi.mock('@/lib/admin-auth', () => ({
+  getSessionToken: vi.fn().mockResolvedValue(undefined),
+  verifySessionToken: vi.fn().mockReturnValue(false),
+}));
+
+import { canManageQueryWithoutToken } from './query-auth';
+
+const ORIGINAL_SELF_HOSTED = process.env.SELF_HOSTED;
+
+describe('canManageQueryWithoutToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsMultiUserEnabled.mockResolvedValue(false);
+    mockGetCurrentUser.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_SELF_HOSTED === undefined) delete process.env.SELF_HOSTED;
+    else process.env.SELF_HOSTED = ORIGINAL_SELF_HOSTED;
+  });
+
+  it('allows anyone in self-hosted solo mode (no token needed)', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockIsMultiUserEnabled.mockResolvedValue(false);
+    expect(await canManageQueryWithoutToken({ userId: null })).toBe(true);
+  });
+
+  it('allows an admin in multi-user mode', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockIsMultiUserEnabled.mockResolvedValue(true);
+    mockGetCurrentUser.mockResolvedValue({ id: 'u-admin', isAdmin: true });
+    expect(await canManageQueryWithoutToken({ userId: 'someone-else' })).toBe(true);
+  });
+
+  it('allows the owning user in multi-user mode', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockIsMultiUserEnabled.mockResolvedValue(true);
+    mockGetCurrentUser.mockResolvedValue({ id: 'u-owner', isAdmin: false });
+    expect(await canManageQueryWithoutToken({ userId: 'u-owner' })).toBe(true);
+  });
+
+  it('denies a non-owning user in multi-user mode', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockIsMultiUserEnabled.mockResolvedValue(true);
+    mockGetCurrentUser.mockResolvedValue({ id: 'u-other', isAdmin: false });
+    expect(await canManageQueryWithoutToken({ userId: 'u-owner' })).toBe(false);
+  });
+
+  it('denies a logged-in non-admin for an ownerless/seed query in multi-user mode', async () => {
+    process.env.SELF_HOSTED = 'true';
+    mockIsMultiUserEnabled.mockResolvedValue(true);
+    mockGetCurrentUser.mockResolvedValue({ id: 'u-other', isAdmin: false });
+    expect(await canManageQueryWithoutToken({ userId: null })).toBe(false);
+  });
+
+  it('denies anonymous visitors in pure hosted mode (token is the only key)', async () => {
+    delete process.env.SELF_HOSTED;
+    expect(await canManageQueryWithoutToken({ userId: 'u-owner' })).toBe(false);
+    expect(mockIsMultiUserEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/query-auth.ts
+++ b/apps/web/src/lib/query-auth.ts
@@ -60,3 +60,33 @@ export async function authorizeMutation(
   }
   return { ok: true };
 }
+
+/**
+ * Whether the current request can manage `query` WITHOUT presenting a delete
+ * token. Used by the public tracker page to decide which edit affordances to
+ * render server-side, so a localStorage-less browser (e.g. after a machine
+ * migration) still surfaces the controls the backend would accept.
+ *
+ * Mirrors `authorizeMutation` minus the deleteToken branch:
+ *   - self hosted solo mode: anyone with box access manages everything.
+ *   - multi user mode: admin session, or the owning user.
+ *   - pure hosted mode: never (token is the only key), so anonymous visitors
+ *     keep the existing token-gated behavior.
+ */
+export async function canManageQueryWithoutToken(
+  query: { userId?: string | null },
+): Promise<boolean> {
+  const isSelfHosted = process.env.SELF_HOSTED === 'true';
+  const multiUser = isSelfHosted ? await isMultiUserEnabled() : false;
+
+  if (isSelfHosted && !multiUser) return true;
+
+  if (multiUser) {
+    const user = await getCurrentUser();
+    if (user?.isAdmin) return true;
+    if (user && query.userId && query.userId === user.id) return true;
+    return false;
+  }
+
+  return false;
+}

--- a/apps/web/src/lib/scraper/settings-parity.test.ts
+++ b/apps/web/src/lib/scraper/settings-parity.test.ts
@@ -74,7 +74,7 @@ describe('settings page parity with admin config', () => {
     // aggregator allowlist that only an admin should configure). Core
     // data fields must exist in both.
     const coreFields = adminFields.filter(
-      (f) => !['hasAdminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'aggregatorsEnabled'].includes(f)
+      (f) => !['hasAdminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'previewMaxCombos', 'aggregatorsEnabled'].includes(f)
     );
 
     for (const field of coreFields) {
@@ -93,7 +93,7 @@ describe('settings page parity with admin config', () => {
     // extract timeout, the aggregator allowlist) that settings doesn't
     // surface. All other extraction-related fields should be in both.
     const extractionFields = adminSaveFields.filter(
-      (f) => !['adminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'aggregatorsEnabled'].includes(f)
+      (f) => !['adminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'previewMaxCombos', 'aggregatorsEnabled'].includes(f)
     );
 
     for (const field of extractionFields) {


### PR DESCRIPTION
Fixes the three things antoniods97 hit on v0.9.1 in issue #89.

**1. Edit controls vanished after a machine migration.** The label button, aggregator picker and scrape interval were gated purely on the localStorage delete token, so a browser that lost the token showed nothing even though the backend would happily accept the edit (solo self host, admin, or owner). Added `canManageQueryWithoutToken` and the q page now passes a `canEdit` flag so those three controls render whenever the server already authorizes the mutation. Force scrape and delete already rendered and already submit token less, so they were left alone. Anonymous viewers on the hosted site keep the old token only behavior.

**2. Theme flashed to default on /q/[id].** The saved Dark/Light choice was only reapplied in a mount effect, so every cold render flashed the server default first. Added an inline bootstrap script in the document head that applies `ft-theme` before first paint. The id to mode map is built from THEME_OPTIONS so it cannot drift.

**3. The 24 combo cap blocked wide flex searches.** The create time preview scrape rejected more than 24 routes by dates. That cap is now `ExtractionConfig.previewMaxCombos` (default 24, admin tunable 6 to 96 from the config page). The recurring cron still walks the full grid as before. Both validation call sites read the config value, so raising it actually unblocks creation.

`previewMaxCombos` is a new column, so deploy needs the usual schema push.

Full suite green (773 tests), web and CLI builds pass. Tests added for the new auth helper, the TrackerLabel affordance, and the configurable cap.
