### PR TITLE
Issue #89: self-hosted default, configurable selection cap, flight-grouped history

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -120,6 +120,7 @@ model ExtractionConfig {
   updatedAt            DateTime  @updatedAt
   extractTimeoutSeconds Int @default(90)
   maxFlightsPerDate     Int @default(10) // max flights the LLM extracts per date pair; raise for busy routes
+  maxTrackedPerRoute    Int @default(10) // max flights a user can select to track per route in the picker; bounded by maxFlightsPerDate
   previewMaxCombos      Int @default(24) // max (routes x dates) the create-time preview scrape fans out; cron does the full grid
   aggregatorsEnabled    String[] @default(["google_flights", "airline_direct"]) // sources allowed in the fallback chain; skyscanner/kayak opt-in
 }

--- a/apps/web/src/app/admin/(dashboard)/config/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/config/page.tsx
@@ -42,6 +42,7 @@ export default function ConfigPage() {
   const [scrapeInterval, setScrapeInterval] = useState(3);
   const [extractTimeoutSeconds, setExtractTimeoutSeconds] = useState(90);
   const [maxFlightsPerDate, setMaxFlightsPerDate] = useState(10);
+  const [maxTrackedPerRoute, setMaxTrackedPerRoute] = useState(10);
   const [previewMaxCombos, setPreviewMaxCombos] = useState(24);
   const [theme, setTheme] = useState<ThemeId>('default');
   const [defaultCurrency, setDefaultCurrency] = useState('');
@@ -98,6 +99,7 @@ export default function ConfigPage() {
           setScrapeInterval(d.data.scrapeInterval);
           setExtractTimeoutSeconds(d.data.extractTimeoutSeconds ?? 90);
           setMaxFlightsPerDate(d.data.maxFlightsPerDate ?? 10);
+          setMaxTrackedPerRoute(d.data.maxTrackedPerRoute ?? 10);
           setPreviewMaxCombos(d.data.previewMaxCombos ?? 24);
           setTheme(d.data.theme || 'default');
           applyTheme(d.data.theme || 'default');
@@ -158,6 +160,7 @@ export default function ConfigPage() {
         scrapeIntervalHours: scrapeInterval,
         extractTimeoutSeconds,
         maxFlightsPerDate,
+        maxTrackedPerRoute,
         previewMaxCombos,
         theme,
         defaultCurrency: defaultCurrency.trim().toUpperCase() || null,
@@ -335,6 +338,22 @@ export default function ConfigPage() {
           />
           <span className={styles.toggleHint}>
             Default 10. Raise to 20-30 for busy routes (JFK-LAX, LHR-CDG) where 10 flights may miss afternoon or budget options. Higher values use more LLM output tokens per scrape.
+          </span>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label}>Max tracked flights per route</label>
+          <input
+            type="number"
+            className={styles.input}
+            min={1}
+            max={50}
+            step={1}
+            value={maxTrackedPerRoute}
+            onChange={(e) => setMaxTrackedPerRoute(Number(e.target.value))}
+          />
+          <span className={styles.toggleHint}>
+            Default 10. How many flights a user can select to track from one route in the results picker. The selection is also bounded by Max flights per date, since you can only pick from the flights that were extracted.
           </span>
         </div>
 

--- a/apps/web/src/app/api/admin/config/route.test.ts
+++ b/apps/web/src/app/api/admin/config/route.test.ts
@@ -93,3 +93,45 @@ describe('PATCH /api/admin/config — extractTimeoutSeconds (issue #86)', () => 
     expect(data.update.extractTimeoutSeconds).toBe(48);
   });
 });
+
+describe('PATCH /api/admin/config — maxTrackedPerRoute (issue #89)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpsert.mockResolvedValue({ id: 'singleton', maxTrackedPerRoute: 10 });
+  });
+
+  it('writes a valid number within range', async () => {
+    const res = await PATCH(patchRequest({ maxTrackedPerRoute: 30 }));
+    expect(res.status).toBe(200);
+    const data = mockUpsert.mock.calls[0]![0] as { update: Record<string, unknown> };
+    expect(data.update.maxTrackedPerRoute).toBe(30);
+  });
+
+  it('clamps a value below the floor of 1 up to 1', async () => {
+    const res = await PATCH(patchRequest({ maxTrackedPerRoute: 0 }));
+    expect(res.status).toBe(200);
+    const data = mockUpsert.mock.calls[0]![0] as { update: Record<string, unknown> };
+    expect(data.update.maxTrackedPerRoute).toBe(1);
+  });
+
+  it('clamps a value above the ceiling of 50 down to 50', async () => {
+    const res = await PATCH(patchRequest({ maxTrackedPerRoute: 999 }));
+    expect(res.status).toBe(200);
+    const data = mockUpsert.mock.calls[0]![0] as { update: Record<string, unknown> };
+    expect(data.update.maxTrackedPerRoute).toBe(50);
+  });
+
+  it('rejects NaN from a cleared number input without crashing Prisma', async () => {
+    const res = await PATCH(patchRequest({ maxTrackedPerRoute: NaN }));
+    expect(res.status).toBe(200);
+    const data = mockUpsert.mock.calls[0]![0] as { update: Record<string, unknown> };
+    expect(data.update).not.toHaveProperty('maxTrackedPerRoute');
+  });
+
+  it('rounds a fractional value to the nearest integer', async () => {
+    const res = await PATCH(patchRequest({ maxTrackedPerRoute: 12.4 }));
+    expect(res.status).toBe(200);
+    const data = mockUpsert.mock.calls[0]![0] as { update: Record<string, unknown> };
+    expect(data.update.maxTrackedPerRoute).toBe(12);
+  });
+});

--- a/apps/web/src/app/api/admin/config/route.ts
+++ b/apps/web/src/app/api/admin/config/route.ts
@@ -76,6 +76,9 @@ export async function PATCH(request: NextRequest) {
   if (typeof body.maxFlightsPerDate === 'number' && Number.isFinite(body.maxFlightsPerDate)) {
     data.maxFlightsPerDate = Math.max(5, Math.min(50, Math.round(body.maxFlightsPerDate)));
   }
+  if (typeof body.maxTrackedPerRoute === 'number' && Number.isFinite(body.maxTrackedPerRoute)) {
+    data.maxTrackedPerRoute = Math.max(1, Math.min(50, Math.round(body.maxTrackedPerRoute)));
+  }
   if (typeof body.previewMaxCombos === 'number' && Number.isFinite(body.previewMaxCombos)) {
     data.previewMaxCombos = Math.max(6, Math.min(96, Math.round(body.previewMaxCombos)));
   }

--- a/apps/web/src/components/FlightHistoryGroup.tsx
+++ b/apps/web/src/components/FlightHistoryGroup.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState } from 'react';
+import { currencySymbol } from '@/lib/currency';
+import styles from './PriceHistory.module.css';
+
+export interface Snapshot {
+  id: string;
+  price: number;
+  currency: string;
+  airline: string;
+  bookingUrl: string | null;
+  stops: number;
+  duration: string | null;
+  flightId: string | null;
+  flightNumber: string | null;
+  departureTime: string | null;
+  arrivalTime: string | null;
+  seatsLeft: number | null;
+  status: string;
+  airlineDirectPrice: number | null;
+  vpnCountry: string | null;
+  scrapedAt: string;
+}
+
+// A long-running tracker accumulates one snapshot per flight per scrape, so a
+// flight's history can run into the hundreds. Collapsing hides it by default;
+// this bounds the expanded view so a single open flight cannot dump an unbounded
+// number of rows into the DOM. The note row reports anything trimmed.
+const MAX_HISTORY_ROWS = 60;
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function flightName(s: Snapshot): string {
+  return `${s.airline}${s.flightNumber ? ` ${s.flightNumber}` : ''}`;
+}
+
+function timesLabel(s: Snapshot): string | null {
+  if (!s.departureTime && !s.arrivalTime) return null;
+  return `${s.departureTime ?? '?'} - ${s.arrivalTime ?? '?'}`;
+}
+
+function stopsLabel(s: Snapshot): string {
+  return s.stops === 0 ? 'Direct' : `${s.stops} stop${s.stops > 1 ? 's' : ''}`;
+}
+
+function PriceCell({ s }: { s: Snapshot }) {
+  return (
+    <td className={styles.price}>
+      {currencySymbol(s.currency)}
+      {s.price.toLocaleString()}
+    </td>
+  );
+}
+
+function TrendCell({ current, previous }: { current: Snapshot; previous: Snapshot | null }) {
+  const diff = previous ? current.price - previous.price : 0;
+  if (!previous || Math.abs(diff) < 1) {
+    return (
+      <td>
+        <span className={styles.trendStable}>&mdash;</span>
+      </td>
+    );
+  }
+  const sym = currencySymbol(current.currency);
+  return (
+    <td>
+      {diff > 0 ? (
+        <span className={styles.trendUp}>+{sym}{Math.abs(diff).toFixed(0)}</span>
+      ) : (
+        <span className={styles.trendDown}>-{sym}{Math.abs(diff).toFixed(0)}</span>
+      )}
+    </td>
+  );
+}
+
+function SeatsCell({ s }: { s: Snapshot }) {
+  return (
+    <td className={styles.seats}>
+      {s.status === 'sold_out' ? (
+        <span className={styles.soldOut}>Sold out</span>
+      ) : s.seatsLeft !== null ? (
+        <span className={s.seatsLeft <= 3 ? styles.seatsLow : styles.seatsNormal}>
+          {s.seatsLeft} left
+        </span>
+      ) : null}
+    </td>
+  );
+}
+
+function BookCell({ s }: { s: Snapshot }) {
+  return (
+    <td>
+      {s.status === 'sold_out' || !s.bookingUrl ? (
+        <span className={styles.soldOutLabel}>&mdash;</span>
+      ) : (
+        <a href={s.bookingUrl} target="_blank" rel="noopener noreferrer" className={styles.bookLink}>
+          Book
+        </a>
+      )}
+    </td>
+  );
+}
+
+/**
+ * One flight's rows in the price-history table. `snapshots` arrives sorted
+ * newest-first: [0] is the live summary shown by default, the rest is the
+ * collapsed history. Trend is computed within this flight's own series, so the
+ * change column reflects this exact flight's last move rather than the airline's.
+ */
+export function FlightHistoryGroup({ snapshots }: { snapshots: Snapshot[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const latest = snapshots[0];
+  if (!latest) return null;
+
+  const history = snapshots.slice(1);
+  const hasHistory = history.length > 0;
+  const shownHistory = history.slice(0, MAX_HISTORY_ROWS);
+  const hiddenCount = history.length - shownHistory.length;
+  const totalChecks = snapshots.length;
+
+  return (
+    <tbody>
+      <tr className={styles.summaryRow}>
+        <td className={styles.date}>
+          {hasHistory ? (
+            <button
+              type="button"
+              className={styles.expandBtn}
+              onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}
+              aria-label={`${expanded ? 'Hide' : 'Show'} earlier checks for ${flightName(latest)}`}
+            >
+              <span className={`${styles.chevron} ${expanded ? styles.chevronOpen : ''}`} aria-hidden="true">
+                ▸
+              </span>
+              {formatDateTime(latest.scrapedAt)}
+            </button>
+          ) : (
+            formatDateTime(latest.scrapedAt)
+          )}
+        </td>
+        <td>
+          {flightName(latest)}
+          {hasHistory && <span className={styles.historyCount}> · {totalChecks} checks</span>}
+        </td>
+        <td className={styles.times}>{timesLabel(latest)}</td>
+        <PriceCell s={latest} />
+        <TrendCell current={latest} previous={history[0] ?? null} />
+        <td className={styles.stops}>{stopsLabel(latest)}</td>
+        <SeatsCell s={latest} />
+        <BookCell s={latest} />
+      </tr>
+
+      {expanded &&
+        shownHistory.map((s, i) => (
+          <tr key={s.id} className={styles.historyRow}>
+            <td className={`${styles.date} ${styles.historyDate}`}>{formatDateTime(s.scrapedAt)}</td>
+            <td>{flightName(s)}</td>
+            <td className={styles.times}>{timesLabel(s)}</td>
+            <PriceCell s={s} />
+            <TrendCell current={s} previous={history[i + 1] ?? null} />
+            <td className={styles.stops}>{stopsLabel(s)}</td>
+            <SeatsCell s={s} />
+            <BookCell s={s} />
+          </tr>
+        ))}
+
+      {expanded && hiddenCount > 0 && (
+        <tr className={styles.historyRow}>
+          <td colSpan={8} className={styles.truncationNote}>
+            Showing the latest {MAX_HISTORY_ROWS} of {history.length} earlier checks.
+          </td>
+        </tr>
+      )}
+    </tbody>
+  );
+}

--- a/apps/web/src/components/FlightPicker.test.tsx
+++ b/apps/web/src/components/FlightPicker.test.tsx
@@ -1,0 +1,89 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FlightPicker, type RouteFlights } from './FlightPicker';
+import type { PriceData } from '@/lib/scraper/extract-prices';
+
+// The per-route selection cap used to be a hardcoded 10 (issue #89). It is now
+// driven by ExtractionConfig.maxTrackedPerRoute, threaded in as a prop. These
+// tests pin the behaviour an admin sees after raising or lowering that value.
+
+function flight(n: number): PriceData {
+  return {
+    travelDate: '2026-11-16',
+    price: 100 + n,
+    currency: 'USD',
+    airline: `Air${n}`,
+    bookingUrl: null,
+    stops: 0,
+    duration: '5h 30m',
+    departureTime: null,
+    arrivalTime: null,
+    seatsLeft: null,
+    flightNumber: null,
+  };
+}
+
+function route(count: number): RouteFlights {
+  return {
+    origin: 'JFK',
+    originName: 'New York',
+    destination: 'LAX',
+    destinationName: 'Los Angeles',
+    flights: Array.from({ length: count }, (_, i) => flight(i)),
+  };
+}
+
+function renderPicker(count: number, max?: number) {
+  return render(
+    <FlightPicker
+      routes={[route(count)]}
+      onTrack={vi.fn()}
+      onBack={vi.fn()}
+      onEdit={vi.fn()}
+      loading={false}
+      {...(max === undefined ? {} : { maxSelectionsPerRoute: max })}
+    />,
+  );
+}
+
+describe('FlightPicker — configurable per-route selection cap (issue #89)', () => {
+  it('pre-selects only up to the configured cap when flights exceed it', () => {
+    const { container } = renderPicker(12, 3);
+    // 12 flights available, cap of 3 -> first 3 pre-selected.
+    expect(screen.getByRole('button', { name: /track 3 flights/i })).toBeInTheDocument();
+    expect(container.textContent).toContain('3 of 3 selected');
+    expect(container.textContent).toContain('Select up to 3 flights');
+  });
+
+  it('honours a raised cap so more than 10 flights can be tracked', () => {
+    // Before #89 this was impossible: the hardcoded 10 capped both the
+    // pre-selection and the counter regardless of admin config.
+    const { container } = renderPicker(15, 12);
+    expect(screen.getByRole('button', { name: /track 12 flights/i })).toBeInTheDocument();
+    expect(container.textContent).toContain('12 of 12 selected');
+  });
+
+  it('falls back to a default cap of 10 when no prop is supplied', () => {
+    renderPicker(15);
+    expect(screen.getByRole('button', { name: /track 10 flights/i })).toBeInTheDocument();
+  });
+
+  it('refuses to select beyond the cap once it is reached', () => {
+    renderPicker(6, 2);
+
+    // Start from a clean slate so we exercise the add path, not pre-selection.
+    fireEvent.click(screen.getByRole('button', { name: /^clear$/i }));
+    expect(screen.getByRole('button', { name: /track 0 flights/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Air0/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Air1/ }));
+    expect(screen.getByRole('button', { name: /track 2 flights/i })).toBeInTheDocument();
+
+    // Cap reached: a third, unselected flight row is disabled and clicking is a no-op.
+    const third = screen.getByRole('button', { name: /Air2/ });
+    expect(third).toBeDisabled();
+    fireEvent.click(third);
+    expect(screen.getByRole('button', { name: /track 2 flights/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/FlightPicker.tsx
+++ b/apps/web/src/components/FlightPicker.tsx
@@ -5,8 +5,6 @@ import type { PriceData } from '@/lib/scraper/extract-prices';
 import { currencySymbol } from '@/lib/currency';
 import styles from './FlightPicker.module.css';
 
-const MAX_SELECTIONS_PER_ROUTE = 10;
-
 export interface RouteFlights {
   origin: string;
   originName: string;
@@ -41,19 +39,23 @@ export function FlightPicker({
   onBack,
   onEdit,
   loading,
+  maxSelectionsPerRoute = 10,
 }: {
   routes: RouteFlights[];
   onTrack: (routeSelections: Array<{ route: RouteFlights; flights: PriceData[] }>) => void;
   onBack: () => void;
   onEdit: () => void;
   loading: boolean;
+  // Admin-configurable cap (ExtractionConfig.maxTrackedPerRoute). Also bounded in
+  // practice by route.flights.length, since you can only pick extracted flights.
+  maxSelectionsPerRoute?: number;
 }) {
   const [selections, setSelections] = useState<Record<string, Set<number>>>(() => {
     const initial: Record<string, Set<number>> = {};
     for (const route of routes) {
       if (route.flights.length > 0) {
         initial[rKey(route)] = new Set(
-          route.flights.slice(0, MAX_SELECTIONS_PER_ROUTE).map((_, i) => i)
+          route.flights.slice(0, maxSelectionsPerRoute).map((_, i) => i)
         );
       }
     }
@@ -65,7 +67,7 @@ export function FlightPicker({
       const current = new Set(prev[key] ?? []);
       if (current.has(index)) {
         current.delete(index);
-      } else if (current.size < MAX_SELECTIONS_PER_ROUTE) {
+      } else if (current.size < maxSelectionsPerRoute) {
         current.add(index);
       }
       return { ...prev, [key]: current };
@@ -73,7 +75,7 @@ export function FlightPicker({
   };
 
   const selectAll = (key: string, flights: PriceData[]) => {
-    const indices = flights.slice(0, MAX_SELECTIONS_PER_ROUTE).map((_, i) => i);
+    const indices = flights.slice(0, maxSelectionsPerRoute).map((_, i) => i);
     setSelections((prev) => ({ ...prev, [key]: new Set(indices) }));
   };
 
@@ -122,7 +124,7 @@ export function FlightPicker({
                     : route.destinationName}
                 </h3>
                 <span className={styles.counter}>
-                  {selected.size} of {Math.min(route.flights.length, MAX_SELECTIONS_PER_ROUTE)} selected
+                  {selected.size} of {Math.min(route.flights.length, maxSelectionsPerRoute)} selected
                 </span>
               </div>
               <div className={styles.headerActions}>
@@ -136,13 +138,13 @@ export function FlightPicker({
             </div>
 
             {isSingleRoute && (
-              <p className={styles.hint}>Select up to {MAX_SELECTIONS_PER_ROUTE} flights to track daily price changes</p>
+              <p className={styles.hint}>Select up to {maxSelectionsPerRoute} flights to track daily price changes</p>
             )}
 
             <div className={styles.list}>
               {route.flights.map((flight, i) => {
                 const isSelected = selected.has(i);
-                const isDisabled = !isSelected && selected.size >= MAX_SELECTIONS_PER_ROUTE;
+                const isDisabled = !isSelected && selected.size >= maxSelectionsPerRoute;
 
                 return (
                   <button

--- a/apps/web/src/components/PriceHistory.module.css
+++ b/apps/web/src/components/PriceHistory.module.css
@@ -139,3 +139,67 @@
 .soldOutLabel {
   color: var(--muted);
 }
+
+/* Flight-grouped history: one summary row per flight, expandable into its
+   own price history. */
+.summaryRow td {
+  background: var(--surface);
+}
+
+.summaryRow:hover td {
+  background: var(--elevated, var(--surface));
+}
+
+.expandBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.expandBtn:hover {
+  color: var(--accent);
+}
+
+.chevron {
+  display: inline-block;
+  font-size: 0.625rem;
+  line-height: 1;
+  color: var(--accent);
+  transition: transform 0.15s ease;
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+}
+
+.historyCount {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--muted);
+}
+
+.historyRow td {
+  background: transparent;
+}
+
+.historyDate {
+  padding-left: 1.6rem;
+  color: var(--muted);
+}
+
+.truncationNote {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--muted);
+  text-align: center;
+  font-style: italic;
+}

--- a/apps/web/src/components/PriceHistory.test.tsx
+++ b/apps/web/src/components/PriceHistory.test.tsx
@@ -1,0 +1,78 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PriceHistory } from './PriceHistory';
+import type { Snapshot } from './FlightHistoryGroup';
+
+// Issue #89: the history table used to render every snapshot as a flat row, so a
+// week of scraping turned it into an unreadable wall. It now groups by flight and
+// shows one summary row per flight, expandable into that flight's history.
+
+function snap(over: Partial<Snapshot> & Pick<Snapshot, 'id' | 'flightId' | 'airline' | 'price' | 'scrapedAt'>): Snapshot {
+  return {
+    currency: 'USD',
+    bookingUrl: 'https://example.com/book',
+    stops: 0,
+    duration: '5h 30m',
+    flightNumber: null,
+    departureTime: null,
+    arrivalTime: null,
+    seatsLeft: null,
+    status: 'available',
+    airlineDirectPrice: null,
+    vpnCountry: null,
+    ...over,
+  };
+}
+
+// Two flights, three scrapes each. Latest prices: Alpha 300, Beta 200.
+const SNAPSHOTS: Snapshot[] = [
+  snap({ id: 'a1', flightId: 'A', airline: 'Alpha', price: 350, scrapedAt: '2026-05-01T08:00:00.000Z' }),
+  snap({ id: 'a2', flightId: 'A', airline: 'Alpha', price: 320, scrapedAt: '2026-05-02T08:00:00.000Z' }),
+  snap({ id: 'a3', flightId: 'A', airline: 'Alpha', price: 300, scrapedAt: '2026-05-03T08:00:00.000Z' }),
+  snap({ id: 'b1', flightId: 'B', airline: 'Beta', price: 250, scrapedAt: '2026-05-01T08:00:00.000Z' }),
+  snap({ id: 'b2', flightId: 'B', airline: 'Beta', price: 210, scrapedAt: '2026-05-02T08:00:00.000Z' }),
+  snap({ id: 'b3', flightId: 'B', airline: 'Beta', price: 200, scrapedAt: '2026-05-03T08:00:00.000Z' }),
+];
+
+describe('PriceHistory — grouped by flight (issue #89)', () => {
+  it('collapses to one summary row per flight showing only the latest price', () => {
+    render(<PriceHistory snapshots={SNAPSHOTS} />);
+
+    // Latest price of each flight is visible...
+    expect(screen.getByText(/\b300\b/)).toBeInTheDocument();
+    expect(screen.getByText(/\b200\b/)).toBeInTheDocument();
+
+    // ...but the older history is hidden until expanded.
+    expect(screen.queryByText(/\b350\b/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\b320\b/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\b250\b/)).not.toBeInTheDocument();
+
+    // One expand control per flight (both have history).
+    expect(screen.getAllByRole('button', { name: /earlier checks/i })).toHaveLength(2);
+  });
+
+  it('reveals a flight\'s own history when its summary row is expanded', () => {
+    render(<PriceHistory snapshots={SNAPSHOTS} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /earlier checks for Alpha/i }));
+
+    // Alpha's older prices now show...
+    expect(screen.getByText(/\b320\b/)).toBeInTheDocument();
+    expect(screen.getByText(/\b350\b/)).toBeInTheDocument();
+
+    // ...while Beta stays collapsed.
+    expect(screen.queryByText(/\b250\b/)).not.toBeInTheDocument();
+  });
+
+  it('shows a total-checks count so the summary row signals there is history', () => {
+    render(<PriceHistory snapshots={SNAPSHOTS} />);
+    // Each flight has 3 snapshots.
+    expect(screen.getAllByText(/3 checks/).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders nothing when there are no snapshots', () => {
+    const { container } = render(<PriceHistory snapshots={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/PriceHistory.tsx
+++ b/apps/web/src/components/PriceHistory.tsx
@@ -1,133 +1,63 @@
-import { currencySymbol } from '@/lib/currency';
+import { FlightHistoryGroup, type Snapshot } from './FlightHistoryGroup';
 import styles from './PriceHistory.module.css';
 
-interface Snapshot {
-  id: string;
-  price: number;
-  currency: string;
-  airline: string;
-  bookingUrl: string | null;
-  stops: number;
-  duration: string | null;
-  flightId: string | null;
-  flightNumber: string | null;
-  departureTime: string | null;
-  arrivalTime: string | null;
-  seatsLeft: number | null;
-  status: string;
-  airlineDirectPrice: number | null;
-  vpnCountry: string | null;
-  scrapedAt: string;
+/** Stable identity for one flight across scrapes. */
+function flightKey(s: Snapshot): string {
+  return s.flightId ?? `${s.airline}|${s.flightNumber ?? ''}|${s.departureTime ?? ''}|${s.arrivalTime ?? ''}`;
 }
 
-function formatDateTime(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
+/**
+ * Bucket snapshots by flight, each bucket sorted newest-first, and order the
+ * buckets by their current (latest) price ascending so the cheapest live option
+ * sits on top. Tie-break by most recently seen.
+ */
+function groupByFlight(snaps: Snapshot[]): Snapshot[][] {
+  const groups = new Map<string, Snapshot[]>();
+  for (const s of snaps) {
+    const key = flightKey(s);
+    const arr = groups.get(key) ?? [];
+    arr.push(s);
+    groups.set(key, arr);
+  }
+
+  const buckets = Array.from(groups.values()).map((g) =>
+    [...g].sort((a, b) => new Date(b.scrapedAt).getTime() - new Date(a.scrapedAt).getTime())
+  );
+
+  buckets.sort((a, b) => {
+    if (a[0]!.price !== b[0]!.price) return a[0]!.price - b[0]!.price;
+    return new Date(b[0]!.scrapedAt).getTime() - new Date(a[0]!.scrapedAt).getTime();
   });
-}
 
-function getTrend(
-  snapshot: Snapshot,
-  allSnapshots: Snapshot[]
-): { direction: 'up' | 'down' | 'stable'; diff: number } {
-  const sameAirline = allSnapshots
-    .filter(
-      (s) =>
-        s.airline === snapshot.airline &&
-        new Date(s.scrapedAt) < new Date(snapshot.scrapedAt)
-    )
-    .sort((a, b) => new Date(b.scrapedAt).getTime() - new Date(a.scrapedAt).getTime());
-
-  if (sameAirline.length === 0) return { direction: 'stable', diff: 0 };
-
-  const prev = sameAirline[0]!;
-  const diff = snapshot.price - prev.price;
-
-  if (Math.abs(diff) < 1) return { direction: 'stable', diff: 0 };
-  return { direction: diff > 0 ? 'up' : 'down', diff };
+  return buckets;
 }
 
 export function PriceHistory({ snapshots }: { snapshots: Snapshot[] }) {
   if (snapshots.length === 0) return null;
 
-  const recent = [...snapshots]
-    .sort((a, b) => new Date(b.scrapedAt).getTime() - new Date(a.scrapedAt).getTime())
-    .slice(0, 50);
-
   const hasCountryData = snapshots.some((s) => s.vpnCountry);
 
-  // Group by country for sectioned display
-  const countryGroups = hasCountryData
+  // Group by country for sectioned display (VPN multi-country trackers), then
+  // by flight within each section. Without country data it is a single section.
+  const countryGroups: Array<readonly [string, Snapshot[]]> = hasCountryData
     ? (() => {
-        const groups = new Map<string, typeof recent>();
-        for (const s of recent) {
+        const groups = new Map<string, Snapshot[]>();
+        for (const s of snapshots) {
           const key = s.vpnCountry ?? 'local';
           const arr = groups.get(key) ?? [];
           arr.push(s);
           groups.set(key, arr);
         }
         // Local first, then alphabetical
-        const sorted = Array.from(groups.entries()).sort(([a], [b]) =>
+        return Array.from(groups.entries()).sort(([a], [b]) =>
           a === 'local' ? -1 : b === 'local' ? 1 : a.localeCompare(b)
         );
-        return sorted;
       })()
-    : [['all', recent] as const];
+    : [['all', snapshots] as const];
 
   function countryLabel(key: string): string {
     if (key === 'local' || key === 'all') return 'Local';
     return String.fromCodePoint(...key.split('').map((c) => 0x1f1e6 + c.charCodeAt(0) - 65)) + ' ' + key;
-  }
-
-  function renderRow(s: Snapshot) {
-    const trend = getTrend(s, snapshots);
-    return (
-      <tr key={s.id}>
-        <td className={styles.date}>{formatDateTime(s.scrapedAt)}</td>
-        <td>{s.airline}{s.flightNumber ? ` ${s.flightNumber}` : ''}</td>
-        <td className={styles.times}>
-          {s.departureTime || s.arrivalTime
-            ? `${s.departureTime ?? '?'} - ${s.arrivalTime ?? '?'}`
-            : null}
-        </td>
-        <td className={styles.price}>{currencySymbol(s.currency)}{s.price.toLocaleString()}</td>
-        <td>
-          {trend.direction === 'up' && (
-            <span className={styles.trendUp}>+{currencySymbol(s.currency)}{Math.abs(trend.diff).toFixed(0)}</span>
-          )}
-          {trend.direction === 'down' && (
-            <span className={styles.trendDown}>-{currencySymbol(s.currency)}{Math.abs(trend.diff).toFixed(0)}</span>
-          )}
-          {trend.direction === 'stable' && (
-            <span className={styles.trendStable}>&mdash;</span>
-          )}
-        </td>
-        <td className={styles.stops}>
-          {s.stops === 0 ? 'Direct' : `${s.stops} stop${s.stops > 1 ? 's' : ''}`}
-        </td>
-        <td className={styles.seats}>
-          {s.status === 'sold_out' ? (
-            <span className={styles.soldOut}>Sold out</span>
-          ) : s.seatsLeft !== null ? (
-            <span className={s.seatsLeft <= 3 ? styles.seatsLow : styles.seatsNormal}>
-              {s.seatsLeft} left
-            </span>
-          ) : null}
-        </td>
-        <td>
-          {s.status === 'sold_out' || !s.bookingUrl ? (
-            <span className={styles.soldOutLabel}>&mdash;</span>
-          ) : (
-            <a href={s.bookingUrl} target="_blank" rel="noopener noreferrer" className={styles.bookLink}>
-              Book
-            </a>
-          )}
-        </td>
-      </tr>
-    );
   }
 
   return (
@@ -136,7 +66,7 @@ export function PriceHistory({ snapshots }: { snapshots: Snapshot[] }) {
       {countryGroups.map(([key, items]) => (
         <div key={key}>
           {hasCountryData && (
-            <div className={styles.countryHeader}>{countryLabel(key as string)}</div>
+            <div className={styles.countryHeader}>{countryLabel(key)}</div>
           )}
           <div className={styles.tableWrapper}>
             <table className={styles.table}>
@@ -152,9 +82,9 @@ export function PriceHistory({ snapshots }: { snapshots: Snapshot[] }) {
                   <th></th>
                 </tr>
               </thead>
-              <tbody>
-                {(items as Snapshot[]).map(renderRow)}
-              </tbody>
+              {groupByFlight(items).map((bucket) => (
+                <FlightHistoryGroup key={flightKey(bucket[0]!)} snapshots={bucket} />
+              ))}
             </table>
           </div>
         </div>

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -107,6 +107,7 @@ export function SearchBar({
 
   const [vpnCountries, setVpnCountries] = useState<string[]>([]);
   const [adminCurrency, setAdminCurrency] = useState<string | null>(null);
+  const [maxTrackedPerRoute, setMaxTrackedPerRoute] = useState(10);
 
   const [createdTrackers, setCreatedTrackers] = useState<CreatedTracker[] | null>(null);
 
@@ -121,6 +122,7 @@ export function SearchBar({
       .then((d) => {
         if (!d.ok) return;
         if (d.data.defaultCurrency) setAdminCurrency(d.data.defaultCurrency);
+        if (typeof d.data.maxTrackedPerRoute === 'number') setMaxTrackedPerRoute(d.data.maxTrackedPerRoute);
         const searchMethod = d.data.defaultSearchMethod === 'manual' ? 'manual' : 'ai';
         setActiveSearchMethod(searchMethod);
         setManualMode(searchMethod === 'manual');
@@ -664,6 +666,7 @@ export function SearchBar({
           onBack={handleBackFromPicker}
           onEdit={handleEdit}
           loading={loading}
+          maxSelectionsPerRoute={maxTrackedPerRoute}
         />
       )}
 

--- a/apps/web/src/lib/scraper/settings-parity.test.ts
+++ b/apps/web/src/lib/scraper/settings-parity.test.ts
@@ -74,7 +74,7 @@ describe('settings page parity with admin config', () => {
     // aggregator allowlist that only an admin should configure). Core
     // data fields must exist in both.
     const coreFields = adminFields.filter(
-      (f) => !['hasAdminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'previewMaxCombos', 'aggregatorsEnabled'].includes(f)
+      (f) => !['hasAdminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'maxTrackedPerRoute', 'previewMaxCombos', 'aggregatorsEnabled'].includes(f)
     );
 
     for (const field of coreFields) {
@@ -89,11 +89,12 @@ describe('settings page parity with admin config', () => {
     const settingsSaveFields = extractSaveBodyFields(SETTINGS_PAGE);
     const adminSaveFields = extractSaveBodyFields(ADMIN_CONFIG_PAGE);
 
-    // Admin page may send additional fields (adminPassword, the LLM
-    // extract timeout, the aggregator allowlist) that settings doesn't
-    // surface. All other extraction-related fields should be in both.
+    // Admin page may send additional fields (adminPassword, the LLM extract
+    // timeout, the per-route extraction/selection caps, the aggregator
+    // allowlist) that settings doesn't surface. All other extraction-related
+    // fields should be in both.
     const extractionFields = adminSaveFields.filter(
-      (f) => !['adminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'previewMaxCombos', 'aggregatorsEnabled'].includes(f)
+      (f) => !['adminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'maxTrackedPerRoute', 'previewMaxCombos', 'aggregatorsEnabled'].includes(f)
     );
 
     for (const field of extractionFields) {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,6 +44,11 @@ services:
       CRON_SECRET: ${CRON_SECRET}
       CHROME_PATH: /usr/bin/chromium-browser
       NODE_ENV: production
+      # flight-finder.org is the ONLY hosted deployment. The image defaults to
+      # self-hosted, so this opt-out is explicit. CLI providers stay installed
+      # (the Claude Code provider runs here via the mounted host auth above).
+      SELF_HOSTED: "false"
+      INSTALL_CLI_PROVIDERS: "true"
 
 volumes:
   pgdata:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -42,3 +42,4 @@ services:
       NODE_ENV: production
       SELF_HOSTED: "false"
       # Skip CLI install to speed up container start
+      INSTALL_CLI_PROVIDERS: "false"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,6 +5,24 @@ echo "============================================"
 echo "  Flight Finder — Flight Price Tracker"
 echo "============================================"
 
+# --- App mode + CLI provider install flags ---
+# This image IS the self-hosted distribution, so the app defaults to self-hosted.
+# flight-finder.org is the only deployment that opts into hosted mode, and it does
+# so by setting SELF_HOSTED=false explicitly in its compose. Exporting here (rather
+# than only defaulting inline) is what makes the Next.js server process see the same
+# value the entrypoint assumes. Without it, a compose that omits the var leaves the
+# app in hosted mode and per-tracker edit controls hide on token-less browsers.
+export SELF_HOSTED="${SELF_HOSTED:-true}"
+# CLI provider install (Claude Code / Codex) is independent of app mode: the hosted
+# production box runs hosted yet still installs the CLIs for the Claude Code provider.
+# Fast hosted test stacks set this to false to skip the ~15s install.
+export INSTALL_CLI_PROVIDERS="${INSTALL_CLI_PROVIDERS:-true}"
+if [ "$SELF_HOSTED" = "true" ]; then
+  echo "[setup] App mode: self-hosted (SELF_HOSTED=true, INSTALL_CLI_PROVIDERS=$INSTALL_CLI_PROVIDERS)"
+else
+  echo "[setup] App mode: hosted (SELF_HOSTED=false, INSTALL_CLI_PROVIDERS=$INSTALL_CLI_PROVIDERS)"
+fi
+
 # --- Auto-generate secrets if not set ---
 generate_secret() {
   # 32 random bytes → 64-char hex string
@@ -17,7 +35,7 @@ if [ -z "$ADMIN_SESSION_SECRET" ]; then
   echo "[setup] Generated ADMIN_SESSION_SECRET (set it in .env to persist across restarts)"
 fi
 
-if [ "${SELF_HOSTED:-true}" = "true" ] && [ -z "$CRON_SECRET" ]; then
+if [ "$SELF_HOSTED" = "true" ] && [ -z "$CRON_SECRET" ]; then
   export CRON_SECRET
   CRON_SECRET=$(generate_secret)
   echo "[setup] Generated CRON_SECRET (set it in .env to persist across restarts)"
@@ -64,9 +82,11 @@ echo "[setup] Applying database schema..."
 npx prisma@^6 db push --schema=apps/web/prisma/schema.prisma --skip-generate 2>&1 | tail -1
 echo "[setup] Schema ready"
 
-# --- Self-hosted only: CLI auth + install ---
-# Skip on production server (SELF_HOSTED=false) to save ~15s startup time.
-if [ "${SELF_HOSTED:-true}" = "true" ]; then
+# --- CLI provider auth + install (Claude Code / Codex) ---
+# Gated on INSTALL_CLI_PROVIDERS (default true), independent of app mode: the hosted
+# production box installs the CLIs for the Claude Code provider, while fast hosted
+# test stacks set INSTALL_CLI_PROVIDERS=false to skip the ~15s install.
+if [ "$INSTALL_CLI_PROVIDERS" = "true" ]; then
   # Copy CLI auth from read-only host mounts into writable directories.
   # The installer mounts host ~/.claude and ~/.codex as read-only at *-host paths.
   # CLIs need write access (models cache, sessions), so we copy into writable dirs.

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -250,6 +250,43 @@ test_entrypoint_pins_prisma_major() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: app defaults to self-hosted; CLI install decoupled from app mode (#89)
+# The Next.js app reads process.env.SELF_HOSTED at runtime. The entrypoint must
+# EXPORT it (defaulting true) so a compose that omits the var still runs the app
+# self-hosted; otherwise canManageQueryWithoutToken returns false and per-tracker
+# edit controls hide on token-less browsers (the migrated-legacy-tracker bug).
+# CLI provider install is gated separately on INSTALL_CLI_PROVIDERS so the one
+# hosted deployment (flight-finder.org) stays hosted yet keeps the Claude Code CLI.
+# ---------------------------------------------------------------------------
+test_entrypoint_self_hosted_default() {
+  local entrypoint="docker-entrypoint.sh"
+  local prod="docker-compose.prod.yml"
+  local code_only
+  code_only=$(grep -vE '^\s*#' "$entrypoint")
+
+  # 1. Entrypoint exports SELF_HOSTED with a default of true.
+  if printf '%s\n' "$code_only" | grep -qF 'export SELF_HOSTED="${SELF_HOSTED:-true}"'; then
+    pass "docker-entrypoint.sh exports SELF_HOSTED defaulting to true (#89)"
+  else
+    fail "docker-entrypoint.sh must 'export SELF_HOSTED=\"\${SELF_HOSTED:-true}\"' so the app defaults to self-hosted (#89)"
+  fi
+
+  # 2. CLI install is gated on INSTALL_CLI_PROVIDERS, not SELF_HOSTED.
+  if printf '%s\n' "$code_only" | grep -qF '"$INSTALL_CLI_PROVIDERS" = "true"'; then
+    pass "docker-entrypoint.sh gates CLI install on INSTALL_CLI_PROVIDERS (#89)"
+  else
+    fail "docker-entrypoint.sh must gate CLI provider install on INSTALL_CLI_PROVIDERS, decoupled from SELF_HOSTED (#89)"
+  fi
+
+  # 3. The one hosted deployment opts out explicitly and keeps CLI install.
+  if grep -qE '^\s*SELF_HOSTED:\s*"false"' "$prod" && grep -qE '^\s*INSTALL_CLI_PROVIDERS:\s*"true"' "$prod"; then
+    pass "docker-compose.prod.yml sets SELF_HOSTED=false + INSTALL_CLI_PROVIDERS=true (#89)"
+  else
+    fail "docker-compose.prod.yml must explicitly set SELF_HOSTED=\"false\" and INSTALL_CLI_PROVIDERS=\"true\" (#89)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Test: _compose_exec_flags emits the right flags for each compose flavor
 # (issue #72 follow-up). docker compose, docker-compose, and podman compose
 # accept Docker's -it/-i; podman-compose (standalone Python tool) rejects
@@ -393,6 +430,7 @@ test_install_supports_no_browser
 test_dockerfile_ships_cli
 test_install_supports_arch_family
 test_entrypoint_pins_prisma_major
+test_entrypoint_self_hosted_default
 test_compose_exec_flags_matrix
 test_cmd_tui_uses_helper
 test_no_raw_it_flags_in_dc_exec


### PR DESCRIPTION
Verification round on #89 (leaving the issue open for the reporter to confirm). Three items from the reporter's retest.

## 1. Legacy tracker edit controls hidden (self-hosted)

The app reads `SELF_HOSTED` at runtime, but `docker-entrypoint.sh` only used it for its own shell logic and never exported it to the Next.js process. A container whose compose omits the var ran the app in hosted mode, so `canManageQueryWithoutToken` returned false and the per-tracker controls (label, scrape interval, aggregator picker) hid on any browser without a delete token. A migrated tracker that lost its localStorage token lost its controls; a newer tracker that still held one kept them.

The image is the self-hosted distribution, so the app now defaults to self-hosted, and flight-finder.org is the only deployment that opts into hosted mode (`SELF_HOSTED=false` set explicitly in `docker-compose.prod.yml`). Production also leaned on the same unset flag to get CLI provider install, so that concern moved to its own `INSTALL_CLI_PROVIDERS` flag (default true). Production behavior is unchanged; the fast hosted smoke stack opts out of install.

## 2. Per-route selection cap stuck at 10

`FlightPicker` hardcoded a cap of 10, unrelated to "Max flights per date" (which only governs LLM extraction) and never wired to any setting. New `maxTrackedPerRoute` config (default 10, clamp 1 to 50) drives the picker. It is still bounded by Max flights per date, since you can only pick flights that were extracted, so the admin hint says as much.

## 3. History table grew without bound

`/q/[id]` now groups history by flight: one summary row per flight (latest price, change, seats, book link), ordered cheapest first, each expandable into that flight's own series. The change column compares against the same flight rather than the airline. Expanded history is capped per flight with a note when trimmed.

## Verification
- `npm run ci`: lint + typecheck (web + cli) + 786 tests + Next build + CLI build, all green.
- `scripts/install-flow-test.sh`: 24 pass (+3 new #89 assertions for the export and decoupling).
- `scripts/cli-runtime-test.sh`: 109 pass.

The `maxTrackedPerRoute` column is added by the entrypoint's existing `prisma db push` on deploy.
