### PR TITLE
Rebrand the TUI header and sweep stale fairtrail strings

### DIFF
--- a/apps/web/public/flight-finder-cli
+++ b/apps/web/public/flight-finder-cli
@@ -242,7 +242,7 @@ cmd_stop() {
   dc stop 2>/dev/null
   printf "${GREEN}${BOLD}✓${RESET} Stopped\n"
   printf "  ${YELLOW}Price tracking is paused — no scrapes will run until you start again.${RESET}\n"
-  printf "  ${DIM}Your data and queries are saved. Run 'fairtrail' to resume.${RESET}\n"
+  printf "  ${DIM}Your data and queries are saved. Run 'flightfinder' to resume.${RESET}\n"
 }
 
 cmd_logs() {
@@ -256,7 +256,7 @@ cmd_status() {
     printf "${GREEN}${BOLD}✓${RESET} Flight Finder is running at ${BOLD}http://localhost:${PORT}${RESET}\n"
     show_tracking_info
   else
-    printf "${DIM}Flight Finder is not running. Start with: fairtrail${RESET}\n"
+    printf "${DIM}Flight Finder is not running. Start with: flightfinder${RESET}\n"
   fi
 }
 
@@ -335,7 +335,7 @@ cmd_search() {
   local health
   health=$(fetch_health)
   if [ -z "$health" ]; then
-    printf "${RED}${BOLD}✗${RESET} Flight Finder is not running. Start with: fairtrail\n"
+    printf "${RED}${BOLD}✗${RESET} Flight Finder is not running. Start with: flightfinder\n"
     exit 1
   fi
 
@@ -494,9 +494,9 @@ cmd_version() {
     local ver commit
     ver=$(echo "$version_json" | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['current'])" 2>/dev/null)
     commit=$(echo "$version_json" | python3 -c "import json,sys; print(json.load(sys.stdin)['data'].get('commit','unknown'))" 2>/dev/null)
-    printf "fairtrail ${BOLD}%s${RESET} ${DIM}(%s)${RESET}\n" "$ver" "${commit:0:7}"
+    printf "flightfinder ${BOLD}%s${RESET} ${DIM}(%s)${RESET}\n" "$ver" "${commit:0:7}"
   else
-    printf "fairtrail ${DIM}(not running — start with: fairtrail)${RESET}\n"
+    printf "flightfinder ${DIM}(not running — start with: flightfinder)${RESET}\n"
   fi
 }
 
@@ -533,7 +533,7 @@ cmd_tui() {
   local health
   health=$(fetch_health)
   if [ -z "$health" ]; then
-    printf "${RED}${BOLD}✗${RESET} Flight Finder is not running. Start with: fairtrail\n"
+    printf "${RED}${BOLD}✗${RESET} Flight Finder is not running. Start with: flightfinder\n"
     exit 1
   fi
 

--- a/packages/cli/src/components/Header.tsx
+++ b/packages/cli/src/components/Header.tsx
@@ -13,12 +13,24 @@ export function Header() {
   const backend = process.env.FLIGHT_FINDER_BACKEND;
   const label = backend ? BACKEND_LABELS[backend] ?? backend : null;
 
+  // ink draws and sizes the border, so it stays aligned regardless of the
+  // brand, the optional backend label, or the ✈ glyph width. alignSelf keeps
+  // the box hugging its content instead of stretching the full terminal width.
   return (
-    <Box flexDirection="column" marginBottom={1}>
-      <Text color="cyan" bold>{'╔══════════════════════════════════════╗'}</Text>
-      <Text color="cyan" bold>{'║'}<Text color="cyan" bold>  ✈  </Text><Text color="white" bold>F A I R T R A I L</Text>{label ? <Text color="yellow" bold>{'  '}{label}</Text> : ''}{'              '.slice(0, label ? 14 - label.length : 14)}{'║'}</Text>
-      <Text color="cyan" bold>{'║'}<Text dimColor>  The price trail they don&apos;t show  </Text>{'║'}</Text>
-      <Text color="cyan" bold>{'╚══════════════════════════════════════╝'}</Text>
+    <Box
+      flexDirection="column"
+      borderStyle="double"
+      borderColor="cyan"
+      paddingX={1}
+      marginBottom={1}
+      alignSelf="flex-start"
+    >
+      <Box>
+        <Text color="cyan" bold>{'✈  '}</Text>
+        <Text color="white" bold>FLIGHT FINDER</Text>
+        {label ? <Text color="yellow" bold>{'  '}{label}</Text> : null}
+      </Box>
+      <Text dimColor>The price trail they don&apos;t show</Text>
     </Box>
   );
 }

--- a/packages/cli/src/e2e-test.ts
+++ b/packages/cli/src/e2e-test.ts
@@ -14,7 +14,7 @@ const RAW_INPUT = 'Frankfurt to Bogota December 2026 economy';
 
 async function main() {
   console.log('═══════════════════════════════════════');
-  console.log('  ✈  FAIRTRAIL E2E TEST');
+  console.log('  ✈  FLIGHT FINDER E2E TEST');
   console.log('  Frankfurt → Bogota, December 2026');
   console.log('═══════════════════════════════════════\n');
 
@@ -103,7 +103,7 @@ async function main() {
   console.log(chart);
   console.log('\n═══════════════════════════════════════');
   console.log('  ✓ E2E test complete');
-  console.log(`  View with: fairtrail --view ${queries[0]?.id}`);
+  console.log(`  View with: flightfinder --view ${queries[0]?.id}`);
   console.log('═══════════════════════════════════════');
 
   // Clean exit (close Prisma/Redis connections)

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -10,7 +10,7 @@ import { App } from './app.js';
 import { launchTmuxView } from './lib/tmux-view.js';
 
 program
-  .name('fairtrail')
+  .name('flightfinder')
   .description('The price trail airlines don\'t show you')
   .option('--headless', 'Terminal UI mode (required for CLI interaction)')
   .option('--list', 'Show all tracked queries (web) or with --headless (terminal)')
@@ -52,14 +52,14 @@ if (opts.backend) {
 // --tmux requires --headless
 if (opts.tmux && !opts.headless) {
   console.error('Error: --tmux requires --headless mode');
-  console.error('Usage: fairtrail --headless --view <id> --tmux');
+  console.error('Usage: flightfinder --headless --view <id> --tmux');
   process.exit(1);
 }
 
 // --tmux requires --view
 if (opts.tmux && !opts.view) {
   console.error('Error: --tmux requires --view <id>');
-  console.error('Usage: fairtrail --headless --view <id> --tmux');
+  console.error('Usage: flightfinder --headless --view <id> --tmux');
   process.exit(1);
 }
 

--- a/packages/cli/src/lib/tmux-view.ts
+++ b/packages/cli/src/lib/tmux-view.ts
@@ -1,7 +1,7 @@
 import { execSync, spawnSync, spawn } from 'child_process';
 import { prisma } from '@/lib/prisma';
 
-const SESSION_NAME = 'fairtrail-view';
+const SESSION_NAME = 'flightfinder-view';
 
 function tmux(...args: string[]): string {
   const result = spawnSync('tmux', args, { encoding: 'utf-8' });
@@ -34,10 +34,10 @@ function buildViewCommand(queryId: string): string {
   const cwd = process.cwd();
   const backend = process.env.FLIGHT_FINDER_BACKEND;
   const backendFlag = backend ? ` --backend ${backend}` : '';
-  // Use the fairtrail wrapper if on PATH, otherwise fall back to raw command
+  // Use the flightfinder wrapper if on PATH, otherwise fall back to raw command
   try {
-    execSync('which fairtrail', { stdio: 'ignore' });
-    return `cd ${cwd} && fairtrail --headless --view ${queryId}${backendFlag}`;
+    execSync('which flightfinder', { stdio: 'ignore' });
+    return `cd ${cwd} && flightfinder --headless --view ${queryId}${backendFlag}`;
   } catch {
     return `cd ${cwd} && doppler run -- node --import tsx/esm --import ./packages/cli/register.mjs packages/cli/src/index.tsx --headless --view ${queryId}${backendFlag}`;
   }

--- a/packages/cli/src/screens/QueryList.tsx
+++ b/packages/cli/src/screens/QueryList.tsx
@@ -103,7 +103,7 @@ export function QueryList({ onView }: QueryListProps) {
     return (
       <Box flexDirection="column">
         <Text dimColor>No tracked queries yet.</Text>
-        <Text dimColor>Run <Text color="white">fairtrail</Text> to search and track flights.</Text>
+        <Text dimColor>Run <Text color="white">flightfinder</Text> to search and track flights.</Text>
       </Box>
     );
   }

--- a/packages/cli/src/screens/SearchWizard.tsx
+++ b/packages/cli/src/screens/SearchWizard.tsx
@@ -257,8 +257,8 @@ export function SearchWizard() {
             ))}
           </Box>
           <Box marginTop={1} flexDirection="column">
-            <Text dimColor>View with: <Text color="white">fairtrail --view {'<id>'}</Text></Text>
-            <Text dimColor>List all:  <Text color="white">fairtrail --list</Text></Text>
+            <Text dimColor>View with: <Text color="white">flightfinder --view {'<id>'}</Text></Text>
+            <Text dimColor>List all:  <Text color="white">flightfinder --list</Text></Text>
           </Box>
         </Box>
       )}

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -429,7 +429,7 @@ test_helper_shipped_by_install_and_update() {
 # Run all tests
 # ---------------------------------------------------------------------------
 echo ""
-printf "${BOLD}Fairtrail install flow regression tests${RESET}\n"
+printf "${BOLD}Flight Finder install flow regression tests${RESET}\n"
 echo ""
 
 test_update_self_path


### PR DESCRIPTION
Follow up to #100 from the #96 thread. The reporter confirmed the booking url and json work, but flagged that another box is still misaligned and still shows the old fairtrail brand.

That box is the TUI header. Like the Best Price card before it, it drew its own border and padded a line with a slice keyed off the content width, so the top and bottom interiors never matched the content and the right border sat out of column. It also still read FAIRTRAIL.

What this does:

1. Rebuild the header on an ink bordered box that sizes itself, so it stays aligned with or without a backend label, and show FLIGHT FINDER.
2. Sweep the remaining stale fairtrail brand strings to flightfinder: the tui usage lines, the empty list and search wizard tips, the tmux pane command, the e2e banner, and the wrapper messages (start with, resume, version output).

The deprecated fairtrail alias is left intact on purpose: the install symlink, the deprecation notice, the command -v fallback, the usage alias list, and the ~/.fairtrail migration all still work and stay tested.

Verified the header visually by rendering the component to an image. Checks: cli typecheck and lint clean, 39 cli tests, install-flow 25/0, cli-runtime 109/0, migration 14/0. No image or schema change, so the docker smoke gate is unaffected.
