### PR TITLE
fix(brand): propagate the real logo mark to the on-page brand

### DIFF
--- a/apps/web/src/components/HomeBrand/HomeBrand.tsx
+++ b/apps/web/src/components/HomeBrand/HomeBrand.tsx
@@ -24,8 +24,8 @@ export function HomeBrand() {
 
   return (
     <Link href="/" className={styles.root} aria-label="Flight Finder home">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M21.5 12 3 4l3 8-3 8 18.5-8Z" />
+      <svg width="16" height="16" viewBox="95 2 58 58" fill="currentColor" aria-hidden="true">
+        <path d="m103.3 13.4 3.6-3.1 24.3 5 8.3-9.2c1.7-1.8 5-2.4 7.5-2.8-0.2 2.6-0.4 5.8-2 7.7l-8.4 9.9 5 22.8-3.3 4.6-10.5-19.3-10.4 10.4 2 8.5-3.7 4.7-4.5-12.3-12.3-4.2 3.3-3.1 10 1.4 10-10.3z" />
       </svg>
       <span className={styles.word}>Flight Finder</span>
     </Link>


### PR DESCRIPTION
The wordmark pinned top-left on every page (HomeBrand) used a simplified paper-plane icon, while the real logo, in the favicon and PWA icons (icon.svg), is the full mark: a plane climbing with its contrail and a peak. That mismatch is why some places showed 'just a plane'.

Swap HomeBrand to the real mark's path (same viewBox as icon.svg), using currentColor so it stays theme aware; the standalone icon assets keep the teal gradient. Admin/setup/login render their own brand and never used the simplified plane, so this is the only on-page occurrence.

Full gate green (1213 web + 43 cli tests, typecheck, build).