### PR TITLE
fix(docker): ship browsers.json so the scraper can launch a browser (#139)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,16 @@ RUN npm ci --omit=dev --loglevel=error
 # it (the root or the apps/web workspace) and skip any a dependency bump dropped.
 # A hardcoded COPY list is brittle: ioredis dropped lodash.*, and Next 16's tree
 # hoists @anthropic-ai into the workspace rather than the root.
+#
+# playwright/playwright-core MUST be here: the standalone trace follows their JS
+# requires but misses browsers.json, which playwright-core reads dynamically at
+# chromium.launch(). Without the full package the scraper dies with
+# "Cannot find module '.../playwright-core/browsers.json'" (issue #139 follow-up).
 RUN set -e; cd /app; mkdir -p /ext; \
     for p in ioredis @ioredis redis-parser redis-errors denque standard-as-callback \
              cluster-key-slot debug ms ua-parser-js @anthropic-ai json-schema-to-ts \
-             @babel/runtime ts-algebra openai @google; do \
+             @babel/runtime ts-algebra openai @google \
+             playwright playwright-core; do \
       for base in node_modules apps/web/node_modules; do \
         if [ -e "$base/$p" ]; then mkdir -p "/ext/$(dirname "$p")"; cp -R "$base/$p" "/ext/$p"; break; fi; \
       done; \

--- a/apps/web/src/app/api/test/scrape/route.ts
+++ b/apps/web/src/app/api/test/scrape/route.ts
@@ -62,6 +62,30 @@ export async function GET(request: NextRequest) {
     })
   );
 
+  // --- Check 2b: Playwright can actually launch a browser ---
+  // The version check above only proves the binary exists. This drives the real
+  // scraper launch path (launchBrowser -> import('playwright') -> chromium.launch),
+  // which loads playwright-core/browsers.json and the system chromium. It is the
+  // guard that would have caught the standalone build dropping browsers.json,
+  // which the version check and the fixture-based extraction check both miss.
+  checks.push(
+    await runCheck('browser_launch', async () => {
+      const { launchBrowser } = await import('@/lib/scraper/browser');
+      const browser = await launchBrowser();
+      try {
+        const page = await browser.newPage();
+        await page.setContent('<h1>flight-finder smoke</h1>');
+        const text = await page.textContent('h1');
+        if (text !== 'flight-finder smoke') {
+          throw new Error(`unexpected rendered text: ${text}`);
+        }
+        return `Launched ${browser.version()} and rendered a page`;
+      } finally {
+        await browser.close();
+      }
+    })
+  );
+
   // --- Check 3: Extraction pipeline with fixture ---
   let testQueryId: string | null = null;
 


### PR DESCRIPTION
Production-breaking regression found via #139: the 0.12.0 scraper cannot launch a browser. `playwright` is in `serverExternalPackages`, but it was never added to the Dockerfile `/ext` allowlist of deps the Next standalone trace omits. The tracer follows playwright-core's JS but drops `browsers.json`, which playwright-core reads dynamically at `chromium.launch()`. So every navigate dies with `Cannot find module '.../playwright-core/browsers.json'`. Confirmed missing in our own production container, so the cron scraper has been failing, not just the reporter's instance.

Fix: add `playwright` + `playwright-core` to `/ext` so the full packages (with `browsers.json` and any other runtime-loaded data files) ship in the runtime image.

Why the gate missed it: nothing ever launched a browser. The smoke test's `chromium` check only runs `chromium --version`, and the `extraction` check feeds a fixture through `extractPrices` — neither touches Playwright. This adds a `browser_launch` check to `/api/test/scrape` that drives the real `launchBrowser()` path (import playwright, `chromium.launch()`, render a page), so a missing `browsers.json` fails the release gate.

Verified by rebuilding the image: `browsers.json` is present and the new check passes (`Launched 149.0.7827.53 and rendered a page`). Full docker smoke green.

Separately noted (not in this PR): `geoip-lite`'s data (~110MB) is also dropped by the same trace, so analytics country lookups return null. Both callers degrade gracefully (try/catch). Bundling 110MB to restore non-critical country codes is a poor tradeoff; the country-only `.dat` files are ~6.5MB if we ever want it back. Left as a follow-up decision.
