### PR TITLE
fix(scraper): harden flight extraction against model output shape drift (#139)

### DIFF
--- a/apps/web/src/lib/scraper/extract-prices.live.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.live.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Live extraction regression guard (issue #139: "All searches end in
+ * 'Flights exist but none matched your filters'").
+ *
+ * Every other extract test mocks the `extract()` function or stubs the SDK at
+ * the HTTP layer (LLMock), so they validate the filter logic but never the real
+ * model -> regex -> JSON.parse -> validity-filter path. A regression in the
+ * prompt, the JSON-extraction regex, or the LLM output shape that empties
+ * `validPrices` would surface as `all_filtered_out` in production yet stay green
+ * in the suite. This test runs the genuine `claude-code` CLI provider (no API
+ * key, just the host's Claude auth) against the bundled Google Flights fixture
+ * and asserts real, schema-valid flights come out the other side.
+ *
+ * Gated: runs only when RUN_LLM_INTEGRATION=1 AND an authenticated `claude` CLI
+ * is on PATH. Skips cleanly in CI / on boxes without Claude auth so the default
+ * suite stays hermetic and fast.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { extractPrices, type QueryFilters } from './extract-prices';
+
+function claudeIsUsable(): boolean {
+  if (process.env.RUN_LLM_INTEGRATION !== '1') return false;
+  try {
+    execSync('which claude', { stdio: 'ignore' });
+  } catch {
+    return false;
+  }
+  const home = homedir();
+  return (
+    existsSync(join(home, '.claude.json')) ||
+    existsSync(join(home, '.claude', 'credentials.json')) ||
+    existsSync(join(home, '.claude', '.credentials.json'))
+  );
+}
+
+const fixture = readFileSync(
+  join(__dirname, '../../test/fixtures/google-flights-sample.txt'),
+  'utf-8',
+);
+
+const CONFIG = {
+  provider: 'claude-code',
+  model: process.env.LLM_INTEGRATION_MODEL ?? 'sonnet',
+  customBaseUrl: null,
+} as const;
+
+const SEARCH_URL = 'https://www.google.com/travel/flights?q=JFK+to+LAX+2026-06-15';
+const FALLBACK_DATE = '2026-06-15';
+
+const noFilters: QueryFilters = {
+  maxPrice: null,
+  maxStops: null,
+  maxDurationHours: null,
+  preferredAirlines: [],
+  timePreference: 'any',
+  cabinClass: 'economy',
+};
+
+describe.skipIf(!claudeIsUsable())('extractPrices live (claude-code) — issue #139 regression guard', () => {
+  // The global test setup (src/test/setup.ts) points ANTHROPIC_BASE_URL at the
+  // LLMock server to trap leaked SDK calls. The claude-code provider spawns the
+  // real `claude` CLI, which would inherit that redirect and fail. Production
+  // does not set these, so clear them for the spawn and restore afterwards.
+  const PROXY_ENV = ['ANTHROPIC_BASE_URL', 'ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'OPENAI_BASE_URL'];
+  const saved: Record<string, string | undefined> = {};
+  beforeAll(() => {
+    for (const k of PROXY_ENV) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterAll(() => {
+    for (const k of PROXY_ENV) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('returns schema-valid flights from the real model, never all_filtered_out', async () => {
+    const result = await extractPrices(
+      fixture,
+      SEARCH_URL,
+      FALLBACK_DATE,
+      noFilters,
+      10,
+      true,
+      'google_flights',
+      'USD',
+      CONFIG,
+    );
+
+    expect(result.failureReason).toBeUndefined();
+    // The fixture lists six flights; a healthy extraction recovers most of them.
+    expect(result.prices.length).toBeGreaterThanOrEqual(4);
+
+    // The exact gate that produces all_filtered_out: every row must have a
+    // positive numeric price and a non-empty airline. A model returning the
+    // wrong field names or stringified prices ("$189") would empty this.
+    for (const p of result.prices) {
+      expect(typeof p.price).toBe('number');
+      expect(p.price).toBeGreaterThan(0);
+      expect(p.airline.length).toBeGreaterThan(0);
+    }
+
+    const cheapest = Math.min(...result.prices.map((p) => p.price));
+    expect(cheapest).toBe(98); // Spirit, the cheapest row in the fixture
+  }, 120_000);
+
+  it('honours a server-side duration filter without emptying valid results', async () => {
+    const result = await extractPrices(
+      fixture,
+      SEARCH_URL,
+      FALLBACK_DATE,
+      { ...noFilters, maxDurationHours: 7 },
+      10,
+      true,
+      'google_flights',
+      'USD',
+      CONFIG,
+    );
+
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices.length).toBeGreaterThan(0);
+    // 7h cap keeps the ~6h15m nonstops, drops the 8h30m / 9h45m one-stops.
+    for (const p of result.prices) {
+      expect(p.stops).toBe(0);
+    }
+  }, 120_000);
+});

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -30,7 +30,7 @@ vi.mock('./ai-registry', () => ({
 
 process.env.ANTHROPIC_API_KEY = 'test-key';
 
-import { extractPrices, sanitizeScrapedHtml } from './extract-prices';
+import { extractPrices, sanitizeScrapedHtml, coercePrice, coerceStops, extractJsonArray, type QueryFilters } from './extract-prices';
 
 describe('sanitizeScrapedHtml (Finding 4: untrusted scraped input)', () => {
   it('strips scripts, styles, comments, noscript, and svg while keeping visible price text', () => {
@@ -411,5 +411,204 @@ describe('extractPrices configOverride (audit A4)', () => {
     await extractPrices('page content', 'https://flights.google.com', '2026-06-15');
 
     expect(findFirstSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #139: "All searches end in 'Flights exist but none matched your
+// filters'". Real models (especially small local ones) drift from the exact
+// JSON shape the prompt asks for. The old pipeline compared raw strings with
+// `> 0` and used a greedy `/\[[\s\S]*\]/`, so a single deviation emptied every
+// result into all_filtered_out / json_parse_error. These tests pin the
+// observed real-world shapes (captured live from ollama qwen3 and the claude
+// CLI) so they can never silently break extraction again.
+// ---------------------------------------------------------------------------
+
+describe('coercePrice (issue #139 — string/symbol/grouped prices)', () => {
+  it('passes through positive numbers', () => {
+    expect(coercePrice(189)).toBe(189);
+    expect(coercePrice(189.5)).toBe(189.5);
+  });
+  it('rejects zero, negatives, NaN, Infinity', () => {
+    expect(coercePrice(0)).toBe(0);
+    expect(coercePrice(-5)).toBe(0);
+    expect(coercePrice(NaN)).toBe(0);
+    expect(coercePrice(Infinity)).toBe(0);
+  });
+  it('strips a currency symbol', () => {
+    expect(coercePrice('$189')).toBe(189);
+    expect(coercePrice('£1234')).toBe(1234);
+    expect(coercePrice('€450')).toBe(450);
+  });
+  it('strips US thousands grouping with and without decimals', () => {
+    expect(coercePrice('1,189')).toBe(1189);
+    expect(coercePrice('$1,189.50')).toBe(1189.5);
+    expect(coercePrice('USD 1,189')).toBe(1189);
+  });
+  it('handles EU grouping/decimal ("1.189,50")', () => {
+    expect(coercePrice('1.189,50')).toBe(1189.5);
+    expect(coercePrice('189,90 €')).toBe(189.9);
+  });
+  it('returns 0 for non-numeric junk and non-strings', () => {
+    expect(coercePrice('free')).toBe(0);
+    expect(coercePrice(null)).toBe(0);
+    expect(coercePrice(undefined)).toBe(0);
+    expect(coercePrice({})).toBe(0);
+    expect(coercePrice(['$1'])).toBe(0);
+  });
+});
+
+describe('coerceStops (issue #139 — loose stop types)', () => {
+  it('passes through non-negative integers', () => {
+    expect(coerceStops(0)).toBe(0);
+    expect(coerceStops(2)).toBe(2);
+  });
+  it('reads stop counts from strings', () => {
+    expect(coerceStops('Nonstop')).toBe(0);
+    expect(coerceStops('non-stop')).toBe(0);
+    expect(coerceStops('Direct')).toBe(0);
+    expect(coerceStops('1 stop')).toBe(1);
+    expect(coerceStops('2 stops')).toBe(2);
+  });
+  it('defaults junk and wrong types to 0 (never drops the flight)', () => {
+    expect(coerceStops(['JFK - LAX'])).toBe(0);
+    expect(coerceStops(null)).toBe(0);
+    expect(coerceStops('layover')).toBe(0);
+    expect(coerceStops(-1)).toBe(0);
+  });
+});
+
+describe('extractJsonArray (issue #139 — wrappers around the array)', () => {
+  it('reads a bare array', () => {
+    const r = extractJsonArray('[{"a":1}]');
+    expect(r.ok && r.value).toEqual([{ a: 1 }]);
+  });
+  it('reads an array inside a ```json markdown fence', () => {
+    const r = extractJsonArray('```json\n[{"a":1}]\n```');
+    expect(r.ok && r.value).toEqual([{ a: 1 }]);
+  });
+  it('reads an array after a reasoning <think> block that contains brackets', () => {
+    const r = extractJsonArray('<think>I should return [a list] of items [1,2]</think>\n[{"price":189}]');
+    expect(r.ok && r.value).toEqual([{ price: 189 }]);
+  });
+  it('skips a stray prose bracket and finds the real array', () => {
+    const r = extractJsonArray('Here are the results [see note]: [{"price":189}] hope this helps');
+    expect(r.ok && r.value).toEqual([{ price: 189 }]);
+  });
+  it('finds the array nested in a wrapper object', () => {
+    const r = extractJsonArray('{"flights": [{"price":189}], "count": 1}');
+    expect(r.ok && r.value).toEqual([{ price: 189 }]);
+  });
+  it('ignores brackets inside string values', () => {
+    const r = extractJsonArray('[{"airline":"Spirit [LCC]","price":98}]');
+    expect(r.ok && r.value).toEqual([{ airline: 'Spirit [LCC]', price: 98 }]);
+  });
+  it('reports no_json_in_response when there is no array at all', () => {
+    const r = extractJsonArray('I could not find any flights.');
+    expect(r).toEqual({ ok: false, reason: 'no_json_in_response' });
+  });
+  it('reports json_parse_error when a bracket exists but nothing parses', () => {
+    const r = extractJsonArray('[{"price": invalid}]');
+    expect(r).toEqual({ ok: false, reason: 'json_parse_error' });
+  });
+});
+
+describe('extractPrices end-to-end shape robustness (issue #139)', () => {
+  beforeEach(() => mockExtract.mockReset());
+
+  const NO_FILTERS: QueryFilters = { maxPrice: null, maxStops: null, maxDurationHours: null, preferredAirlines: [], timePreference: 'any', cabinClass: 'economy' };
+
+  async function run(content: string) {
+    mockExtract.mockResolvedValue({ content, usage: { inputTokens: 100, outputTokens: 50 } });
+    return extractPrices('page', 'https://flights.google.com', '2026-06-15', { ...NO_FILTERS }, 10, true, 'google_flights', 'USD');
+  }
+
+  it('recovers flights when EVERY price is a "$"-prefixed string (the exact #139 failure)', async () => {
+    const result = await run(JSON.stringify([
+      { travelDate: '2026-06-15', price: '$189', currency: 'USD', airline: 'Delta', stops: 0, duration: '6h 15m' },
+      { travelDate: '2026-06-15', price: '$98', currency: 'USD', airline: 'Spirit', stops: 1, duration: '9h 45m' },
+    ]));
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices).toHaveLength(2);
+    expect(result.prices.map((p) => p.price).sort((a, b) => a - b)).toEqual([98, 189]);
+  });
+
+  it('recovers flights when prices use thousands separators ("1,189")', async () => {
+    const result = await run(JSON.stringify([
+      { price: '1,189', airline: 'BA', currency: 'USD', duration: '8h' },
+      { price: '$2,450.00', airline: 'United', currency: 'USD', duration: '11h' },
+    ]));
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices.map((p) => p.price).sort((a, b) => a - b)).toEqual([1189, 2450]);
+  });
+
+  it('keeps a flight whose stops field is an array (qwen3 shape)', async () => {
+    const result = await run(JSON.stringify([
+      { price: 189, airline: 'Delta', currency: 'USD', stops: ['JFK - LAX'], duration: '6h 15m' },
+    ]));
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices).toHaveLength(1);
+    expect(result.prices[0]!.stops).toBe(0);
+  });
+
+  it('extracts from a ```json markdown fence (claude CLI shape)', async () => {
+    const result = await run('```json\n' + JSON.stringify([
+      { price: 205, airline: 'Alaska Airlines', currency: 'USD', stops: 0, duration: '6h 15m' },
+    ]) + '\n```');
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices).toHaveLength(1);
+    expect(result.prices[0]!.airline).toBe('Alaska Airlines');
+  });
+
+  it('extracts after a reasoning <think> block containing brackets', async () => {
+    const result = await run('<think>The cheapest options are [Spirit, Delta]. I will format as [...]</think>\n' + JSON.stringify([
+      { price: 98, airline: 'Spirit', currency: 'USD', stops: 1, duration: '9h 45m' },
+    ]));
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices).toHaveLength(1);
+    expect(result.prices[0]!.price).toBe(98);
+  });
+
+  it('extracts when the array is wrapped in an object and trailed by prose', async () => {
+    const result = await run('{"flights": [{"price": 172, "airline": "United", "currency": "USD", "stops": 1, "duration": "8h 30m"}]} — found 1 flight');
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices).toHaveLength(1);
+    expect(result.prices[0]!.price).toBe(172);
+  });
+
+  it('trims whitespace-padded airline names', async () => {
+    const result = await run(JSON.stringify([
+      { price: 189, airline: '  Delta  ', currency: 'USD', stops: 0, duration: '6h' },
+    ]));
+    expect(result.prices).toHaveLength(1);
+    expect(result.prices[0]!.airline).toBe('Delta');
+  });
+
+  it('keeps valid rows and drops only the genuinely broken ones', async () => {
+    const result = await run(JSON.stringify([
+      { price: '$189', airline: 'Delta', currency: 'USD', stops: 0, duration: '6h' },
+      { price: 0, airline: 'Ghost', currency: 'USD', stops: 0, duration: '6h' },
+      { price: 'free', airline: 'Scam', currency: 'USD', stops: 0, duration: '6h' },
+      { price: 245, airline: '', currency: 'USD', stops: 0, duration: '6h' },
+      { price: 98, airline: 'Spirit', currency: 'USD', stops: 1, duration: '9h' },
+    ]));
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices.map((p) => p.airline).sort()).toEqual(['Delta', 'Spirit']);
+  });
+
+  it('still reports all_filtered_out only when nothing is genuinely usable', async () => {
+    const result = await run(JSON.stringify([
+      { price: 0, airline: 'A', currency: 'USD', stops: 0 },
+      { price: 'free', airline: 'B', currency: 'USD', stops: 0 },
+      { price: 200, airline: '', currency: 'USD', stops: 0 },
+    ]));
+    expect(result.prices).toEqual([]);
+    expect(result.failureReason).toBe('all_filtered_out');
+  });
+
+  it('reports all_filtered_out for an array of non-objects', async () => {
+    const result = await run('["Delta $189", "Spirit $98"]');
+    expect(result.prices).toEqual([]);
+    expect(result.failureReason).toBe('all_filtered_out');
   });
 });

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -170,6 +170,136 @@ export interface ExtractionResult {
 }
 
 /**
+ * Find the index of the ']' that closes the '[' at `start`, ignoring brackets
+ * that appear inside JSON string literals. Returns -1 when unbalanced.
+ */
+function matchingArrayEnd(text: string, start: number): number {
+  let depth = 0;
+  let inStr = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i]!;
+    if (inStr) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === '[') depth++;
+    else if (ch === ']' && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/**
+ * Robustly pull the JSON array of flights out of a model's raw text.
+ *
+ * Real models (especially small local ones and reasoning models) wrap the
+ * answer in ways a naive `/\[[\s\S]*\]/` cannot survive:
+ *  - markdown code fences (```json ... ```)
+ *  - <think>...</think> reasoning blocks that themselves contain brackets
+ *  - a prose sentence before/after the array, sometimes with stray brackets
+ *  - the array nested inside a wrapper object ({"flights": [...]})
+ *
+ * The greedy regex matched from the FIRST '[' to the LAST ']', so any stray
+ * bracket in the prose produced invalid JSON and a hard failure. Instead we
+ * strip reasoning blocks, then scan every '[' and return the first balanced
+ * substring that actually parses into an array. Issue #139.
+ */
+export function extractJsonArray(
+  content: string,
+): { ok: true; value: unknown[] } | { ok: false; reason: 'no_json_in_response' | 'json_parse_error' } {
+  const text = content.replace(/<think>[\s\S]*?<\/think>/gi, '');
+  let sawBracket = false;
+  for (let start = text.indexOf('['); start !== -1; start = text.indexOf('[', start + 1)) {
+    sawBracket = true;
+    const end = matchingArrayEnd(text, start);
+    if (end === -1) continue;
+    try {
+      const parsed: unknown = JSON.parse(text.slice(start, end + 1));
+      if (Array.isArray(parsed)) return { ok: true, value: parsed };
+    } catch {
+      // Not a valid array at this '['; try the next one.
+    }
+  }
+  return { ok: false, reason: sawBracket ? 'json_parse_error' : 'no_json_in_response' };
+}
+
+/**
+ * Coerce whatever the model put in `price` into a positive number, or 0 when
+ * it is unusable. Models frequently ignore the "number, no symbols" rule and
+ * emit "$189", "1,189", "USD 1,189.50", or "1.189,50" (EU). The old code
+ * compared these strings directly with `> 0`, which is NaN for anything with a
+ * symbol or grouping separator, so every row was dropped -> all_filtered_out
+ * on every search. Issue #139.
+ */
+export function coercePrice(value: unknown): number {
+  if (typeof value === 'number') return Number.isFinite(value) && value > 0 ? value : 0;
+  if (typeof value !== 'string') return 0;
+  let s = value.replace(/[^0-9.,]/g, '');
+  if (!s) return 0;
+  const lastComma = s.lastIndexOf(',');
+  const lastDot = s.lastIndexOf('.');
+  if (lastComma !== -1 && lastDot !== -1) {
+    // Both separators present: the rightmost is the decimal point, the other
+    // is the thousands grouping. "1,189.50" (US) vs "1.189,50" (EU).
+    s = lastComma > lastDot ? s.replace(/\./g, '').replace(',', '.') : s.replace(/,/g, '');
+  } else if (lastComma !== -1) {
+    // Only commas: 1-2 trailing digits reads as a decimal ("189,5"); otherwise
+    // it is thousands grouping ("1,189").
+    s = s.length - lastComma - 1 <= 2 ? s.replace(',', '.') : s.replace(/,/g, '');
+  }
+  const n = parseFloat(s);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/** Coerce `stops` into a non-negative integer. Accepts numbers, "1 stop",
+ * "Nonstop"/"Direct", or junk (-> 0). Not part of the validity gate, but keeps
+ * the stored data clean when a model types it loosely. */
+export function coerceStops(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.max(0, Math.trunc(value));
+  if (typeof value === 'string') {
+    if (/non[\s-]?stop|direct/i.test(value)) return 0;
+    const m = value.match(/\d+/);
+    return m ? parseInt(m[0]!, 10) : 0;
+  }
+  return 0;
+}
+
+function coerceSeatsLeft(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const m = value.match(/\d+/);
+    if (m) return parseInt(m[0]!, 10);
+  }
+  return null;
+}
+
+/**
+ * Normalize one raw model entry into a fully typed PriceData. Every field is
+ * defended against the wrong type (e.g. qwen3 emits `stops` as an array), so a
+ * single loosely-typed field can never silently drop a real flight.
+ */
+function normalizeEntry(entry: unknown, travelDateFallback: string, currency: string | null): PriceData | null {
+  if (typeof entry !== 'object' || entry === null) return null;
+  const e = entry as Record<string, unknown>;
+  return {
+    travelDate: typeof e.travelDate === 'string' && e.travelDate ? e.travelDate : travelDateFallback,
+    price: coercePrice(e.price),
+    currency: typeof e.currency === 'string' && e.currency ? e.currency : (currency ?? 'USD'),
+    airline: typeof e.airline === 'string' ? e.airline.trim() : '',
+    bookingUrl: typeof e.bookingUrl === 'string' ? e.bookingUrl : '',
+    stops: coerceStops(e.stops),
+    duration: typeof e.duration === 'string' ? e.duration : null,
+    departureTime: typeof e.departureTime === 'string' ? e.departureTime : null,
+    arrivalTime: typeof e.arrivalTime === 'string' ? e.arrivalTime : null,
+    seatsLeft: coerceSeatsLeft(e.seatsLeft),
+    flightNumber: typeof e.flightNumber === 'string' ? e.flightNumber : null,
+  };
+}
+
+/**
  * Slim subset of ExtractionConfig that extractPrices needs. Allows callers
  * (preview-runner, run-scrape) to read the config once up front and pass
  * it through every per-attempt call, instead of extractPrices hitting the
@@ -268,39 +398,35 @@ ${UNTRUSTED_CLOSE}`;
     return { prices: [], usage: { inputTokens: 0, outputTokens: 0 }, failureReason: 'llm_error' };
   }
 
-  const jsonMatch = result.content.match(/\[[\s\S]*\]/);
-  if (!jsonMatch) {
-    console.log(`[extract] FAIL no_json_in_response — LLM returned no parseable JSON`);
-    return { prices: [], usage: result.usage, failureReason: 'no_json_in_response' };
+  const parsed = extractJsonArray(result.content);
+  if (!parsed.ok) {
+    if (parsed.reason === 'no_json_in_response') {
+      console.log(`[extract] FAIL no_json_in_response — LLM returned no parseable JSON`);
+    } else {
+      console.error(`[extract] FAIL json_parse_error — found '[' but no balanced array parsed; preview=${result.content.slice(0, 200)}`);
+    }
+    return { prices: [], usage: result.usage, failureReason: parsed.reason };
   }
 
-  let raw: PriceData[];
-  try {
-    raw = JSON.parse(jsonMatch[0]) as PriceData[];
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    const preview = jsonMatch[0].slice(0, 200);
-    console.error(`[extract] FAIL json_parse_error length=${jsonMatch[0].length} err=${msg} preview=${preview}`);
-    return { prices: [], usage: result.usage, failureReason: 'json_parse_error' };
-  }
-
-  if (raw.length === 0) {
+  if (parsed.value.length === 0) {
     console.log(`[extract] FAIL empty_extraction — LLM returned [] (${result.usage.inputTokens} input tokens)`);
     return { prices: [], usage: result.usage, failureReason: 'empty_extraction' };
   }
 
-  // Coerce null bookingUrl to empty string (LLMs frequently return null)
-  for (const p of raw) {
-    if (!p.bookingUrl) p.bookingUrl = '';
-  }
+  // Normalize every entry into a fully typed PriceData, defending each field
+  // against the wrong type. This is what stops loosely-formatted model output
+  // (string prices like "$189", `stops` as an array, etc.) from silently
+  // emptying the result set. Issue #139.
+  const raw = parsed.value
+    .map((entry) => normalizeEntry(entry, travelDateFallback, currency))
+    .filter((p): p is PriceData => p !== null);
 
-  // Filter out obviously invalid entries
-  const validPrices = raw.filter(
-    (p) => p.price > 0 && p.airline && p.airline.length > 0
-  );
+  // Filter out invalid entries: a usable flight needs a positive price and an
+  // airline name. coercePrice has already turned "$189"/"1,189" into numbers.
+  const validPrices = raw.filter((p) => p.price > 0 && p.airline.length > 0);
 
   if (validPrices.length === 0) {
-    console.log(`[extract] FAIL all_filtered_out — ${raw.length} raw results all invalid`);
+    console.log(`[extract] FAIL all_filtered_out — ${parsed.value.length} raw results all invalid (no positive price + airline after normalization)`);
     return { prices: [], usage: result.usage, failureReason: 'all_filtered_out' };
   }
 


### PR DESCRIPTION
Reporter (#139) saw every search end in "Flights exist but none matched your filters", on every route and even on manual entry.

Cause: the extractor kept a flight only when `price > 0`, comparing the raw value the model returned. Models often return the price as a string with a symbol or thousands separator ("$189", "1,189"), which compares as NaN, so every row was dropped and the search collapsed to all_filtered_out. The JSON locator was greedy as well (first bracket to last), so a reasoning model's think block or a stray bracket in prose broke parsing. Weak and local models drift from the requested shape the most, which is why it hit on every search.

Every test tier mocked the model with already-clean JSON, so this class of shape drift was invisible. That is the real gap.

What changed:
* Normalize each entry before validating: parse string/symbol/grouped prices to numbers (US and EU formats), read stops and seats loosely, trim airline names.
* Locate the array by stripping reasoning and code fence wrappers, then taking the first balanced array that actually parses (also handles a wrapper object and trailing prose). A row is dropped only with no positive price or no airline.
* 27 tests pinning the real shapes models emit (string/grouped prices, stops as an array, fences, reasoning blocks, wrapper objects, prose brackets) plus a gated live test running the real provider end to end.

Reproduced live with ollama qwen3 (recovered 1 of 6 flights, typed stops as an array). Also verified the Claude Code provider extracts the fixture cleanly, which confirms the cause is model output formatting and not the scraper.

The CLI imports the same extractPrices, so it is covered too. Gate green: lint, typecheck, 1240 tests, build.
