### PR TITLE
chore: add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,48 +5,52 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       npm:
         patterns:
           - '*'
-        update-types:
-          - minor
-          - patch
   # Desktop launcher (deliberately not an npm workspace member).
   - package-ecosystem: npm
     directory: /apps/desktop
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
     groups:
       desktop-npm:
         patterns:
           - '*'
-        update-types:
-          - minor
-          - patch
   # Tauri (Rust) dependencies for the desktop app.
   - package-ecosystem: cargo
     directory: /apps/desktop/src-tauri
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
     groups:
       tauri:
         patterns:
           - '*'
-        update-types:
-          - minor
-          - patch
   # Production container base image.
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   # CI, docker, and desktop release workflows.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+updates:
+  # Web and CLI workspaces (the root lockfile covers both).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+  # Desktop launcher (deliberately not an npm workspace member).
+  - package-ecosystem: npm
+    directory: /apps/desktop
+    schedule:
+      interval: weekly
+    groups:
+      desktop-npm:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+  # Tauri (Rust) dependencies for the desktop app.
+  - package-ecosystem: cargo
+    directory: /apps/desktop/src-tauri
+    schedule:
+      interval: weekly
+    groups:
+      tauri:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+  # Production container base image.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+  # CI, docker, and desktop release workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Adds weekly Dependabot updates across all ecosystems, grouped to one PR per ecosystem so it does not flood the PR list.

Ecosystems:
- npm at `/` (web and cli workspaces, root lockfile)
- npm at `/apps/desktop` (Tauri launcher)
- cargo at `/apps/desktop/src-tauri` (Tauri Rust deps)
- docker at `/` (production image base)
- github-actions at `/`

Minor and patch updates are grouped; majors come as individual PRs for review.

Note: merging this only adds the config. It is unrelated to the deploy on main, but the merge commit to main will trigger the usual deploy.