### PR TITLE
fix(ci): staging version check asserts a semver, not the old brand

### DIFF
--- a/scripts/staging-test.sh
+++ b/scripts/staging-test.sh
@@ -283,7 +283,10 @@ if [ "$RETRIES" -gt 0 ]; then
   echo "$STATUS_OUT" | grep -qi "running" && pass "flight-finder status: running" || fail "flight-finder status: $STATUS_OUT"
 
   VERSION_OUT=$(flight-finder version 2>&1 | sed 's/\x1b\[[0-9;]*m//g') || true
-  echo "$VERSION_OUT" | grep -qi "fairtrail" && pass "flight-finder version: $(echo "$VERSION_OUT" | head -1)" || fail "flight-finder version failed"
+  # Assert it reports a semver, not a brand string: the brand was renamed from
+  # fairtrail to flightfinder (#96), and a version smoke check should survive
+  # the next rebrand too. A missing version (app down) still prints no semver.
+  echo "$VERSION_OUT" | grep -qE '[0-9]+\.[0-9]+\.[0-9]+' && pass "flight-finder version: $(echo "$VERSION_OUT" | head -1)" || fail "flight-finder version failed"
 fi
 
 # === Report ===


### PR DESCRIPTION
The `staging` job (main-only) has failed on every push since the rebrand — v0.9.5, #101, and #103 — on a single assertion:

```
FAIL flight-finder version failed
Staging: 22 passed, 1 FAILED
```

`scripts/staging-test.sh:286` grepped the `flight-finder version` output for the string `fairtrail`, but #96 rebranded that output to `flightfinder 0.9.5 (<sha>)`, so the grep never matches. The rebrand updated the CLI but missed this assertion.

Switched it to assert the output contains a semver (`[0-9]+\.[0-9]+\.[0-9]+`) instead of a brand string. That verifies the real behavior (the version command reports a version), survives the next rebrand, and still fails if the app is down and prints no version. Verified the grep against the running output (passes), the app-down output (fails), and the old brand string (passes).

All other `fairtrail` references in the file are internal test names or the intentional check that the deprecated `fairtrail` alias still resolves; left untouched.
