### PR TITLE
fix(deploy): drop dead lodash copies that break the image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,8 +91,6 @@ COPY --from=proddeps --chown=node:node /app/node_modules/redis-errors ./node_mod
 COPY --from=proddeps --chown=node:node /app/node_modules/denque ./node_modules/denque
 COPY --from=proddeps --chown=node:node /app/node_modules/standard-as-callback ./node_modules/standard-as-callback
 COPY --from=proddeps --chown=node:node /app/node_modules/cluster-key-slot ./node_modules/cluster-key-slot
-COPY --from=proddeps --chown=node:node /app/node_modules/lodash.defaults ./node_modules/lodash.defaults
-COPY --from=proddeps --chown=node:node /app/node_modules/lodash.isarguments ./node_modules/lodash.isarguments
 COPY --from=proddeps --chown=node:node /app/node_modules/debug ./node_modules/debug
 COPY --from=proddeps --chown=node:node /app/node_modules/ms ./node_modules/ms
 COPY --from=proddeps --chown=node:node /app/node_modules/ua-parser-js ./node_modules/ua-parser-js


### PR DESCRIPTION
main's production image build is currently broken: ioredis 5.11 dropped `lodash.defaults`/`lodash.isarguments`, but the Dockerfile still `COPY`s them, so the build fails with 'not found' (this is why the integration CI job is red on every PR).

Removes the two dead lines. Validated with a local `docker build` to exit 0 (image builds, @anthropic-ai resolves at root on the Next 15 tree).

Merge this first to unblock the deploy and turn integration green.