### PR TITLE
Alert links fall back to the booking page when no site URL is set

### DIFF
--- a/apps/web/src/components/BestPrice.tsx
+++ b/apps/web/src/components/BestPrice.tsx
@@ -1,4 +1,5 @@
 import { currencySymbol } from '@/lib/currency';
+import { safeHttpUrl } from '@/lib/safe-url';
 import styles from './BestPrice.module.css';
 
 interface Snapshot {
@@ -42,9 +43,9 @@ export function BestPrice({ snapshots }: { snapshots: Snapshot[] }) {
             {(best.departureTime || best.arrivalTime) && ` · ${best.departureTime ?? '?'} - ${best.arrivalTime ?? '?'}`}
           </span>
         </div>
-        {best.bookingUrl && (
+        {safeHttpUrl(best.bookingUrl) && (
           <a
-            href={best.bookingUrl}
+            href={safeHttpUrl(best.bookingUrl)}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.bookButton}

--- a/apps/web/src/components/PriceCalendar.tsx
+++ b/apps/web/src/components/PriceCalendar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { safeHttpUrl } from '@/lib/safe-url';
 import styles from './PriceCalendar.module.css';
 
 interface Snapshot {
@@ -69,7 +70,7 @@ export function PriceCalendar({ snapshots, currency }: Props) {
           return (
             <a
               key={d.date}
-              href={d.bookingUrl || undefined}
+              href={safeHttpUrl(d.bookingUrl) || undefined}
               target="_blank"
               rel="noopener noreferrer"
               className={`${styles.cell} ${isMin ? styles.cellBest : ''}`}

--- a/apps/web/src/components/PriceHistorySection.tsx
+++ b/apps/web/src/components/PriceHistorySection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { currencySymbol } from '@/lib/currency';
+import { safeHttpUrl } from '@/lib/safe-url';
 import styles from './PriceHistory.module.css';
 import type { Snapshot } from './PriceHistory';
 
@@ -104,10 +105,10 @@ function FlightRow({
         ) : null}
       </td>
       <td>
-        {s.status === 'sold_out' || !s.bookingUrl ? (
+        {s.status === 'sold_out' || !safeHttpUrl(s.bookingUrl) ? (
           <span className={styles.soldOutLabel}>&mdash;</span>
         ) : (
-          <a href={s.bookingUrl} target="_blank" rel="noopener noreferrer" className={styles.bookLink}>
+          <a href={safeHttpUrl(s.bookingUrl)} target="_blank" rel="noopener noreferrer" className={styles.bookLink}>
             Book
           </a>
         )}

--- a/apps/web/src/lib/notifications/channels/email.ts
+++ b/apps/web/src/lib/notifications/channels/email.ts
@@ -20,6 +20,6 @@ export async function sendEmail(config: EmailConfig, message: ChannelMessage): P
 function renderHtml(message: ChannelMessage): string {
   const esc = (s: string) =>
     s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c] ?? c);
-  const link = message.url ? `<p><a href="${esc(message.url)}">View price history</a></p>` : '';
+  const link = message.url ? `<p><a href="${esc(message.url)}">Open</a></p>` : '';
   return `<p>${esc(message.body)}</p>${link}`;
 }

--- a/apps/web/src/lib/notifications/format.test.ts
+++ b/apps/web/src/lib/notifications/format.test.ts
@@ -46,15 +46,44 @@ describe('formatNewLowMessage', () => {
     expect(msg.url).toBe('https://flights.example/q/q-abc');
   });
 
-  it('emits no link when the base url is null (self-hosted, unset)', () => {
+  it('prefers the chart link over the booking link when a base url is set', () => {
+    const msg = formatNewLowMessage({
+      alert: ALERT, // bookingUrl: https://book/x
+      route: { origin: 'LHR', destination: 'JFK' },
+      baseUrl: 'https://flights.example',
+    });
+    expect(msg.url).toBe('https://flights.example/q/q-abc');
+    expect(msg.data.chartUrl).toBe('https://flights.example/q/q-abc');
+    expect(msg.data.bookingUrl).toBe('https://book/x');
+  });
+
+  it('falls back to the booking link when no base url is set (self-hosted, unset)', () => {
     const msg = formatNewLowMessage({
       alert: ALERT,
       route: { origin: 'LHR', destination: 'JFK' },
       baseUrl: null,
     });
+    expect(msg.url).toBe('https://book/x');
+    expect(msg.body).toContain('dropped to $250'); // price/route still present
+  });
+
+  it('emits no link when there is no base url and no usable booking url', () => {
+    const msg = formatNewLowMessage({
+      alert: { ...ALERT, bookingUrl: null },
+      route: { origin: 'LHR', destination: 'JFK' },
+      baseUrl: null,
+    });
     expect(msg.url).toBe('');
-    // The price/route content is still there.
     expect(msg.body).toContain('dropped to $250');
+  });
+
+  it('rejects a dangerous booking url scheme instead of linking to it', () => {
+    const msg = formatNewLowMessage({
+      alert: { ...ALERT, bookingUrl: 'javascript:alert(1)' },
+      route: { origin: 'LHR', destination: 'JFK' },
+      baseUrl: null,
+    });
+    expect(msg.url).toBe('');
   });
 });
 

--- a/apps/web/src/lib/notifications/format.ts
+++ b/apps/web/src/lib/notifications/format.ts
@@ -1,5 +1,6 @@
 import type { ChannelMessage } from './channels/types';
 import type { NewLowAlert } from './detect';
+import { safeHttpUrl } from '@/lib/safe-url';
 
 export interface AlertRoute {
   origin: string;
@@ -16,7 +17,12 @@ export function formatNewLowMessage(params: {
 }): ChannelMessage {
   const { alert, route, baseUrl } = params;
   const price = (n: number) => formatPrice(n, alert.currency);
-  const url = baseUrl ? `${baseUrl.replace(/\/+$/, '')}/q/${alert.queryId}` : '';
+  const chartUrl = baseUrl ? `${baseUrl.replace(/\/+$/, '')}/q/${alert.queryId}` : '';
+  // Prefer the instance's own tracker page when a public URL is configured;
+  // otherwise fall back to the fare's booking link so a self-hoster still gets
+  // a tappable link with zero config. http(s) only (booking URLs are
+  // LLM-extracted). Empty when neither exists — senders omit the link.
+  const url = chartUrl || safeHttpUrl(alert.bookingUrl);
   const travelDate = alert.travelDate.toISOString().slice(0, 10);
   const lane = `${route.origin} to ${route.destination}`;
   const title = `New low: ${lane} ${price(alert.currentMin)}`;
@@ -39,6 +45,7 @@ export function formatNewLowMessage(params: {
       airline: alert.airline,
       travelDate,
       bookingUrl: alert.bookingUrl,
+      chartUrl,
     },
   };
 }

--- a/apps/web/src/lib/safe-url.test.ts
+++ b/apps/web/src/lib/safe-url.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { safeHttpUrl } from './safe-url';
+
+describe('safeHttpUrl', () => {
+  it('passes through http and https URLs unchanged', () => {
+    expect(safeHttpUrl('https://example.com/book?x=1')).toBe('https://example.com/book?x=1');
+    expect(safeHttpUrl('http://example.com')).toBe('http://example.com');
+  });
+
+  it('rejects dangerous schemes', () => {
+    expect(safeHttpUrl('javascript:alert(1)')).toBe('');
+    expect(safeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+    expect(safeHttpUrl('file:///etc/passwd')).toBe('');
+    expect(safeHttpUrl('vbscript:msgbox(1)')).toBe('');
+  });
+
+  it('returns empty for null, undefined, and empty string', () => {
+    expect(safeHttpUrl(null)).toBe('');
+    expect(safeHttpUrl(undefined)).toBe('');
+    expect(safeHttpUrl('')).toBe('');
+  });
+
+  it('returns empty for non-URL or relative strings', () => {
+    expect(safeHttpUrl('not a url')).toBe('');
+    expect(safeHttpUrl('/relative/path')).toBe('');
+  });
+});

--- a/apps/web/src/lib/safe-url.ts
+++ b/apps/web/src/lib/safe-url.ts
@@ -1,0 +1,16 @@
+/**
+ * Return the URL only when it is a plain http(s) URL, otherwise an empty string.
+ * Guards hrefs and notification links against javascript:/data:/file: and other
+ * schemes — React does not strip those from an href in production, and booking
+ * URLs are LLM-extracted (untrusted), so any place that renders one as a link
+ * must run it through here first.
+ */
+export function safeHttpUrl(u: string | null | undefined): string {
+  if (!u) return '';
+  try {
+    const parsed = new URL(u);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? u : '';
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
Follow up to #107 (issue #106). On a self hosted box with no Public site URL set, new low alerts had no chart link. Now they fall back to the cheapest fare's booking page, so the link works with zero config. When a site URL is set, the alert still links to the tracker page `/q/<id>` as before. No link when neither exists, same as today.

Also adds a shared `safeHttpUrl` guard (http/https only), applied to the alert link and to the booking URLs already rendered as hrefs on the public chart page (BestPrice, PriceHistorySection, PriceCalendar) — those are extracted by the LLM and React does not strip a `javascript:` scheme from an href, so it closes a latent gap there too.

Tested: safe-url unit tests, format precedence + dangerous-scheme rejection, full CI green.
