### PR TITLE
fix(migration): prompt stranded pre-rename users to migrate (#139)

### DIFF
--- a/apps/web/public/fairtrail-cli
+++ b/apps/web/public/fairtrail-cli
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Fairtrail -> Flight Finder migration prompt (deprecated CLI shim)
+# ============================================================================
+# Fairtrail was renamed to Flight Finder at v0.9.0. Installs from before the
+# rename run a `fairtrail` binary whose `update` command re-fetches THIS file
+# (from https://fairtrail.org/fairtrail-cli, which now redirects to
+# https://flight-finder.org/fairtrail-cli) and then re-pulls
+# ghcr.io/affromero/fairtrail:latest. That image is frozen at the rename, so
+# `fairtrail update` silently never advances and the user is stranded on the
+# old version (issue #139: a 0.8.0 user could not get the extraction fix).
+#
+# Serving this shim at the legacy URL turns that dead-end into an action: the
+# stale `fairtrail update` overwrites its own binary with this prompt, so the
+# next `fairtrail` invocation offers to migrate (re-runs the installer, which
+# auto-detects ~/.fairtrail, renames the database, reuses the volume, and
+# installs the latest Flight Finder, keeping `fairtrail` as an alias).
+# ============================================================================
+set -euo pipefail
+
+BOLD=$'\033[1m'; CYAN=$'\033[0;36m'; YELLOW=$'\033[0;33m'; GREEN=$'\033[0;32m'; RESET=$'\033[0m'
+ONELINER="curl -fsSL https://flight-finder.org/install.sh | bash"
+
+printf '%b\n' "${YELLOW}${BOLD}!${RESET} Fairtrail is now ${BOLD}Flight Finder${RESET} (renamed at v0.9.0)."
+printf '%b\n' "Your install predates the rename and can no longer update in place: new releases ship"
+printf '%b\n' "under a different image and command, so ${BOLD}fairtrail update${RESET} keeps re-pulling the frozen"
+printf '%b\n' "pre-rename image and never advances."
+printf '\n'
+printf '%b\n' "Migrating keeps all your data. It renames the database, reuses the existing volume, and"
+printf '%b\n' "installs the latest Flight Finder, leaving ${BOLD}fairtrail${RESET} working as an alias."
+printf '\n'
+
+# Only prompt when attached to a real terminal; in a pipe or script, print the
+# command and exit cleanly so nothing hangs on a missing stdin.
+if [ -t 0 ] && [ -t 1 ]; then
+  printf '%b' "${CYAN}${BOLD}Migrate now?${RESET} [Y/n] "
+  read -r reply || reply=""
+  case "${reply:-Y}" in
+    [Nn]*)
+      printf '%b\n' "When you are ready, run:\n  ${BOLD}${ONELINER}${RESET}"
+      exit 0
+      ;;
+  esac
+  printf '%b\n' "${GREEN}${BOLD}>${RESET} Migrating..."
+  exec bash -c "$(curl -fsSL https://flight-finder.org/install.sh)"
+fi
+
+printf '%b\n' "To migrate, run:\n  ${BOLD}${ONELINER}${RESET}"
+exit 0

--- a/scripts/migration-test.sh
+++ b/scripts/migration-test.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 INSTALLER="$REPO_ROOT/apps/web/public/install.sh"
 WRAPPER="$REPO_ROOT/apps/web/public/flight-finder-cli"
+LEGACY_SHIM="$REPO_ROOT/apps/web/public/fairtrail-cli"
 
 PASS=0
 FAIL=0
@@ -51,6 +52,15 @@ assert_grep 'FLIGHT_FINDER_SILENCE_RENAME'                     "$WRAPPER"   "wra
 assert_grep '_FF_INVOKED_AS="\$\(basename "\$0"\)"'            "$WRAPPER"   "wrapper detects invocation name for deprecation notice"
 assert_grep '^cmd_migrate\(\)'                                 "$WRAPPER"   "wrapper defines cmd_migrate function"
 assert_grep 'migrate\)[[:space:]]+cmd_migrate'                 "$WRAPPER"   "wrapper dispatches migrate subcommand"
+
+# Legacy /fairtrail-cli shim: a pre-rename `fairtrail update` re-fetches this
+# file, so it must prompt to migrate instead of being the old stale CLI (#139).
+if [ -f "$LEGACY_SHIM" ]; then pass "legacy fairtrail-cli shim is served from public/"; else fail "legacy fairtrail-cli shim is served from public/"; fi
+assert_grep 'renamed at v0\.9\.0'                              "$LEGACY_SHIM" "legacy shim states Fairtrail was renamed to Flight Finder"
+assert_grep 'curl -fsSL https://flight-finder\.org/install\.sh \| bash' "$LEGACY_SHIM" "legacy shim points at the install one-liner"
+assert_grep 'Migrate now\?'                                    "$LEGACY_SHIM" "legacy shim prompts to migrate when interactive"
+assert_grep '\[ -t 0 \] && \[ -t 1 \]'                         "$LEGACY_SHIM" "legacy shim only prompts on a real terminal"
+if bash -n "$LEGACY_SHIM" 2>/dev/null; then pass "legacy shim is valid bash"; else fail "legacy shim is valid bash"; fi
 
 echo ""
 if [ $FAIL -eq 0 ]; then


### PR DESCRIPTION
Follow-up to #139. The reporter is on v0.8.0 and `fairtrail update` will not go past it.

Root cause: a pre-rename install runs the `fairtrail` command against dir `~/.fairtrail` and image `ghcr.io/affromero/fairtrail`. `fairtrail update` re-fetches `/fairtrail-cli` and re-pulls that image, but the image is frozen at the rename (new releases publish to `ghcr.io/affromero/flight-finder`) and `/fairtrail-cli` now 404s. So the update silently no-ops and the user is stranded, with no hint to migrate. We already migrate cleanly when `install.sh` is re-run (it detects `~/.fairtrail`, renames the DB, reuses the volume, installs the latest, keeps a `fairtrail` alias) — but nothing pointed stranded users there.

Fix: serve a small shim at the legacy `/fairtrail-cli` URL. `fairtrail update` overwrites its own binary with this shim, so the next `fairtrail` invocation prints a deprecation notice and offers to migrate (re-runs the installer on confirmation). In a pipe or non-terminal it just prints the one-liner and exits, so nothing hangs.

`fairtrail.org` already 301-redirects to `flight-finder.org`, so the legacy fetch resolves here once this deploys. Adds migration-test coverage (shim exists, is valid bash, states the rename, points at the one-liner, only prompts on a real terminal). Verified the non-interactive path prints the command and exits 0 without running anything.
