### PR TITLE
feat(community): registration toggle + secret-decrypt fallback (no release)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,9 @@ CRON_SECRET=
 # COMMUNITY_HUB_URL=https://flight-finder.org
 
 # Allow public registration of community API keys (POST /api/community/register).
-# Off by default. Set to 'true' on the hub instance to let self-hosted nodes
-# register themselves automatically.
+# Off by default. The admin toggle "Accept community registrations" in Settings is
+# the primary control; this env var is an override that also opens registration
+# when set to 'true' (handy for headless hub setups).
 # COMMUNITY_REGISTRATION_OPEN=false
 
 # --- Cron (built-in scheduler) ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+* **Admin toggle for accepting community registrations.** The hub-side control that lets other instances register to contribute their data is now an admin toggle in Settings (default off, opt-in), next to a clearer explainer of why to enable Community Data Sharing. The `COMMUNITY_REGISTRATION_OPEN` env var still works as an override.
+
+### Fixed
+* Notification and VPN channel secrets encrypted before v0.10.0 now decrypt after upgrading, via a backward-compatible key-derivation fallback, so upgrading no longer requires re-entering them. They are re-encrypted under the stronger derivation the next time they are saved.
+
 ## [0.10.0] - 2026-06-05
 
 This release adds new-low price alerts with pluggable notification channels, CLI account recovery for multi user mode, and the full results of a security audit and remediation (PR #109).

--- a/README.md
+++ b/README.md
@@ -504,13 +504,15 @@ mode, with quick links to `/account` and logout.
 
 Flight Finder is fully decentralized. You run everything on your own machine.
 
+**Why share?** The price trail gets richer the more instances pool their history. When you opt in, your anonymized data points join a shared fare dataset everyone can explore, and you get community prices back on routes you have not scraped yourself. It is genuinely opt-in, reversible any time, and never touches anything personal.
+
 **flight-finder.org** aggregates anonymized price data that self-hosted instances **opt in** to share.
 
 **What gets shared (opt-in only):** route, travel date, price, currency, airline, stops, cabin class, scrape timestamp.
 
 **What is never shared:** your queries, search history, preferences, API keys, IP address, or identity.
 
-Enable in Settings or during setup. Explore community data at [flight-finder.org/explore](https://flight-finder.org/explore).
+Turn on **Community Data Sharing** in Settings (or during setup) to contribute. If you run a shared hub that other instances contribute to, enable **Accept community registrations** in the same panel (off by default; rate limited and globally capped). Explore community data at [flight-finder.org/explore](https://flight-finder.org/explore).
 </details>
 
 <details>

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -110,6 +110,7 @@ model ExtractionConfig {
   defaultSearchMethod  String    @default("ai") // 'ai' | 'manual'
   adminPasswordHash    String?
   communitySharing     Boolean   @default(false)
+  communityRegistrationOpen Boolean @default(false) // hub side: accept new community key registrations (opt-in). Env COMMUNITY_REGISTRATION_OPEN still works as an override.
   communityApiKey      String?
   lastCommunitySyncAt  DateTime?
   defaultCurrency      String?   // ISO 4217 (EUR, GBP). null = Google auto-detects

--- a/apps/web/src/app/admin/(dashboard)/config/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/config/page.tsx
@@ -12,6 +12,7 @@ interface Config {
   scrapeInterval: number;
   hasAdminPassword: boolean;
   communitySharing: boolean;
+  communityRegistrationOpen: boolean;
   communityApiKey: string | null;
   theme: ThemeId;
   defaultCurrency: string | null;
@@ -597,6 +598,14 @@ export default function ConfigPage() {
       <div className={styles.form}>
         <h2 className={styles.sectionTitle}>Community Data Sharing</h2>
 
+        <p className={styles.toggleHint}>
+          Flight Finder gets better when instances pool their price history. Turn on
+          sharing to contribute your anonymized data points (route, price, airline,
+          and date only, never anything personal) to a shared fare dataset everyone
+          can explore, and in return you see community prices on routes you have not
+          scraped yourself. It is fully opt-in and you can turn it off any time.
+        </p>
+
         <div className={styles.toggleRow}>
           <button
             type="button"
@@ -619,7 +628,34 @@ export default function ConfigPage() {
               {config.communitySharing ? 'Sharing enabled' : 'Sharing disabled'}
             </span>
             <p className={styles.toggleHint}>
-              Share anonymized price data (route, price, airline, date) with the Flight Finder community.
+              Contribute this instance&apos;s anonymized prices (route, price, airline, date) to the community dataset.
+            </p>
+          </div>
+        </div>
+
+        <div className={styles.toggleRow}>
+          <button
+            type="button"
+            className={`${styles.toggle} ${config.communityRegistrationOpen ? styles.toggleOn : ''}`}
+            onClick={async () => {
+              const newValue = !config.communityRegistrationOpen;
+              const res = await fetch('/api/admin/config', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ communityRegistrationOpen: newValue }),
+              });
+              const data = await res.json();
+              if (data.ok) setConfig(data.data);
+            }}
+          >
+            <span className={styles.toggleKnob} />
+          </button>
+          <div>
+            <span className={styles.toggleLabel}>
+              {config.communityRegistrationOpen ? 'Accepting new contributors' : 'Registration closed'}
+            </span>
+            <p className={styles.toggleHint}>
+              Let other Flight Finder instances register with this one to contribute their data. Off by default, for when you run a shared hub. New registrations are rate limited and globally capped.
             </p>
           </div>
         </div>

--- a/apps/web/src/app/api/admin/config/route.ts
+++ b/apps/web/src/app/api/admin/config/route.ts
@@ -137,6 +137,9 @@ export async function PATCH(request: NextRequest) {
     // rejected by the Node guard's adminSessionsValidFrom check.
     data.adminSessionsValidFrom = new Date();
   }
+  if (typeof body.communityRegistrationOpen === 'boolean') {
+    data.communityRegistrationOpen = body.communityRegistrationOpen;
+  }
   if (typeof body.communitySharing === 'boolean') {
     data.communitySharing = body.communitySharing;
     // Register for community API key if enabling and no key exists

--- a/apps/web/src/app/api/community/register/route.test.ts
+++ b/apps/web/src/app/api/community/register/route.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { mockCreate, mockIncr, mockExpire, mockGetClientIp } = vi.hoisted(() => ({
+const { mockCreate, mockIncr, mockExpire, mockGetClientIp, mockFindUnique } = vi.hoisted(() => ({
   mockCreate: vi.fn().mockResolvedValue({ id: 'key_1' }),
   mockIncr: vi.fn(),
   mockExpire: vi.fn().mockResolvedValue(1),
   mockGetClientIp: vi.fn().mockReturnValue('203.0.113.5'),
+  mockFindUnique: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
     communityApiKey: { create: mockCreate },
+    extractionConfig: { findUnique: mockFindUnique },
   },
 }));
 
@@ -37,6 +39,8 @@ describe('POST /api/community/register', () => {
     mockGetClientIp.mockReturnValue('203.0.113.5');
     // Per-IP and global counters both report well under their caps by default.
     mockIncr.mockResolvedValue(1);
+    // The admin toggle (DB flag) is off by default; the env override opens it.
+    mockFindUnique.mockResolvedValue(null);
     process.env.COMMUNITY_REGISTRATION_OPEN = 'true';
   });
 
@@ -67,6 +71,14 @@ describe('POST /api/community/register', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.apiKey).toMatch(/^ft_[0-9a-f]{64}$/);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('mints a key when the admin toggle is on, even with the env override unset', async () => {
+    delete process.env.COMMUNITY_REGISTRATION_OPEN;
+    mockFindUnique.mockResolvedValue({ communityRegistrationOpen: true });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
     expect(mockCreate).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/app/api/community/register/route.ts
+++ b/apps/web/src/app/api/community/register/route.ts
@@ -38,8 +38,17 @@ async function checkGlobalCap(): Promise<LimitResult> {
 
 export async function POST(request: Request) {
   // Registration is an opt-in, admin-enabled feature. Off by default so a
-  // public deployment never mints keys unless the operator turns it on.
-  if (process.env.COMMUNITY_REGISTRATION_OPEN !== 'true') {
+  // public deployment never mints keys unless the operator turns it on, either
+  // from the admin UI (ExtractionConfig.communityRegistrationOpen) or the
+  // COMMUNITY_REGISTRATION_OPEN env override.
+  const config = await prisma.extractionConfig.findUnique({
+    where: { id: 'singleton' },
+    select: { communityRegistrationOpen: true },
+  });
+  const open =
+    config?.communityRegistrationOpen === true ||
+    process.env.COMMUNITY_REGISTRATION_OPEN === 'true';
+  if (!open) {
     return apiError('Community registration is disabled.', 403);
   }
 

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -13,6 +13,7 @@ interface Config {
   enabled: boolean;
   scrapeInterval: number;
   communitySharing: boolean;
+  communityRegistrationOpen: boolean;
   communityApiKey: string | null;
   customBaseUrl: string | null;
   theme: ThemeId;
@@ -641,6 +642,14 @@ export default function SettingsPage() {
         <div className={styles.section}>
           <h2 className={styles.sectionTitle}>Community Data Sharing</h2>
 
+          <p className={styles.toggleHint}>
+            Flight Finder gets better when instances pool their price history. Turn on
+            sharing to contribute your anonymized data points (route, price, airline,
+            and date only, never anything personal) to a shared fare dataset everyone
+            can explore, and in return you see community prices on routes you have not
+            scraped yourself. It is fully opt-in and you can turn it off any time.
+          </p>
+
           <div className={styles.toggleRow}>
             <button
               type="button"
@@ -663,7 +672,34 @@ export default function SettingsPage() {
                 {config.communitySharing ? 'Sharing enabled' : 'Sharing disabled'}
               </span>
               <p className={styles.toggleHint}>
-                Share anonymized price data (route, price, airline, date) with the Flight Finder community.
+                Contribute this instance&apos;s anonymized prices (route, price, airline, date) to the community dataset.
+              </p>
+            </div>
+          </div>
+
+          <div className={styles.toggleRow}>
+            <button
+              type="button"
+              className={`${styles.toggle} ${config.communityRegistrationOpen ? styles.toggleOn : ''}`}
+              onClick={async () => {
+                const newValue = !config.communityRegistrationOpen;
+                const res = await fetch('/api/admin/config', {
+                  method: 'PATCH',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ communityRegistrationOpen: newValue }),
+                });
+                const data = await res.json();
+                if (data.ok) setConfig(data.data);
+              }}
+            >
+              <span className={styles.toggleKnob} />
+            </button>
+            <div>
+              <span className={styles.toggleLabel}>
+                {config.communityRegistrationOpen ? 'Accepting new contributors' : 'Registration closed'}
+              </span>
+              <p className={styles.toggleHint}>
+                Let other Flight Finder instances register with this one to contribute their data. Off by default, for when you run a shared hub. New registrations are rate limited and globally capped.
               </p>
             </div>
           </div>

--- a/apps/web/src/lib/secret-crypto.test.ts
+++ b/apps/web/src/lib/secret-crypto.test.ts
@@ -1,8 +1,22 @@
+import crypto from 'crypto';
 import { describe, it, expect } from 'vitest';
 import { encryptSecret, decryptSecret } from './secret-crypto';
 
 // ADMIN_SESSION_SECRET is provided by src/test/setup.ts, so the scrypt key
 // derivation and AES-256-GCM round-trip work without extra wiring.
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+
+function encryptWithLegacyKey(plaintext: string): string {
+  const secret = process.env.ADMIN_SESSION_SECRET;
+  if (!secret) throw new Error('ADMIN_SESSION_SECRET is required to encrypt stored secrets');
+  const key = crypto.createHash('sha256').update(secret).digest();
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${tag.toString('hex')}:${encrypted.toString('hex')}`;
+}
 
 describe('encryptSecret / decryptSecret', () => {
   it('round-trips a plaintext secret', () => {
@@ -15,6 +29,12 @@ describe('encryptSecret / decryptSecret', () => {
   it('round-trips unicode and empty strings', () => {
     expect(decryptSecret(encryptSecret(''))).toBe('');
     expect(decryptSecret(encryptSecret('café ☕ 秘密'))).toBe('café ☕ 秘密');
+  });
+
+  it('decrypts a pre-upgrade value encrypted with the legacy SHA-256 key', () => {
+    const plaintext = 'legacy-notification-token';
+    const legacyEncrypted = encryptWithLegacyKey(plaintext);
+    expect(decryptSecret(legacyEncrypted)).toBe(plaintext);
   });
 
   it('uses a fresh random IV per encryption, so ciphertext differs', () => {
@@ -59,17 +79,9 @@ describe('encryptSecret / decryptSecret', () => {
   it('returns null when the auth tag is shorter than 16 bytes (truncated tag)', () => {
     const encrypted = encryptSecret('secret');
     const [iv, tag, ct] = encrypted.split(':');
-    // Truncate the tag to 8 bytes (16 hex chars) -- a short tag must be rejected
+    // Truncate the tag to 8 bytes (16 hex chars). A short tag must be rejected
     // before setAuthTag is called to prevent weakened forgery resistance.
     const shortTag = tag!.slice(0, 16);
     expect(decryptSecret(`${iv}:${shortTag}:${ct}`)).toBeNull();
-  });
-
-  it('returns null for a legacy SHA-256-key ciphertext (re-entry required)', () => {
-    // A well-formed iv:tag:ciphertext that was never produced by the current
-    // scrypt key decrypts to null because the auth tag will not verify under
-    // the new key. Simulated here with a structurally valid but foreign value.
-    const legacy = `${'a'.repeat(24)}:${'b'.repeat(32)}:${'c'.repeat(16)}`;
-    expect(decryptSecret(legacy)).toBeNull();
   });
 });

--- a/apps/web/src/lib/secret-crypto.ts
+++ b/apps/web/src/lib/secret-crypto.ts
@@ -35,6 +35,18 @@ function getKey(): Buffer {
   });
 }
 
+function getLegacyKey(): Buffer {
+  const secret = process.env.ADMIN_SESSION_SECRET;
+  if (!secret) throw new Error('ADMIN_SESSION_SECRET is required to encrypt stored secrets');
+  return crypto.createHash('sha256').update(secret).digest();
+}
+
+function decryptWithKey(key: Buffer, iv: Buffer, tag: Buffer, encrypted: Buffer): string {
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+}
+
 /** Encrypt a plaintext secret at rest. Returns hex-encoded iv:tag:ciphertext. */
 export function encryptSecret(plaintext: string): string {
   const key = getKey();
@@ -48,9 +60,9 @@ export function encryptSecret(plaintext: string): string {
 /**
  * Decrypt a hex-encoded iv:tag:ciphertext string produced by encryptSecret.
  * Returns null on any failure (malformed input, wrong key, or a failed auth-tag
- * check) so callers never crash on tampered or legacy ciphertext. Legacy values
- * encrypted under the old SHA-256 key derivation will no longer decrypt and
- * resolve to null, signalling the secret must be re-entered.
+ * check) so callers never crash on tampered ciphertext. Legacy values encrypted
+ * under the old SHA-256 key derivation decrypt through a fallback without
+ * requiring user re-entry.
  */
 export function decryptSecret(encoded: string): string | null {
   const parts = encoded.split(':');
@@ -61,10 +73,13 @@ export function decryptSecret(encoded: string): string | null {
     const encrypted = Buffer.from(parts[2]!, 'hex');
     if (iv.length !== IV_LENGTH) return null;
     if (tag.length !== TAG_LENGTH) return null;
-    const key = getKey();
-    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
-    decipher.setAuthTag(tag);
-    return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+    try {
+      return decryptWithKey(getKey(), iv, tag, encrypted);
+    } catch {
+      // encryptSecret always writes the current scrypt format, so legacy
+      // ciphertext is lazily migrated the next time an admin saves it.
+      return decryptWithKey(getLegacyKey(), iv, tag, encrypted);
+    }
   } catch {
     return null;
   }


### PR DESCRIPTION
Two post-v0.10.0 follow-ups. No version bump or tag (changelog lands under Unreleased). Audited by Codex (acceptable as scoped, no security/correctness issues); local CI green (typecheck, lint, 1157 web + 43 CLI tests, build).

**feat(community): admin toggle for registration + encourage sharing**
- `ExtractionConfig.communityRegistrationOpen` makes the hub's accept-new-registrations control an admin toggle (default off, opt-in) instead of env-only; `COMMUNITY_REGISTRATION_OPEN` still works as an override. Registration opens when either is on, keeping the per-IP and global daily caps that fail closed.
- Surfaced in the admin config and the self-hosted settings page, next to a new encouraging "why share" explainer for Community Data Sharing. Documented in the README. Sharing stays fully opt-in.

**fix(security): decrypt legacy secrets via fallback**
- v0.10.0 changed the secret-at-rest key derivation to scrypt, which broke decryption of secrets encrypted before the upgrade. `decryptSecret` now tries the new scrypt key, then falls back to the old SHA-256 derivation, so notification/VPN secrets keep working after upgrade and are re-encrypted on next save. Both keys failing still returns null (fail closed). Implemented via Codex, reviewed and tested.
