### PR TITLE
Issue 96 followups: headless polish, --json, auto expire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - run: npm run typecheck
       - run: npx vitest run --reporter=verbose
         working-directory: apps/web
+      - run: npx vitest run --reporter=verbose
+        working-directory: packages/cli
       - run: npm run build
       - run: bash scripts/install-flow-test.sh
       - run: bash scripts/cli-runtime-test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,11 @@ COPY --from=proddeps --chown=node:node /app/node_modules/@google ./node_modules/
 #      chalk v5 that npm could not hoist due to version conflicts at root.
 # Without layer 2 the wrapper picks up commander v2.20.3 which is ESM hostile.
 COPY --from=builder --chown=node:node /app/packages/cli/dist /app/packages/cli/dist
+# Ship the cli package.json next to dist so Node finds "type":"module" when it
+# resolves dist/index.js. Without it Node walks up to the Next standalone
+# /app/package.json (no type field) and reparses every run as ESM, printing the
+# MODULE_TYPELESS_PACKAGE_JSON performance warning.
+COPY --from=builder --chown=node:node /app/packages/cli/package.json /app/packages/cli/package.json
 COPY --from=proddeps --chown=node:node /app/node_modules /app/packages/cli/node_modules
 COPY --from=proddeps --chown=node:node /app/packages/cli/node_modules /app/packages/cli/node_modules
 RUN printf '#!/bin/sh\nexec node /app/packages/cli/dist/index.js "$@"\n' > /home/node/.npm-global/bin/flight-finder-tui \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,18 @@ COPY apps/web/prisma ./apps/web/prisma/
 RUN npm ci --omit=dev --loglevel=error
 RUN npx prisma generate --schema=apps/web/prisma/schema.prisma
 
+# Prisma CLI as a self-contained toolchain for the entrypoint schema push.
+# The CLI is a devDependency, so it is absent from the lean runtime
+# node_modules, and fetching it with npx at container start round-trips the
+# registry and fails in restricted networks. Install it in isolation here so
+# the full dependency closure and the alpine engine binaries are bundled, then
+# copy the whole tree into the runner. Pinned to the v6 major that matches the
+# schema (Prisma 7 dropped `url = env(...)`).
+FROM docker.io/library/node:22-alpine AS prismacli
+RUN apk add --no-cache openssl
+WORKDIR /pcli
+RUN npm install --no-save --no-package-lock prisma@6
+
 FROM docker.io/library/node:22-alpine AS builder
 RUN apk add --no-cache libc6-compat openssl python3 make g++
 WORKDIR /app
@@ -66,6 +78,10 @@ COPY --from=builder /app/apps/web/public ./apps/web/public
 COPY --from=builder --chown=node:node /app/apps/web/prisma ./apps/web/prisma
 COPY --from=proddeps --chown=node:node /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=proddeps --chown=node:node /app/node_modules/@prisma ./node_modules/@prisma
+
+# Self-contained Prisma CLI for the entrypoint schema push (db push). Calling
+# it directly avoids the unreliable runtime `npx prisma` registry fetch.
+COPY --from=prismacli --chown=node:node /pcli/node_modules /app/prisma-cli/node_modules
 
 # Runtime packages that standalone trace misses (dynamic imports in cron callbacks)
 COPY --from=proddeps --chown=node:node /app/node_modules/ioredis ./node_modules/ioredis

--- a/apps/web/src/app/api/cron/scrape/route.test.ts
+++ b/apps/web/src/app/api/cron/scrape/route.test.ts
@@ -3,10 +3,15 @@ import { NextRequest } from 'next/server';
 
 const mockRunScrapeAll = vi.fn();
 const mockCleanup = vi.fn();
+const mockExpire = vi.fn().mockResolvedValue(0);
 
 vi.mock('@/lib/scraper/run-scrape', () => ({
   runScrapeAll: () => mockRunScrapeAll(),
   cleanupUnvisitedQueries: () => mockCleanup(),
+}));
+
+vi.mock('@/lib/scraper/expire-queries', () => ({
+  expireDepartedQueries: () => mockExpire(),
 }));
 
 import { GET } from './route';
@@ -30,6 +35,7 @@ describe('GET /api/cron/scrape', () => {
 
   it('runs scrape and returns summary on valid auth', async () => {
     mockCleanup.mockResolvedValue(2);
+    mockExpire.mockResolvedValue(4);
     mockRunScrapeAll.mockResolvedValue([
       { status: 'success', snapshotsCount: 5, extractionCost: 0.01 },
       { status: 'failed', snapshotsCount: 0, extractionCost: 0 },
@@ -43,6 +49,7 @@ describe('GET /api/cron/scrape', () => {
     expect(body.data.successful).toBe(1);
     expect(body.data.failed).toBe(1);
     expect(body.data.totalSnapshots).toBe(5);
+    expect(body.data.expiredDeparted).toBe(4);
   });
 
   it('includes cleanup count in response', async () => {

--- a/apps/web/src/app/api/cron/scrape/route.ts
+++ b/apps/web/src/app/api/cron/scrape/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { runScrapeAll, cleanupUnvisitedQueries } from '@/lib/scraper/run-scrape';
+import { expireDepartedQueries } from '@/lib/scraper/expire-queries';
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization');
@@ -12,6 +13,9 @@ export async function GET(request: NextRequest) {
 
   // Clean up queries never visited within 24h
   const deletedUnvisited = await cleanupUnvisitedQueries();
+
+  // Deactivate trackers whose departure day has already passed
+  const expiredDeparted = await expireDepartedQueries();
 
   let results;
   try {
@@ -25,6 +29,7 @@ export async function GET(request: NextRequest) {
 
   const summary = {
     deletedUnvisited,
+    expiredDeparted,
     queriesProcessed: results.length,
     successful: results.filter((r) => r.status === 'success').length,
     partial: results.filter((r) => r.status === 'partial').length,

--- a/apps/web/src/lib/cron.ts
+++ b/apps/web/src/lib/cron.ts
@@ -52,15 +52,17 @@ async function runAndReschedule() {
   console.log(`[cron] Starting scheduled scrape...`);
   try {
     const { runScrapeAll, cleanupUnvisitedQueries } = await import('./scraper/run-scrape');
+    const { expireDepartedQueries } = await import('./scraper/expire-queries');
 
     await cleanupUnvisitedQueries();
+    const expired = await expireDepartedQueries();
     const results = await runScrapeAll();
     lastScrapeAt = new Date();
 
     const successful = results.filter((r) => r.status === 'success').length;
     const failed = results.filter((r) => r.status === 'failed').length;
     const snapshots = results.reduce((sum, r) => sum + r.snapshotsCount, 0);
-    console.log(`[cron] Scrape complete: ${successful} ok, ${failed} failed, ${snapshots} snapshots`);
+    console.log(`[cron] Scrape complete: ${successful} ok, ${failed} failed, ${snapshots} snapshots, ${expired} expired`);
   } catch (err) {
     console.error('[cron] Scrape failed:', err instanceof Error ? err.message : err);
   }

--- a/apps/web/src/lib/scraper/expire-queries.test.ts
+++ b/apps/web/src/lib/scraper/expire-queries.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockUpdateMany } = vi.hoisted(() => ({ mockUpdateMany: vi.fn() }));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { query: { updateMany: mockUpdateMany } },
+}));
+
+import { expireDepartedQueries } from './expire-queries';
+
+interface UpdateManyArgs {
+  where: { active: boolean; isSeed: boolean; dateFrom: { lt: Date } };
+  data: { active: boolean };
+}
+
+describe('expireDepartedQueries', () => {
+  beforeEach(() => mockUpdateMany.mockReset());
+
+  it('deactivates only active non seed trackers whose departure day has passed', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 3 });
+
+    const count = await expireDepartedQueries();
+    expect(count).toBe(3);
+
+    const args = mockUpdateMany.mock.calls[0]![0] as UpdateManyArgs;
+    expect(args.where.active).toBe(true);
+    expect(args.where.isSeed).toBe(false);
+    expect(args.data.active).toBe(false);
+
+    // Cutoff is midnight UTC today, so a tracker departing today is not swept.
+    const cutoff = args.where.dateFrom.lt;
+    expect(cutoff).toBeInstanceOf(Date);
+    expect(cutoff.getUTCHours()).toBe(0);
+    expect(cutoff.getUTCMinutes()).toBe(0);
+    expect(cutoff.getUTCSeconds()).toBe(0);
+    expect(cutoff.getUTCMilliseconds()).toBe(0);
+  });
+
+  it('returns zero when nothing has departed', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+    expect(await expireDepartedQueries()).toBe(0);
+  });
+});

--- a/apps/web/src/lib/scraper/expire-queries.ts
+++ b/apps/web/src/lib/scraper/expire-queries.ts
@@ -1,0 +1,18 @@
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Deactivate trackers whose departure day has already passed. A trip is
+ * unbookable once its outbound (dateFrom) date is in the past, so there is no
+ * point scraping it. The cutoff is midnight UTC today, so a flight departing
+ * today survives until tomorrow. Seeds are left alone (they have no real
+ * departure). Returns the number of trackers expired.
+ */
+export async function expireDepartedQueries(): Promise<number> {
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+  const result = await prisma.query.updateMany({
+    where: { active: true, isSeed: false, dateFrom: { lt: todayStart } },
+    data: { active: false },
+  });
+  return result.count;
+}

--- a/apps/web/src/test/llmock-setup.ts
+++ b/apps/web/src/test/llmock-setup.ts
@@ -3,24 +3,47 @@
  * calls that escape vi.mock(). This prevents 401 errors from leaked API
  * requests during tests.
  */
+import net from 'node:net';
 import { LLMock } from '@copilotkit/llmock';
 
 const LLMOCK_PORT = 19876;
 
 let mock: LLMock | null = null;
 
+/** Resolve true when nothing is listening on the port yet. */
+function portIsFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = net
+      .createServer()
+      .once('error', () => resolve(false))
+      .once('listening', () => probe.close(() => resolve(true)))
+      .listen(port, '127.0.0.1');
+  });
+}
+
 export async function setup() {
-  mock = new LLMock({ port: LLMOCK_PORT });
+  // A killed test run (Ctrl+C, timeout) leaves the LLMock server orphaned on
+  // the fixed port. It is a static catch-all, so a leftover instance serves
+  // identically: reuse it rather than crashing the whole suite with an
+  // unhandled EADDRINUSE bind error. Pre-check instead of catching, because
+  // LLMock surfaces the failure as an async server 'error' event, not a
+  // rejected start() promise.
+  if (!(await portIsFree(LLMOCK_PORT))) return;
+
+  const instance = new LLMock({ port: LLMOCK_PORT });
 
   // Default fallback: return a valid but empty response for any unmatched request
-  mock.onMessage(/./, {
+  instance.onMessage(/./, {
     content: '[]',
   });
 
-  await mock.start();
+  await instance.start();
+  mock = instance;
 }
 
 export async function teardown() {
+  // Only stop the server this run actually started; a reused leftover is left
+  // alone for whoever owns it.
   if (mock) {
     await mock.stop();
     mock = null;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -55,14 +55,19 @@ done
 echo "[setup] Database is ready"
 
 # --- Run migrations ---
-# Pin prisma to the major version that matches the schema (currently v6).
-# Without the pin, `npx prisma` fetches whatever the npm registry serves
-# as latest, which broke deploys when Prisma 7 dropped `url = env(...)`.
-# A future Dockerfile change should bundle the CLI + transitive deps so
-# this stops round-tripping the registry entirely.
+# Use the Prisma CLI bundled into the image (see the prismacli stage in the
+# Dockerfile) instead of fetching it with npx at runtime, which round-trips the
+# registry and failed when it could not resolve the CLI. Run it directly and
+# honor the exit code so a failed push halts startup instead of masking the
+# error behind a misleading "Schema ready".
 echo "[setup] Applying database schema..."
-npx prisma@^6 db push --schema=apps/web/prisma/schema.prisma --skip-generate 2>&1 | tail -1
-echo "[setup] Schema ready"
+if node /app/prisma-cli/node_modules/prisma/build/index.js db push \
+     --schema=apps/web/prisma/schema.prisma --skip-generate; then
+  echo "[setup] Schema ready"
+else
+  echo "[setup] ERROR: database schema push failed" >&2
+  exit 1
+fi
 
 # --- Self-hosted only: CLI auth + install ---
 # Skip on production server (SELF_HOSTED=false) to save ~15s startup time.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run build --workspace=@flight-finder/web",
     "lint": "npm run lint --workspace=@flight-finder/web && npm run lint --workspace=@flight-finder/cli",
     "typecheck": "npm run typecheck --workspace=@flight-finder/web && npm run typecheck --workspace=@flight-finder/cli",
-    "test": "npm run test --workspace=@flight-finder/web",
+    "test": "npm run test --workspace=@flight-finder/web && npm run test --workspace=@flight-finder/cli",
     "cli": "doppler run -- node --import tsx/esm --import ./packages/cli/register.mjs packages/cli/src/index.tsx --headless",
     "cli:dev": "npm run dev --workspace=@flight-finder/cli",
     "ci": "npm run lint && npm run typecheck && npm run test && npm run build && npm run build --workspace=@flight-finder/cli",

--- a/packages/cli/src/__tests__/best-price.test.ts
+++ b/packages/cli/src/__tests__/best-price.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { pickBest, formatBookingLine, type BestPriceSnapshot } from '../lib/best-price.js';
+
+function snap(over: Partial<BestPriceSnapshot> = {}): BestPriceSnapshot {
+  return {
+    price: 100,
+    currency: 'USD',
+    airline: 'TestAir',
+    stops: 0,
+    duration: null,
+    bookingUrl: null,
+    scrapedAt: new Date('2026-06-01T00:00:00Z'),
+    ...over,
+  };
+}
+
+describe('pickBest', () => {
+  it('returns the lowest priced snapshot', () => {
+    const best = pickBest([
+      snap({ price: 300, airline: 'A' }),
+      snap({ price: 120, airline: 'B' }),
+      snap({ price: 250, airline: 'C' }),
+    ]);
+    expect(best?.price).toBe(120);
+    expect(best?.airline).toBe('B');
+  });
+
+  it('returns null when there are no snapshots', () => {
+    expect(pickBest([])).toBeNull();
+  });
+});
+
+describe('formatBookingLine', () => {
+  it('keeps the full booking url instead of truncating it', () => {
+    // Regression for issue 96: the card sliced the url to 33 chars, producing
+    // an incomplete link that 404s. The full url must survive intact.
+    const url = 'https://www.google.com/travel/flights/booking?tfs=' + 'A'.repeat(80);
+    expect(formatBookingLine(url)).toBe(`Book: ${url}`);
+  });
+
+  it('returns null when there is no booking url', () => {
+    expect(formatBookingLine(null)).toBeNull();
+  });
+});

--- a/packages/cli/src/__tests__/create-queries.test.ts
+++ b/packages/cli/src/__tests__/create-queries.test.ts
@@ -11,6 +11,10 @@ vi.mock('@/lib/prisma', () => ({
   prisma: {
     query: { create: mockQueryCreate },
     priceSnapshot: { createMany: mockSnapshotCreateMany },
+    // resolveOwnerId() reads the singleton config; solo mode (multiUserMode
+    // false) short circuits before any user lookup, leaving trackers unowned.
+    extractionConfig: { findUnique: vi.fn().mockResolvedValue({ multiUserMode: false }) },
+    user: { findFirst: vi.fn().mockResolvedValue(null) },
   },
 }));
 

--- a/packages/cli/src/__tests__/json-output.test.ts
+++ b/packages/cli/src/__tests__/json-output.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockFindUnique, mockFindMany } = vi.hoisted(() => ({
+  mockFindUnique: vi.fn(),
+  mockFindMany: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    query: { findUnique: mockFindUnique, findMany: mockFindMany },
+    $disconnect: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { getQueryJson, getQueryListJson } from '../lib/json-output.js';
+
+const FAR_FUTURE = new Date('2099-12-31T00:00:00Z');
+const PAST_DAY = new Date('2020-01-01T00:00:00Z');
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    id: 'q1',
+    origin: 'JFK',
+    originName: 'New York JFK',
+    destination: 'LHR',
+    destinationName: 'London Heathrow',
+    dateFrom: new Date('2099-07-01T00:00:00Z'),
+    dateTo: new Date('2099-07-14T00:00:00Z'),
+    tripType: 'round_trip',
+    cabinClass: 'economy',
+    currency: 'USD',
+    active: true,
+    expiresAt: FAR_FUTURE,
+    snapshots: [],
+    fetchRuns: [],
+    ...over,
+  };
+}
+
+function snap(over: Record<string, unknown> = {}) {
+  return {
+    price: 600,
+    currency: 'USD',
+    airline: 'Delta',
+    stops: 0,
+    duration: '7h',
+    bookingUrl: 'https://book/x',
+    travelDate: new Date('2099-07-01T00:00:00Z'),
+    scrapedAt: new Date('2026-06-01T09:00:00Z'),
+    ...over,
+  };
+}
+
+describe('getQueryJson', () => {
+  beforeEach(() => mockFindUnique.mockReset());
+
+  it('returns null when the tracker does not exist', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    expect(await getQueryJson('nope')).toBeNull();
+  });
+
+  it('includes iata codes, best price as the minimum, and the full booking url', async () => {
+    const longUrl = 'https://www.delta.com/booking?tfs=' + 'y'.repeat(80);
+    mockFindUnique.mockResolvedValue(
+      row({
+        snapshots: [
+          snap({ price: 700, airline: 'United', bookingUrl: 'https://united/x' }),
+          snap({ price: 540, airline: 'Delta', bookingUrl: longUrl }),
+        ],
+        fetchRuns: [{ startedAt: new Date('2026-06-01T09:00:00Z') }],
+      }),
+    );
+
+    const data = await getQueryJson('q1');
+    expect(data?.origin).toBe('JFK');
+    expect(data?.destination).toBe('LHR');
+    expect(data?.bestPrice?.price).toBe(540);
+    expect(data?.bestPrice?.airline).toBe('Delta');
+    expect(data?.bestPrice?.bookingUrl).toBe(longUrl);
+    expect(data?.snapshotCount).toBe(2);
+    expect(data?.expired).toBe(false);
+    expect(data?.lastScraped).toBe('2026-06-01T09:00:00.000Z');
+    expect(typeof data?.dateFrom).toBe('string');
+  });
+
+  it('marks a tracker whose departure day has passed as expired', async () => {
+    mockFindUnique.mockResolvedValue(row({ dateFrom: PAST_DAY, dateTo: PAST_DAY }));
+    const data = await getQueryJson('q1');
+    expect(data?.expired).toBe(true);
+  });
+});
+
+describe('getQueryListJson', () => {
+  beforeEach(() => mockFindMany.mockReset());
+
+  it('returns summaries with computed min and max prices', async () => {
+    mockFindMany.mockResolvedValue([
+      row({ id: 'a', snapshots: [{ price: 120 }, { price: 250 }, { price: 340 }] }),
+    ]);
+    const list = await getQueryListJson();
+    expect(list).toHaveLength(1);
+    expect(list[0]!.id).toBe('a');
+    expect(list[0]!.snapshotCount).toBe(3);
+    expect(list[0]!.minPrice).toBe(120);
+    expect(list[0]!.maxPrice).toBe(340);
+  });
+
+  it('reports null prices when a tracker has no snapshots', async () => {
+    mockFindMany.mockResolvedValue([row({ id: 'b', snapshots: [] })]);
+    const list = await getQueryListJson();
+    expect(list[0]!.minPrice).toBeNull();
+    expect(list[0]!.maxPrice).toBeNull();
+  });
+});

--- a/packages/cli/src/components/BestPriceCard.tsx
+++ b/packages/cli/src/components/BestPriceCard.tsx
@@ -1,32 +1,42 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { formatCurrency, formatStops } from '../lib/format.js';
-
-interface Snapshot {
-  price: number;
-  currency: string;
-  airline: string;
-  stops: number;
-  duration: string | null;
-  bookingUrl: string | null;
-  scrapedAt: Date;
-}
+import { pickBest, formatBookingLine, type BestPriceSnapshot } from '../lib/best-price.js';
 
 interface BestPriceCardProps {
-  snapshots: Snapshot[];
+  snapshots: BestPriceSnapshot[];
 }
 
 export function BestPriceCard({ snapshots }: BestPriceCardProps) {
-  if (snapshots.length === 0) return null;
+  const best = pickBest(snapshots);
+  if (!best) return null;
 
-  const best = snapshots.reduce((min, s) => (s.price < min.price ? s : min), snapshots[0]!);
+  const bookingLine = formatBookingLine(best.bookingUrl);
 
+  // The box hugs its content (alignSelf flex-start) and only ever holds short
+  // lines, so ink keeps the border aligned. The booking url renders below the
+  // box as its own line: a long url wraps naturally instead of blowing out the
+  // border, and stays copyable in full.
   return (
     <Box flexDirection="column">
-      <Text color="cyan">{'┌─ Best Price ─────────────────────────┐'}</Text>
-      <Text color="cyan">{'│'} <Text color="green" bold>{formatCurrency(best.price, best.currency)}</Text>{'  '}<Text color="white">{best.airline}</Text>{' · '}<Text dimColor>{formatStops(best.stops)}</Text>{best.duration ? ` · ${best.duration}` : ''}{'                                      '.slice(0, Math.max(0, 36 - formatCurrency(best.price, best.currency).length - best.airline.length - formatStops(best.stops).length - (best.duration?.length ?? 0) - 7))}<Text color="cyan">{'│'}</Text></Text>
-      {best.bookingUrl && <Text color="cyan">{'│'} <Text dimColor>Book: {best.bookingUrl.slice(0, 33)}</Text><Text color="cyan">{' │'}</Text></Text>}
-      <Text color="cyan">{'└──────────────────────────────────────┘'}</Text>
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor="cyan"
+        paddingX={1}
+        alignSelf="flex-start"
+      >
+        <Text bold color="cyan">Best Price</Text>
+        <Text>
+          <Text color="green" bold>{formatCurrency(best.price, best.currency)}</Text>
+          {'  '}
+          <Text color="white">{best.airline}</Text>
+          {' · '}
+          <Text dimColor>{formatStops(best.stops)}</Text>
+          {best.duration ? <Text dimColor>{` · ${best.duration}`}</Text> : null}
+        </Text>
+      </Box>
+      {bookingLine && <Text dimColor>{bookingLine}</Text>}
     </Box>
   );
 }

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -16,11 +16,12 @@ program
   .option('--list', 'Show all tracked queries (web) or with --headless (terminal)')
   .option('--view <id>', 'View price chart (web) or with --headless (terminal)')
   .option('--tmux', 'Split grouped routes into tmux panes (requires --headless --view)')
+  .option('--json', 'Output JSON: with --view <id> one tracker, otherwise the full list')
   .option('--backend <provider>', 'AI backend: claude-code, codex, anthropic, openai, google')
   .option('--model <model>', 'Model override (e.g. sonnet, opus, gpt-4.1-mini, codex)')
   .parse();
 
-const opts = program.opts() as { headless?: boolean; list?: boolean; view?: string; tmux?: boolean; backend?: string; model?: string };
+const opts = program.opts() as { headless?: boolean; list?: boolean; view?: string; tmux?: boolean; json?: boolean; backend?: string; model?: string };
 
 const baseUrl = process.env.FLIGHT_FINDER_URL
   ?? `http://localhost:${process.env.HOST_PORT ?? process.env.PORT ?? '3003'}`;
@@ -62,7 +63,16 @@ if (opts.tmux && !opts.view) {
   process.exit(1);
 }
 
-if (opts.headless) {
+if (opts.json) {
+  // Machine readable output for automation. Bypasses ink and the browser; the
+  // helper prints to stdout and exits.
+  import('./lib/json-output.js')
+    .then(({ runJson }) => runJson({ view: opts.view }))
+    .catch((err) => {
+      console.error(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+      process.exit(1);
+    });
+} else if (opts.headless) {
   // Terminal UI mode
   if (opts.view && opts.tmux) {
     launchTmuxView(opts.view).catch((err) => {

--- a/packages/cli/src/lib/best-price.ts
+++ b/packages/cli/src/lib/best-price.ts
@@ -1,0 +1,27 @@
+// Pure helpers for the Best Price card. Kept out of the .tsx so the unit test
+// imports plain TypeScript and vitest never has to transpile JSX.
+
+export interface BestPriceSnapshot {
+  price: number;
+  currency: string;
+  airline: string;
+  stops: number;
+  duration: string | null;
+  bookingUrl: string | null;
+  scrapedAt: Date;
+}
+
+/** Lowest priced snapshot, or null when there is nothing to show. */
+export function pickBest(snapshots: BestPriceSnapshot[]): BestPriceSnapshot | null {
+  if (snapshots.length === 0) return null;
+  return snapshots.reduce((min, s) => (s.price < min.price ? s : min), snapshots[0]!);
+}
+
+/**
+ * Full booking line for the card, or null when there is no url. The url is
+ * never truncated: a sliced link is an incomplete link that 404s (issue 96).
+ */
+export function formatBookingLine(url: string | null): string | null {
+  if (!url) return null;
+  return `Book: ${url}`;
+}

--- a/packages/cli/src/lib/json-output.ts
+++ b/packages/cli/src/lib/json-output.ts
@@ -1,0 +1,194 @@
+// Machine readable output for automation: `--json` with `--view <id>` dumps a
+// single tracker, otherwise the whole list. Plain TypeScript (no JSX) so the
+// pure getters are unit testable by mocking the prisma client.
+import { prisma } from '@/lib/prisma';
+
+export interface JsonSnapshot {
+  price: number;
+  currency: string;
+  airline: string;
+  stops: number;
+  duration: string | null;
+  bookingUrl: string | null;
+  travelDate: string;
+  scrapedAt: string;
+}
+
+export interface JsonBestPrice {
+  price: number;
+  currency: string;
+  airline: string;
+  stops: number;
+  duration: string | null;
+  bookingUrl: string | null;
+}
+
+export interface JsonQuery {
+  id: string;
+  origin: string;
+  originName: string;
+  destination: string;
+  destinationName: string;
+  dateFrom: string;
+  dateTo: string;
+  tripType: string;
+  cabinClass: string;
+  currency: string | null;
+  active: boolean;
+  expired: boolean;
+  expiresAt: string;
+  lastScraped: string | null;
+  snapshotCount: number;
+  bestPrice: JsonBestPrice | null;
+  snapshots: JsonSnapshot[];
+}
+
+export interface JsonQuerySummary {
+  id: string;
+  origin: string;
+  originName: string;
+  destination: string;
+  destinationName: string;
+  dateFrom: string;
+  dateTo: string;
+  currency: string | null;
+  active: boolean;
+  expired: boolean;
+  expiresAt: string;
+  lastScraped: string | null;
+  snapshotCount: number;
+  minPrice: number | null;
+  maxPrice: number | null;
+}
+
+// A tracker is no longer live once it is paused, past its expiry, or its
+// departure day has passed. Mirrors the list screen and the scrape sweep.
+function isExpired(dateFrom: Date, expiresAt: Date, active: boolean): boolean {
+  const now = new Date();
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+  return !active || expiresAt <= now || dateFrom < todayStart;
+}
+
+export async function getQueryJson(id: string): Promise<JsonQuery | null> {
+  const row = await prisma.query.findUnique({
+    where: { id },
+    include: {
+      snapshots: {
+        where: { status: 'available' },
+        orderBy: { scrapedAt: 'desc' },
+      },
+      fetchRuns: {
+        orderBy: { startedAt: 'desc' },
+        take: 1,
+        select: { startedAt: true },
+      },
+    },
+  });
+  if (!row) return null;
+
+  const snapshots = row.snapshots;
+  const best = snapshots.length > 0
+    ? snapshots.reduce((min, s) => (s.price < min.price ? s : min), snapshots[0]!)
+    : null;
+
+  return {
+    id: row.id,
+    origin: row.origin,
+    originName: row.originName,
+    destination: row.destination,
+    destinationName: row.destinationName,
+    dateFrom: row.dateFrom.toISOString(),
+    dateTo: row.dateTo.toISOString(),
+    tripType: row.tripType,
+    cabinClass: row.cabinClass,
+    currency: row.currency,
+    active: row.active,
+    expired: isExpired(row.dateFrom, row.expiresAt, row.active),
+    expiresAt: row.expiresAt.toISOString(),
+    lastScraped: row.fetchRuns[0]?.startedAt.toISOString() ?? null,
+    snapshotCount: snapshots.length,
+    bestPrice: best
+      ? {
+          price: best.price,
+          currency: best.currency,
+          airline: best.airline,
+          stops: best.stops,
+          duration: best.duration,
+          bookingUrl: best.bookingUrl,
+        }
+      : null,
+    snapshots: snapshots.map((s) => ({
+      price: s.price,
+      currency: s.currency,
+      airline: s.airline,
+      stops: s.stops,
+      duration: s.duration,
+      bookingUrl: s.bookingUrl,
+      travelDate: s.travelDate.toISOString(),
+      scrapedAt: s.scrapedAt.toISOString(),
+    })),
+  };
+}
+
+export async function getQueryListJson(): Promise<JsonQuerySummary[]> {
+  const rows = await prisma.query.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      snapshots: {
+        where: { status: 'available' },
+        orderBy: { price: 'asc' },
+        select: { price: true },
+      },
+      fetchRuns: {
+        orderBy: { startedAt: 'desc' },
+        take: 1,
+        select: { startedAt: true },
+      },
+    },
+  });
+
+  return rows.map((r) => ({
+    id: r.id,
+    origin: r.origin,
+    originName: r.originName,
+    destination: r.destination,
+    destinationName: r.destinationName,
+    dateFrom: r.dateFrom.toISOString(),
+    dateTo: r.dateTo.toISOString(),
+    currency: r.currency,
+    active: r.active,
+    expired: isExpired(r.dateFrom, r.expiresAt, r.active),
+    expiresAt: r.expiresAt.toISOString(),
+    lastScraped: r.fetchRuns[0]?.startedAt.toISOString() ?? null,
+    snapshotCount: r.snapshots.length,
+    minPrice: r.snapshots.length > 0 ? r.snapshots[0]!.price : null,
+    maxPrice: r.snapshots.length > 0 ? r.snapshots[r.snapshots.length - 1]!.price : null,
+  }));
+}
+
+/**
+ * Print tracker JSON to stdout and exit. With a view id, dumps that one
+ * tracker (exit 1 and a stderr error if it is missing); otherwise dumps the
+ * full list. Never renders ink or opens a browser.
+ */
+export async function runJson(opts: { view?: string }): Promise<void> {
+  let exitCode = 0;
+  try {
+    if (opts.view) {
+      const data = await getQueryJson(opts.view);
+      if (data) {
+        console.log(JSON.stringify(data, null, 2));
+      } else {
+        console.error(JSON.stringify({ error: `Tracker "${opts.view}" not found` }));
+        exitCode = 1;
+      }
+    } else {
+      const list = await getQueryListJson();
+      console.log(JSON.stringify(list, null, 2));
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+  process.exit(exitCode);
+}

--- a/packages/cli/src/screens/QueryList.tsx
+++ b/packages/cli/src/screens/QueryList.tsx
@@ -108,6 +108,10 @@ export function QueryList({ onView }: QueryListProps) {
     );
   }
 
+  const now = new Date();
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
@@ -128,8 +132,11 @@ export function QueryList({ onView }: QueryListProps) {
         const isCursor = i === cursor;
         const route = `${q.origin} → ${q.destination}`;
         const dates = `${formatDate(q.dateFrom)} – ${formatDate(q.dateTo)}`;
-        const isExpired = q.expiresAt && q.expiresAt < new Date();
-        const status = !q.active ? 'Paused' : isExpired ? 'Expired' : 'Active';
+        // Departure passed means the trip is unbookable; show Expired even if
+        // the scrape sweep has not yet flipped active to false.
+        const departed = q.dateFrom < todayStart;
+        const isExpired = departed || (q.expiresAt !== null && q.expiresAt < now);
+        const status = isExpired ? 'Expired' : !q.active ? 'Paused' : 'Active';
         const statusColor = status === 'Active' ? 'green' : status === 'Expired' ? 'red' : 'yellow';
         const lastScraped = q.lastScraped ? formatTimeAgo(q.lastScraped) : '—';
         const prices = q.minPrice !== null && q.maxPrice !== null

--- a/packages/cli/src/screens/QueryView.tsx
+++ b/packages/cli/src/screens/QueryView.tsx
@@ -240,8 +240,10 @@ export function QueryView({ id, onBack }: QueryViewProps) {
     <Box flexDirection="column">
       <Box marginBottom={1}>
         <Text bold color="white">{query.originName}</Text>
+        <Text dimColor>{` (${query.origin})`}</Text>
         <Text color="cyan">{' → '}</Text>
         <Text bold color="white">{query.destinationName}</Text>
+        <Text dimColor>{` (${query.destination})`}</Text>
         <Text dimColor>{'  '}{formatDate(query.dateFrom)} – {formatDate(query.dateTo)}</Text>
         {newDataFlash && <Text color="green" bold>{'  ● NEW DATA'}</Text>}
       </Box>

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -224,28 +224,45 @@ test_install_supports_arch_family() {
 }
 
 # ---------------------------------------------------------------------------
-# Test: docker-entrypoint.sh pins the prisma major version
-# Regression test against the v0.5.2 deploy: `npx prisma` (no version)
-# in the runtime entrypoint round-trips to the npm registry every startup
-# and Prisma 7 dropped `url = env("DATABASE_URL")`, breaking schema
-# parsing on every startup until pinned.
+# Test: the runtime entrypoint applies the schema with the BUNDLED prisma CLI
+# Regression test against the v0.5.2 deploy: `npx prisma` in the runtime
+# entrypoint round-trips to the npm registry every startup, and Prisma 7
+# dropped `url = env("DATABASE_URL")`, breaking schema parsing until pinned.
+# A later regression: even pinned `npx prisma@^6` failed to resolve the CLI at
+# runtime (`sh: prisma: not found`), so the schema was never applied.
 #
-# Bundling the CLI in the runtime image is the proper fix but requires
-# also bundling its transitive deps (effect, @prisma/config, ...). Until
-# that lands, the version pin is the cheap insurance.
+# The fix bundles the CLI in the image (the `prismacli` Dockerfile stage) and
+# the entrypoint runs it directly. This test enforces that invariant: no
+# runtime `npx prisma`, and the bundled CLI pinned to a major so it never
+# silently jumps to a new one.
 # ---------------------------------------------------------------------------
-test_entrypoint_pins_prisma_major() {
+test_entrypoint_uses_bundled_pinned_prisma() {
   local entrypoint="docker-entrypoint.sh"
-  local code_only
+  local dockerfile="Dockerfile"
+  local code_only docker_code
   code_only=$(grep -vE '^\s*#' "$entrypoint")
-  if printf '%s\n' "$code_only" | grep -qE 'npx prisma@(\^|~)?[0-9]'; then
-    pass "docker-entrypoint.sh pins the prisma major version"
+  docker_code=$(grep -vE '^\s*#' "$dockerfile")
+
+  # Entrypoint applies the schema with the bundled CLI, not a runtime fetch.
+  if printf '%s\n' "$code_only" | grep -qE 'prisma-cli/node_modules/prisma/build/index\.js'; then
+    pass "docker-entrypoint.sh applies the schema with the bundled prisma CLI"
   else
-    fail "docker-entrypoint.sh must pin prisma (e.g. 'npx prisma@^6 db push'), never run unpinned 'npx prisma'"
+    fail "docker-entrypoint.sh must run the bundled prisma CLI (/app/prisma-cli/.../build/index.js) for db push"
   fi
-  # Specifically forbid unpinned 'npx prisma' (no @version) inside code.
-  if printf '%s\n' "$code_only" | grep -qE 'npx prisma( |$)'; then
-    fail "docker-entrypoint.sh contains unpinned 'npx prisma' which silently picks up new majors"
+
+  # Forbid any runtime 'npx prisma' (pinned or not) — it round-trips the registry.
+  if printf '%s\n' "$code_only" | grep -qE 'npx +prisma'; then
+    fail "docker-entrypoint.sh must not run 'npx prisma' at runtime; use the bundled CLI"
+  fi
+
+  # The bundled CLI must be pinned to a major in the prismacli stage.
+  if printf '%s\n' "$docker_code" | grep -qE 'npm install .*prisma@(\^|~)?[0-9]'; then
+    pass "Dockerfile pins the bundled prisma CLI to a major version"
+  else
+    fail "Dockerfile prismacli stage must pin prisma (e.g. 'npm install ... prisma@6')"
+  fi
+  if printf '%s\n' "$docker_code" | grep -qE 'prisma@latest'; then
+    fail "Dockerfile must not install prisma@latest (silently picks up new majors)"
   fi
 }
 
@@ -392,7 +409,7 @@ test_cli_has_cmd_tui
 test_install_supports_no_browser
 test_dockerfile_ships_cli
 test_install_supports_arch_family
-test_entrypoint_pins_prisma_major
+test_entrypoint_uses_bundled_pinned_prisma
 test_compose_exec_flags_matrix
 test_cmd_tui_uses_helper
 test_no_raw_it_flags_in_dc_exec


### PR DESCRIPTION
Follow ups from the report on #96. The original fix landed in #98 and the reporter confirmed it works, then listed five more things.

What this does:

1. Docker: ship the cli package.json next to dist so node sees type:module and stops printing the MODULE_TYPELESS_PACKAGE_JSON warning (and reparsing the bundle as ESM) on every run.
2. Best Price card: rebuilt on an ink bordered box that hugs its content, so the border stays aligned whatever the values are. The booking url is no longer sliced to 33 chars, so the link is complete and does not 404. The full url renders on its own line below the box where it wraps cleanly and stays copyable.
3. Headless view header now shows the iata codes next to the city names.
4. New --json flag. `--view <id> --json` dumps one tracker (metadata, codes, iso dates, an expired flag, best price, every available snapshot with full booking urls). `--json` alone dumps a summary of every tracker. Prints to stdout and exits, no ink, no browser.
5. Trackers expire once their departure day has passed. A new sweep deactivates active non seed trackers whose dateFrom is before midnight utc today, on every scrape pass from the cron route and the in process scheduler. The list shows them as Expired.

Also in here, because the new tests needed it:

* The cli vitest suite was never run by CI and had gone red on a stale prisma mock. Wired it into the workflow and root npm test, and fixed the mock.
* The global test setup crashed the whole suite when its fixed mock llm port was already bound (an orphan from a killed run). It now reuses a leftover instead of failing.

Tests: unit tests for best price selection and the untruncated url, the json getters, and the expire sweep, plus a cron route assertion. Full ci green.

Not exercised locally: a live --json against a real db, and a full image build. Both are covered by the pre release docker smoke test.
