### PR TITLE
Add CLI account recovery for multi user mode lockout (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+* **CLI account recovery for multi user mode** (#102): two recovery commands for a self hosted admin who is locked out. `flight-finder reset-password <username> <new-password>` sets a known password for any user; `flight-finder disable-accounts` turns multi user mode off and clears the stored admin credential, dropping the instance back to solo self hosted mode where no login is required. Both run inside the web container against the live database. Until now the only escape from a forgotten multi user password was hand editing Postgres. Reported by @garrynutter.
+
 ## [0.9.5] - 2026-06-02
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,5 +129,12 @@ COPY --chown=node:node docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh
 USER node
 RUN flight-finder-tui --help >/dev/null
+# Guard: the recovery commands depend on tsup's `@`->apps/web/src alias inlining
+# the real admin-recovery into the bundle. If the typecheck/dev stub leaks in
+# instead, every recovery run would throw. Fail the build if its sentinel is
+# present.
+RUN if grep -q 'admin-recovery stub' /app/packages/cli/dist/index.js; then \
+      echo 'ERROR: admin-recovery stub leaked into the CLI bundle' >&2; exit 1; \
+    fi
 EXPOSE 3003
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -394,7 +394,8 @@ manage everyone else from `/admin/users`. `disable-accounts` flips multi
 user mode off and clears the stored admin credential, dropping the instance
 back to solo self hosted mode where no login is required at all. Your
 trackers survive either way. (The password you pass to `reset-password`
-lands in your shell history, so clear it afterward.)
+is visible in your shell history and in the host process list while the
+command runs, so treat it as throwaway and change it once you are back in.)
 
 Never enabled multi user mode and forgot the solo admin password instead?
 Set `ADMIN_PASSWORD` in `~/.flight-finder/.env` and restart.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ Commands:
   version      Show version and commit
   uninstall    Remove Flight Finder and all data
   help         Show this help
+
+Account recovery (self hosted multi user mode):
+  reset-password <username> <password>   Set a new password for a user
+  disable-accounts                       Turn multi user mode off (no login required)
 ```
 
 <details>
@@ -373,6 +377,27 @@ right person.
   admin creates accounts manually and resets passwords from the panel
 - It does **not** restrict cron, the headless CLI's read views, or
   share links — those work the same in both modes
+
+#### Locked out?
+
+Forgot the admin password, or want the accounts gone entirely? Two recovery
+commands run from the host. They exec inside the `web` container, so it has
+to be running:
+
+```bash
+flight-finder reset-password <username> <new-password>   # set a known password, keep accounts
+flight-finder disable-accounts                           # turn multi user mode off entirely
+```
+
+`reset-password` sets a new password for any user; log in with it, then
+manage everyone else from `/admin/users`. `disable-accounts` flips multi
+user mode off and clears the stored admin credential, dropping the instance
+back to solo self hosted mode where no login is required at all. Your
+trackers survive either way. (The password you pass to `reset-password`
+lands in your shell history, so clear it afterward.)
+
+Never enabled multi user mode and forgot the solo admin password instead?
+Set `ADMIN_PASSWORD` in `~/.flight-finder/.env` and restart.
 
 #### Screenshots
 

--- a/apps/web/public/flight-finder-cli
+++ b/apps/web/public/flight-finder-cli
@@ -519,6 +519,10 @@ cmd_help() {
   echo "    uninstall    Remove Flight Finder and all data"
   echo "    help         Show this help"
   echo ""
+  echo "  Account recovery (self hosted multi user mode):"
+  echo "    reset-password <username> <password>   Set a new password for a user"
+  echo "    disable-accounts                       Turn multi user mode off (no login required)"
+  echo ""
   echo "  Terminal UI flags (forwarded to flight-finder-tui inside the container):"
   echo "    --headless              Render the Ink terminal UI"
   echo "    --list                  List tracked queries (with --headless)"
@@ -550,6 +554,50 @@ cmd_tui() {
   exec $_DC $COMPOSE_FILES exec $exec_flags web flight-finder-tui "$@"
 }
 
+# Recover a locked out multi user mode account by setting a new password.
+# Runs the recovery path inside the container against the same DB.
+cmd_reset_password() {
+  local username="$1" newpass="$2"
+  if [ -z "$username" ] || [ -z "$newpass" ]; then
+    printf "${RED}${BOLD}✗${RESET} Usage: flight-finder reset-password <username> <new-password>\n"
+    printf "  ${DIM}The password is visible in your shell history; clear it afterward.${RESET}\n"
+    exit 1
+  fi
+
+  local health
+  health=$(fetch_health)
+  if [ -z "$health" ]; then
+    printf "${RED}${BOLD}✗${RESET} Flight Finder is not running. Start with: flightfinder\n"
+    exit 1
+  fi
+
+  # Same compose-flavor flag handling as cmd_tui (issue #72).
+  local stdin_tty stdout_tty exec_flags
+  [ -t 0 ] && stdin_tty=1 || stdin_tty=0
+  [ -t 1 ] && stdout_tty=1 || stdout_tty=0
+  exec_flags=$(_compose_exec_flags "$_DC" "$stdin_tty" "$stdout_tty")
+
+  exec $_DC $COMPOSE_FILES exec $exec_flags web flight-finder-tui --reset-password "$username" --new-password "$newpass"
+}
+
+# Turn multi user mode off entirely. Drops the self hosted instance back to solo
+# mode where no login is required, and clears the stored admin credential.
+cmd_disable_accounts() {
+  local health
+  health=$(fetch_health)
+  if [ -z "$health" ]; then
+    printf "${RED}${BOLD}✗${RESET} Flight Finder is not running. Start with: flightfinder\n"
+    exit 1
+  fi
+
+  local stdin_tty stdout_tty exec_flags
+  [ -t 0 ] && stdin_tty=1 || stdin_tty=0
+  [ -t 1 ] && stdout_tty=1 || stdout_tty=0
+  exec_flags=$(_compose_exec_flags "$_DC" "$stdin_tty" "$stdout_tty")
+
+  exec $_DC $COMPOSE_FILES exec $exec_flags web flight-finder-tui --disable-accounts
+}
+
 cmd_migrate() {
   printf "${CYAN}${BOLD}▸${RESET} Running Flight Finder migration...\n"
   if [ -d "$HOME/.fairtrail" ]; then
@@ -568,6 +616,8 @@ case "${1:-}" in
     printf "${YELLOW}${BOLD}!${RESET} --tmux is not supported in the production install. Use the dev mode CLI: npm run cli -- --tmux ...\n"
     exit 1 ;;
   search)    shift; cmd_search "$@" ;;
+  reset-password)   shift; cmd_reset_password "$@" ;;
+  disable-accounts) cmd_disable_accounts ;;
   start)     cmd_start_background ;;
   stop)      cmd_stop ;;
   logs)      cmd_logs ;;

--- a/apps/web/src/lib/admin-recovery.test.ts
+++ b/apps/web/src/lib/admin-recovery.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/prisma', () => ({
       update: vi.fn().mockResolvedValue({}),
     },
     extractionConfig: {
-      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      upsert: vi.fn().mockResolvedValue({}),
     },
   },
 }));
@@ -32,7 +32,7 @@ describe('resetUserPassword', () => {
 
     expect(result).toEqual({ ok: true, isAdmin: true });
     expect(prisma.user.update).toHaveBeenCalledWith({
-      where: { username: 'garry' },
+      where: { id: 'u1' },
       data: { passwordHash: expect.stringMatching(/^[0-9a-f]+:[0-9a-f]+$/) },
     });
   });
@@ -72,9 +72,10 @@ describe('disableMultiUserMode', () => {
 
     await disableMultiUserMode();
 
-    expect(prisma.extractionConfig.updateMany).toHaveBeenCalledWith({
+    expect(prisma.extractionConfig.upsert).toHaveBeenCalledWith({
       where: { id: 'singleton' },
-      data: { multiUserMode: false, adminPasswordHash: null },
+      create: { id: 'singleton', multiUserMode: false, adminPasswordHash: null },
+      update: { multiUserMode: false, adminPasswordHash: null },
     });
     expect(invalidateMultiUserCache).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/lib/admin-recovery.test.ts
+++ b/apps/web/src/lib/admin-recovery.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const invalidateMultiUserCache = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/multi-user', () => ({
+  invalidateMultiUserCache: () => invalidateMultiUserCache(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    extractionConfig: {
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+  },
+}));
+
+describe('resetUserPassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes a scrypt salt:hex hash for an existing user and reports admin status', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'u1', isAdmin: true } as never);
+
+    const { resetUserPassword } = await import('./admin-recovery');
+    const result = await resetUserPassword('garry', 'correcthorse');
+
+    expect(result).toEqual({ ok: true, isAdmin: true });
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { username: 'garry' },
+      data: { passwordHash: expect.stringMatching(/^[0-9a-f]+:[0-9a-f]+$/) },
+    });
+  });
+
+  it('rejects a password shorter than the minimum without touching the DB', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { resetUserPassword } = await import('./admin-recovery');
+
+    const result = await resetUserPassword('garry', 'short');
+
+    expect(result.ok).toBe(false);
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:false and does not update when the user does not exist', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+    const { resetUserPassword } = await import('./admin-recovery');
+    const result = await resetUserPassword('ghost', 'correcthorse');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/ghost/);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('disableMultiUserMode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('flips the flag off, clears the legacy admin hash, and invalidates the cache', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { disableMultiUserMode } = await import('./admin-recovery');
+
+    await disableMultiUserMode();
+
+    expect(prisma.extractionConfig.updateMany).toHaveBeenCalledWith({
+      where: { id: 'singleton' },
+      data: { multiUserMode: false, adminPasswordHash: null },
+    });
+    expect(invalidateMultiUserCache).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/admin-recovery.ts
+++ b/apps/web/src/lib/admin-recovery.ts
@@ -38,7 +38,9 @@ export async function resetUserPassword(
   }
 
   const passwordHash = await hashPassword(newPassword);
-  await prisma.user.update({ where: { username }, data: { passwordHash } });
+  // Update by the id we just selected, not the username, so a concurrent rename
+  // can't redirect the write to a different row.
+  await prisma.user.update({ where: { id: user.id }, data: { passwordHash } });
 
   return { ok: true, isAdmin: user.isAdmin };
 }
@@ -48,17 +50,20 @@ export async function resetUserPassword(
  * a self-hosted instance with no stored credential. In SELF_HOSTED mode the
  * middleware skips admin auth entirely, so afterward the app requires no login.
  *
- * updateMany (not update) so a missing singleton row is a no-op instead of a
- * throw, the same guarded write style the enable route uses.
+ * upsert (not updateMany) so the end state is guaranteed: a break-glass command
+ * must not print success while changing nothing if the singleton row is somehow
+ * absent. If it exists (the normal case), only these two fields change and every
+ * other setting is left intact.
  *
  * Cache invalidation is correct because this runs inside the `web` container,
  * sharing REDIS_URL and the `ft:multi-user` key; the 60s TTL would self-heal a
  * missed bust anyway.
  */
 export async function disableMultiUserMode(): Promise<void> {
-  await prisma.extractionConfig.updateMany({
+  await prisma.extractionConfig.upsert({
     where: { id: 'singleton' },
-    data: { multiUserMode: false, adminPasswordHash: null },
+    create: { id: 'singleton', multiUserMode: false, adminPasswordHash: null },
+    update: { multiUserMode: false, adminPasswordHash: null },
   });
   await invalidateMultiUserCache();
 }

--- a/apps/web/src/lib/admin-recovery.ts
+++ b/apps/web/src/lib/admin-recovery.ts
@@ -1,0 +1,64 @@
+import { prisma } from '@/lib/prisma';
+import { hashPassword } from '@/lib/password';
+import { invalidateMultiUserCache } from '@/lib/multi-user';
+
+// Break-glass recovery used by the self-hosted CLI (`flight-finder reset-password`
+// / `flight-finder disable-accounts`) when an admin is locked out of multi user
+// mode. There is no in-app UI for these: the only password reset is the admin
+// Users page, which itself needs an admin session, the very thing a locked out
+// admin lacks. These run inside the `web` container against the same DB/Redis.
+
+// Mirrors the per-route convention (multi-user/route.ts, admin/users/[id]/route.ts):
+// each handler declares its own minimum rather than sharing a constant.
+const MIN_PASSWORD_LENGTH = 8;
+
+export type ResetPasswordResult =
+  | { ok: true; isAdmin: boolean }
+  | { ok: false; error: string };
+
+/**
+ * Set a new password for the user with the given username. username is @unique,
+ * so the lookup is unambiguous. Returns ok:false (rather than throwing) for the
+ * two expected operator errors so the CLI can print a clean message.
+ */
+export async function resetUserPassword(
+  username: string,
+  newPassword: string,
+): Promise<ResetPasswordResult> {
+  if (newPassword.length < MIN_PASSWORD_LENGTH) {
+    return { ok: false, error: `Password must be at least ${MIN_PASSWORD_LENGTH} characters` };
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { username },
+    select: { id: true, isAdmin: true },
+  });
+  if (!user) {
+    return { ok: false, error: `User "${username}" not found` };
+  }
+
+  const passwordHash = await hashPassword(newPassword);
+  await prisma.user.update({ where: { username }, data: { passwordHash } });
+
+  return { ok: true, isAdmin: user.isAdmin };
+}
+
+/**
+ * Turn multi user mode off and clear the dormant legacy solo-admin hash, leaving
+ * a self-hosted instance with no stored credential. In SELF_HOSTED mode the
+ * middleware skips admin auth entirely, so afterward the app requires no login.
+ *
+ * updateMany (not update) so a missing singleton row is a no-op instead of a
+ * throw, the same guarded write style the enable route uses.
+ *
+ * Cache invalidation is correct because this runs inside the `web` container,
+ * sharing REDIS_URL and the `ft:multi-user` key; the 60s TTL would self-heal a
+ * missed bust anyway.
+ */
+export async function disableMultiUserMode(): Promise<void> {
+  await prisma.extractionConfig.updateMany({
+    where: { id: 'singleton' },
+    data: { multiUserMode: false, adminPasswordHash: null },
+  });
+  await invalidateMultiUserCache();
+}

--- a/packages/cli/src/__tests__/recovery-cli.test.ts
+++ b/packages/cli/src/__tests__/recovery-cli.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockReset, mockDisable, mockDisconnect } = vi.hoisted(() => ({
+  mockReset: vi.fn(),
+  mockDisable: vi.fn(),
+  mockDisconnect: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/admin-recovery', () => ({
+  resetUserPassword: mockReset,
+  disableMultiUserMode: mockDisable,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { $disconnect: mockDisconnect },
+}));
+
+import { runResetPassword, runDisableAccounts } from '../lib/recovery-cli.js';
+
+function spies() {
+  return {
+    exit: vi.spyOn(process, 'exit').mockImplementation(() => undefined as never),
+    log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+    error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+  };
+}
+
+describe('runResetPassword', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('forwards the credentials, confirms success, disconnects, and exits 0', async () => {
+    const s = spies();
+    mockReset.mockResolvedValue({ ok: true, isAdmin: true });
+
+    await runResetPassword('garry', 'correcthorse');
+
+    expect(mockReset).toHaveBeenCalledWith('garry', 'correcthorse');
+    expect(s.log).toHaveBeenCalledWith(expect.stringContaining('garry'));
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    expect(s.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('prints the error and exits 1 when the reset fails', async () => {
+    const s = spies();
+    mockReset.mockResolvedValue({ ok: false, error: 'User "ghost" not found' });
+
+    await runResetPassword('ghost', 'correcthorse');
+
+    expect(s.error).toHaveBeenCalledWith(expect.stringContaining('not found'));
+    expect(s.exit).toHaveBeenCalledWith(1);
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runDisableAccounts', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('disables multi user mode, confirms, disconnects, and exits 0', async () => {
+    const s = spies();
+    mockDisable.mockResolvedValue(undefined);
+
+    await runDisableAccounts();
+
+    expect(mockDisable).toHaveBeenCalledTimes(1);
+    expect(s.log).toHaveBeenCalledWith(expect.stringContaining('disabled'));
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    expect(s.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('reports a failure and exits 1 when the disable throws', async () => {
+    const s = spies();
+    mockDisable.mockRejectedValue(new Error('DB down'));
+
+    await runDisableAccounts();
+
+    expect(s.error).toHaveBeenCalledWith(expect.stringContaining('DB down'));
+    expect(s.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -19,15 +19,19 @@ program
   .option('--json', 'Output JSON: with --view <id> one tracker, otherwise the full list')
   .option('--backend <provider>', 'AI backend: claude-code, codex, anthropic, openai, google')
   .option('--model <model>', 'Model override (e.g. sonnet, opus, gpt-4.1-mini, codex)')
+  .option('--reset-password <username>', "Reset a user's password (multi user mode); pair with --new-password")
+  .option('--new-password <password>', 'New password to set (use with --reset-password)')
+  .option('--disable-accounts', 'Disable multi user mode and clear stored credentials (self hosted)')
   .parse();
 
-const opts = program.opts() as { headless?: boolean; list?: boolean; view?: string; tmux?: boolean; json?: boolean; backend?: string; model?: string };
+const opts = program.opts() as { headless?: boolean; list?: boolean; view?: string; tmux?: boolean; json?: boolean; backend?: string; model?: string; resetPassword?: string; newPassword?: string; disableAccounts?: boolean };
 
 const baseUrl = process.env.FLIGHT_FINDER_URL
   ?? `http://localhost:${process.env.HOST_PORT ?? process.env.PORT ?? '3003'}`;
 
-// Set backend/model override — update DB config so parse-query.ts and extract-prices.ts pick it up
-if (opts.backend) {
+// Set backend/model override — update DB config so parse-query.ts and extract-prices.ts pick it up.
+// Skipped during recovery so those commands never write config as a side effect.
+if (opts.backend && !opts.resetPassword && !opts.disableAccounts) {
   process.env.FLIGHT_FINDER_BACKEND = opts.backend;
 
   const defaultModels: Record<string, string> = {
@@ -63,7 +67,24 @@ if (opts.tmux && !opts.view) {
   process.exit(1);
 }
 
-if (opts.json) {
+if (opts.resetPassword || opts.disableAccounts) {
+  // Break-glass account recovery for self hosted multi user mode. Talks to the
+  // DB and exits; never renders ink or opens a browser. First branch so it can
+  // never fall through to program.help().
+  import('./lib/recovery-cli.js')
+    .then(({ runResetPassword, runDisableAccounts }) => {
+      if (opts.disableAccounts) return runDisableAccounts();
+      if (!opts.resetPassword || !opts.newPassword) {
+        console.error('Error: --reset-password <username> requires --new-password <password>');
+        process.exit(1);
+      }
+      return runResetPassword(opts.resetPassword, opts.newPassword);
+    })
+    .catch((err) => {
+      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    });
+} else if (opts.json) {
   // Machine readable output for automation. Bypasses ink and the browser; the
   // helper prints to stdout and exits.
   import('./lib/json-output.js')

--- a/packages/cli/src/lib/admin-recovery.ts
+++ b/packages/cli/src/lib/admin-recovery.ts
@@ -1,0 +1,21 @@
+// Self-contained stub. At build time tsup's `@` -> apps/web/src alias swaps in
+// the real apps/web/src/lib/admin-recovery.ts, so this file is never in the
+// bundle. It exists only so the CLI's own `tsc` (paths `@/*` -> ./src/*) and the
+// dev loader can resolve the import; tests mock it. Same shim pattern as
+// ./prisma.ts. If this ever runs, the build wiring is wrong.
+export type ResetPasswordResult =
+  | { ok: true; isAdmin: boolean }
+  | { ok: false; error: string };
+
+const STUB_MESSAGE = 'admin-recovery stub: only valid in the bundled build';
+
+export async function resetUserPassword(
+  _username: string,
+  _newPassword: string,
+): Promise<ResetPasswordResult> {
+  throw new Error(STUB_MESSAGE);
+}
+
+export async function disableMultiUserMode(): Promise<void> {
+  throw new Error(STUB_MESSAGE);
+}

--- a/packages/cli/src/lib/recovery-cli.ts
+++ b/packages/cli/src/lib/recovery-cli.ts
@@ -1,0 +1,50 @@
+import { resetUserPassword, disableMultiUserMode } from '@/lib/admin-recovery';
+import { prisma } from '@/lib/prisma';
+
+// Headless recovery entry points invoked from index.tsx for the self-hosted
+// `flight-finder reset-password` / `flight-finder disable-accounts` commands.
+// They run inside the `web` container, talk straight to the DB, and exit.
+// Never render ink or open a browser. Mirrors lib/json-output.ts.
+
+/**
+ * Set a known password for a user and exit. Recovers a locked out multi user
+ * mode admin who forgot their password.
+ */
+export async function runResetPassword(username: string, newPassword: string): Promise<void> {
+  let exitCode = 0;
+  try {
+    const result = await resetUserPassword(username, newPassword);
+    if (result.ok) {
+      console.log(`Password updated for "${username}".`);
+      if (result.isAdmin) {
+        console.log('Log in with it, then manage other accounts from the admin Users page.');
+      }
+    } else {
+      console.error(`Error: ${result.error}`);
+      exitCode = 1;
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+  process.exit(exitCode);
+}
+
+/**
+ * Turn multi user mode off and exit. Restores solo self hosted operation where
+ * no login is required, and clears the stored admin credential.
+ */
+export async function runDisableAccounts(): Promise<void> {
+  let exitCode = 0;
+  try {
+    await disableMultiUserMode();
+    console.log('Multi user mode disabled. Your trackers are preserved.');
+    console.log('This self hosted instance no longer requires any login or password.');
+    console.log('Turn accounts back on any time from Settings.');
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+  process.exit(exitCode);
+}

--- a/scripts/cli-runtime-test.sh
+++ b/scripts/cli-runtime-test.sh
@@ -784,6 +784,63 @@ test_run_cli_captures_exit() {
 }
 
 # ---------------------------------------------------------------------------
+# Test cases — cmd_reset_password / cmd_disable_accounts (issue #102)
+# ---------------------------------------------------------------------------
+
+test_reset_password_execs_with_credentials() {
+  for rt in docker_v2 docker_v1 podman_native podman_delegated podman_pc; do
+    setup_runtime "$rt"
+    run_cli reset-password garry secretpass123
+    LAST_RUNTIME="$rt"; LAST_CMD="reset-password"
+    case "$rt" in
+      docker_v2)        assert_recorded "reset-password -> docker compose exec -i web --reset-password garry --new-password" \
+        '^docker compose -f docker-compose.yml exec -i web flight-finder-tui --reset-password garry --new-password secretpass123$' ;;
+      docker_v1)        assert_recorded "reset-password -> docker-compose exec -i web --reset-password garry --new-password" \
+        '^docker-compose -f docker-compose.yml exec -i web flight-finder-tui --reset-password garry --new-password secretpass123$' ;;
+      podman_native)    assert_recorded "reset-password -> podman compose exec -i web --reset-password garry --new-password" \
+        '^podman compose -f docker-compose.yml exec -i web flight-finder-tui --reset-password garry --new-password secretpass123$' ;;
+      podman_delegated) assert_recorded "reset-password -> podman-compose exec -T web (delegated #96)" \
+        '^podman-compose -f docker-compose.yml exec -T web flight-finder-tui --reset-password garry --new-password secretpass123$' ;;
+      podman_pc)        assert_recorded "reset-password -> podman-compose exec -T web (#72)" \
+        '^podman-compose -f docker-compose.yml exec -T web flight-finder-tui --reset-password garry --new-password secretpass123$' ;;
+    esac
+    assert_not_recorded "reset-password never sends -it/-i to podman-compose" \
+      'podman-compose .* exec [^ ]*(-it|-i ) '
+  done
+}
+
+test_reset_password_requires_both_args() {
+  # Missing password must abort before any container exec.
+  setup_runtime docker_v2
+  EXPECT_NONZERO=1 run_cli reset-password garry
+  unset EXPECT_NONZERO
+  assert_not_recorded "reset-password with no password never execs the container" \
+    'exec .* web flight-finder-tui --reset-password'
+}
+
+test_disable_accounts_execs() {
+  for rt in docker_v2 docker_v1 podman_native podman_delegated podman_pc; do
+    setup_runtime "$rt"
+    run_cli disable-accounts
+    LAST_RUNTIME="$rt"; LAST_CMD="disable-accounts"
+    case "$rt" in
+      docker_v2)        assert_recorded "disable-accounts -> docker compose exec -i web --disable-accounts" \
+        '^docker compose -f docker-compose.yml exec -i web flight-finder-tui --disable-accounts$' ;;
+      docker_v1)        assert_recorded "disable-accounts -> docker-compose exec -i web --disable-accounts" \
+        '^docker-compose -f docker-compose.yml exec -i web flight-finder-tui --disable-accounts$' ;;
+      podman_native)    assert_recorded "disable-accounts -> podman compose exec -i web --disable-accounts" \
+        '^podman compose -f docker-compose.yml exec -i web flight-finder-tui --disable-accounts$' ;;
+      podman_delegated) assert_recorded "disable-accounts -> podman-compose exec -T web (delegated #96)" \
+        '^podman-compose -f docker-compose.yml exec -T web flight-finder-tui --disable-accounts$' ;;
+      podman_pc)        assert_recorded "disable-accounts -> podman-compose exec -T web (#72)" \
+        '^podman-compose -f docker-compose.yml exec -T web flight-finder-tui --disable-accounts$' ;;
+    esac
+    assert_not_recorded "disable-accounts never sends -it/-i to podman-compose" \
+      'podman-compose .* exec [^ ]*(-it|-i ) '
+  done
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 echo ""
@@ -820,6 +877,9 @@ test_vpn_compose_excluded_when_empty_value
 test_vpn_compose_included_when_enabled
 test_missing_helper_fails_loudly
 test_run_cli_captures_exit
+test_reset_password_execs_with_credentials
+test_reset_password_requires_both_args
+test_disable_accounts_execs
 
 echo ""
 printf "${BOLD}Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}\n" "$PASS" "$FAIL"

--- a/scripts/install-flow-test.sh
+++ b/scripts/install-flow-test.sh
@@ -182,6 +182,37 @@ test_cli_has_cmd_tui() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: flight-finder-cli ships the multi user recovery commands (#102)
+# ---------------------------------------------------------------------------
+test_cli_has_recovery_commands() {
+  local cli="apps/web/public/flight-finder-cli"
+
+  if grep -q 'cmd_reset_password()' "$cli" && grep -q 'cmd_disable_accounts()' "$cli"; then
+    pass "flight-finder-cli defines cmd_reset_password and cmd_disable_accounts (#102)"
+  else
+    fail "flight-finder-cli should define cmd_reset_password and cmd_disable_accounts (#102)"
+  fi
+
+  if grep -qE 'reset-password\)' "$cli" && grep -qE 'disable-accounts\)' "$cli"; then
+    pass "flight-finder-cli dispatches reset-password and disable-accounts (#102)"
+  else
+    fail "flight-finder-cli should dispatch reset-password and disable-accounts (#102)"
+  fi
+
+  if grep -q 'flight-finder-tui --reset-password' "$cli" && grep -q 'flight-finder-tui --disable-accounts' "$cli"; then
+    pass "recovery commands exec flight-finder-tui with the recovery flags (#102)"
+  else
+    fail "recovery commands should exec flight-finder-tui --reset-password / --disable-accounts (#102)"
+  fi
+
+  if grep -q 'Account recovery' "$cli"; then
+    pass "cmd_help documents the account recovery commands (#102)"
+  else
+    fail "cmd_help should document reset-password and disable-accounts (#102)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Test: install.sh supports --no-browser flag
 # ---------------------------------------------------------------------------
 test_install_supports_no_browser() {
@@ -443,6 +474,7 @@ test_install_overrides
 test_ansi_variables_defined
 test_cli_dispatches_tui_flags
 test_cli_has_cmd_tui
+test_cli_has_recovery_commands
 test_install_supports_no_browser
 test_dockerfile_ships_cli
 test_install_supports_arch_family


### PR DESCRIPTION
Garry (#102) enabled multi user mode, forgot the password, and got locked out with no way back short of editing Postgres by hand. This adds two recovery commands the host owner runs against a running instance:

- `flight-finder reset-password <username> <new-password>` sets a known password for a user and keeps accounts on.
- `flight-finder disable-accounts` turns multi user mode off, clears the stored admin credential, and drops back to solo self hosted mode where no login is required. Trackers are preserved either way.

Both exec inside the `web` container against the live DB. The logic lives in `apps/web/src/lib/admin-recovery.ts` (reusing `hashPassword` and the multi user cache invalidation); the CLI bundle inlines it through the tsup alias, with a typecheck stub that mirrors the existing prisma shim. The bash CLI mirrors `cmd_tui` so the exec flags stay correct across the docker/podman/compose matrix.

Covered by web and CLI unit tests, per-runtime assertions in `cli-runtime-test.sh`, and static checks in `install-flow-test.sh`. Lint, typecheck, both test suites, and both builds pass.

Solo mode lockout (someone who never turned multi user mode on) still recovers through the `ADMIN_PASSWORD` env var, now documented in the README.
