### PR TITLE
ci(security): add OpenSSF Scorecard and Gitleaks

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,20 @@
+name: Gitleaks
+
+# Scan the repository for committed secrets and keys on every push and PR.
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,38 @@
+name: Scorecard
+
+# OpenSSF Scorecard rates the repository's supply chain security posture and
+# publishes the result to the Security tab and the public Scorecard API.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '27 7 * * 2'
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Two supply chain guards:
- OpenSSF Scorecard rates the repo's security posture (publishes to the Security tab and the Scorecard API).
- Gitleaks scans for committed secrets and keys on push and PR. Highest value here, since the app handles ANTHROPIC_API_KEY, ADMIN_PASSWORD, etc. (Doppler keeps them out of the repo; this catches an accidental commit).