### PR TITLE
fix(scraper): post-#140 extraction + CLI provider hardening

### DIFF
--- a/apps/web/src/lib/scraper/ai-registry.test.ts
+++ b/apps/web/src/lib/scraper/ai-registry.test.ts
@@ -771,6 +771,38 @@ describe('CLI provider lockdown (Finding 4)', () => {
     expect(args).not.toContain('--allow-dangerously-skip-permissions');
   });
 
+  it('claude-code spawns without the API key or any host endpoint/token override (#139 follow-up)', async () => {
+    const proc = createFakeProc();
+    mockSpawn.mockReturnValue(proc);
+    const saved = {
+      key: process.env.ANTHROPIC_API_KEY,
+      base: process.env.ANTHROPIC_BASE_URL,
+      token: process.env.ANTHROPIC_AUTH_TOKEN,
+    };
+    // Simulate a host (or the test harness) that redirects Anthropic traffic.
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-host';
+    process.env.ANTHROPIC_BASE_URL = 'http://127.0.0.1:19876/v1';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'host-token';
+    try {
+      const done = EXTRACTION_PROVIDERS['claude-code']!.extract('', 'sonnet', 'system', 'page');
+      await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
+      proc.stdout!.emit('data', Buffer.from('[]'));
+      proc.emit('close', 0);
+      await done;
+
+      const opts = mockSpawn.mock.calls[0]![2] as { env: NodeJS.ProcessEnv };
+      expect(opts.env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(opts.env.ANTHROPIC_BASE_URL).toBeUndefined();
+      expect(opts.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+      // PATH and other host env still pass through.
+      expect(opts.env.PATH).toBeDefined();
+    } finally {
+      if (saved.key === undefined) delete process.env.ANTHROPIC_API_KEY; else process.env.ANTHROPIC_API_KEY = saved.key;
+      if (saved.base === undefined) delete process.env.ANTHROPIC_BASE_URL; else process.env.ANTHROPIC_BASE_URL = saved.base;
+      if (saved.token === undefined) delete process.env.ANTHROPIC_AUTH_TOKEN; else process.env.ANTHROPIC_AUTH_TOKEN = saved.token;
+    }
+  });
+
   it('codex runs with the read-only sandbox, never danger-full-access', async () => {
     const proc = createFakeProc();
     mockSpawn.mockReturnValue(proc);

--- a/apps/web/src/lib/scraper/ai-registry.ts
+++ b/apps/web/src/lib/scraper/ai-registry.ts
@@ -283,7 +283,14 @@ export const EXTRACTION_PROVIDERS: Record<string, ProviderConfig> = {
 
       const result = await new Promise<string>((resolve, reject) => {
         const env = { ...process.env };
+        // Force the CLI onto its own Max-subscription auth. Drop the API key AND
+        // any inherited base-URL / auth-token override that would otherwise
+        // redirect the spawned `claude` at a different endpoint (a host proxy,
+        // or a test harness's mock server). A stray ANTHROPIC_BASE_URL silently
+        // breaks extraction with an llm_error. Issue #139 follow-up.
         delete env.ANTHROPIC_API_KEY;
+        delete env.ANTHROPIC_AUTH_TOKEN;
+        delete env.ANTHROPIC_BASE_URL;
         // Extraction is pure text-in / JSON-out and needs no agentic capability.
         // The input is adversarial scraped HTML, so run the agent locked down:
         // deny every tool (overrides any pre-approval in the host's

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -449,6 +449,18 @@ describe('coercePrice (issue #139 — string/symbol/grouped prices)', () => {
     expect(coercePrice('1.189,50')).toBe(1189.5);
     expect(coercePrice('189,90 €')).toBe(189.9);
   });
+  it('treats a lone dot with 3 trailing digits as thousands grouping (PR #140 review)', () => {
+    // 3 places after a lone dot is grouping, not a decimal — currency uses 1-2
+    // places. Misreading "1.234" as 1.234 would record a fake ultra-cheap fare.
+    expect(coercePrice('1.234')).toBe(1234);
+    expect(coercePrice('12.500')).toBe(12500);
+    expect(coercePrice('1.234.567')).toBe(1234567);
+  });
+  it('keeps a lone dot with 1-2 trailing digits as a decimal', () => {
+    expect(coercePrice('189.00')).toBe(189);
+    expect(coercePrice('189.9')).toBe(189.9);
+    expect(coercePrice('1234.50')).toBe(1234.5);
+  });
   it('returns 0 for non-numeric junk and non-strings', () => {
     expect(coercePrice('free')).toBe(0);
     expect(coercePrice(null)).toBe(0);
@@ -469,6 +481,14 @@ describe('coerceStops (issue #139 — loose stop types)', () => {
     expect(coerceStops('Direct')).toBe(0);
     expect(coerceStops('1 stop')).toBe(1);
     expect(coerceStops('2 stops')).toBe(2);
+  });
+  it('reads a bare numeric string as a stop count', () => {
+    expect(coerceStops('2')).toBe(2);
+    expect(coerceStops(' 0 ')).toBe(0);
+  });
+  it('does not read an unrelated number as stops (PR #140 review)', () => {
+    expect(coerceStops('Flight 123')).toBe(0);
+    expect(coerceStops('AA123 nonstop')).toBe(0);
   });
   it('defaults junk and wrong types to 0 (never drops the flight)', () => {
     expect(coerceStops(['JFK - LAX'])).toBe(0);
@@ -498,6 +518,14 @@ describe('extractJsonArray (issue #139 — wrappers around the array)', () => {
   it('finds the array nested in a wrapper object', () => {
     const r = extractJsonArray('{"flights": [{"price":189}], "count": 1}');
     expect(r.ok && r.value).toEqual([{ price: 189 }]);
+  });
+  it('prefers a later object array over an earlier scalar/header array (PR #140 review)', () => {
+    const r = extractJsonArray('Columns: ["price","airline"]\n[{"price":189,"airline":"Delta"}]');
+    expect(r.ok && r.value).toEqual([{ price: 189, airline: 'Delta' }]);
+  });
+  it('falls back to a scalar array only when no object array exists', () => {
+    const r = extractJsonArray('["Delta","Spirit"]');
+    expect(r.ok && r.value).toEqual(['Delta', 'Spirit']);
   });
   it('ignores brackets inside string values', () => {
     const r = extractJsonArray('[{"airline":"Spirit [LCC]","price":98}]');
@@ -610,5 +638,14 @@ describe('extractPrices end-to-end shape robustness (issue #139)', () => {
     const result = await run('["Delta $189", "Spirit $98"]');
     expect(result.prices).toEqual([]);
     expect(result.failureReason).toBe('all_filtered_out');
+  });
+
+  it('recovers flights when a header/prose array precedes the real flight array', async () => {
+    const result = await run('Columns: ["price","airline","stops"]\n' + JSON.stringify([
+      { price: 189, airline: 'Delta', currency: 'USD', stops: 0, duration: '6h 15m' },
+      { price: 98, airline: 'Spirit', currency: 'USD', stops: 1, duration: '9h 45m' },
+    ]));
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices.map((p) => p.airline).sort()).toEqual(['Delta', 'Spirit']);
   });
 });

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -212,17 +212,30 @@ export function extractJsonArray(
 ): { ok: true; value: unknown[] } | { ok: false; reason: 'no_json_in_response' | 'json_parse_error' } {
   const text = content.replace(/<think>[\s\S]*?<\/think>/gi, '');
   let sawBracket = false;
+  let firstArray: unknown[] | null = null;
   for (let start = text.indexOf('['); start !== -1; start = text.indexOf('[', start + 1)) {
     sawBracket = true;
     const end = matchingArrayEnd(text, start);
     if (end === -1) continue;
+    let parsed: unknown;
     try {
-      const parsed: unknown = JSON.parse(text.slice(start, end + 1));
-      if (Array.isArray(parsed)) return { ok: true, value: parsed };
+      parsed = JSON.parse(text.slice(start, end + 1));
     } catch {
-      // Not a valid array at this '['; try the next one.
+      continue; // not valid JSON at this '['; try the next one
     }
+    if (!Array.isArray(parsed)) continue;
+    // Prefer the first array that holds object rows. A model can emit a header
+    // or prose array (["price","airline"], or a reasoning list) before the real
+    // flight array; returning that scalar array would drop every real row.
+    // Issue #139 / PR #140 review finding 1.
+    if (parsed.some((el) => typeof el === 'object' && el !== null)) {
+      return { ok: true, value: parsed };
+    }
+    if (firstArray === null) firstArray = parsed;
   }
+  // No object array found. Fall back to the first array seen, which keeps `[]`
+  // as empty_extraction and a pure scalar array as all_filtered_out downstream.
+  if (firstArray !== null) return { ok: true, value: firstArray };
   return { ok: false, reason: sawBracket ? 'json_parse_error' : 'no_json_in_response' };
 }
 
@@ -249,6 +262,13 @@ export function coercePrice(value: unknown): number {
     // Only commas: 1-2 trailing digits reads as a decimal ("189,5"); otherwise
     // it is thousands grouping ("1,189").
     s = s.length - lastComma - 1 <= 2 ? s.replace(',', '.') : s.replace(/,/g, '');
+  } else if (lastDot !== -1) {
+    // Only dots. Multiple dots are thousands grouping ("1.234.567"). A single
+    // dot with exactly 3 trailing digits is also grouping ("1.234" -> 1234):
+    // currency decimals use 1-2 places, so 3 places means grouping. Treating it
+    // as a decimal would record a fake ultra-cheap fare. PR #140 review finding 2.
+    const dotCount = (s.match(/\./g) ?? []).length;
+    if (dotCount > 1 || s.length - lastDot - 1 === 3) s = s.replace(/\./g, '');
   }
   const n = parseFloat(s);
   return Number.isFinite(n) && n > 0 ? n : 0;
@@ -261,8 +281,14 @@ export function coerceStops(value: unknown): number {
   if (typeof value === 'number' && Number.isFinite(value)) return Math.max(0, Math.trunc(value));
   if (typeof value === 'string') {
     if (/non[\s-]?stop|direct/i.test(value)) return 0;
-    const m = value.match(/\d+/);
-    return m ? parseInt(m[0]!, 10) : 0;
+    // Read a stop-specific phrase ("1 stop", "2 stops") rather than any digit,
+    // so "Flight 123" or "AA123" is not misread as 123 stops. PR #140 review
+    // finding 4.
+    const phrase = value.match(/(\d+)\s*stops?/i);
+    if (phrase) return parseInt(phrase[1]!, 10);
+    // A bare numeric string ("2") is a stop count; anything else is unknown.
+    const trimmed = value.trim();
+    return /^\d+$/.test(trimmed) ? parseInt(trimmed, 10) : 0;
   }
   return 0;
 }


### PR DESCRIPTION
Follow-up to #140. Closes the gaps a code review of that PR surfaced, plus the CLI proxy-env footgun I hit while reproducing #139.

Extraction parsing (`extract-prices.ts`):
* `extractJsonArray` now prefers the first array that holds object rows. A model can emit a header or prose array (`["price","airline"]`, or a reasoning list) before the real flight array; returning that scalar array dropped every real row. Falls back to the first array seen, so `[]` stays empty_extraction and a pure scalar array stays all_filtered_out.
* `coercePrice` treats a lone dot with 3 trailing digits (or multiple dots) as thousands grouping (`"1.234"` becomes `1234`). Currency decimals use 1-2 places, so 3 places is grouping. Misreading it recorded a fake ultra-cheap fare, which on this app could trip the new-low alerts.
* `coerceStops` reads a stop-specific phrase (`"1 stop"`) or a bare numeric string rather than any digit, so `"Flight 123"` is no longer read as 123 stops.

CLI provider (`ai-registry.ts`):
* The claude-code provider now also drops `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` before spawning, not just `ANTHROPIC_API_KEY`. An inherited base-URL override (a host proxy, or a test mock server) silently redirected the spawned CLI and failed extraction with `llm_error`. Codex (read-only sandbox) authenticates via its own config and is unaffected by these vars, so it is left unchanged.

Tests cover each case plus a spawn-env assertion. lint, typecheck, full suite, and build all green.
