### PR TITLE
fix(ollama): UI/probe no longer force localhost over OLLAMA_HOST in Docker (#139)

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/config/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/config/page.tsx
@@ -151,7 +151,11 @@ export default function ConfigPage() {
   const handleProviderChange = (newProvider: string) => {
     setProvider(newProvider);
     setCustomModel('');
-    setCustomBaseUrl(PROVIDER_METADATA[newProvider]?.defaultBaseUrl ?? '');
+    // Leave the base URL empty so the default is only a placeholder, not a saved
+    // value. Persisting the localhost default would be stored as customBaseUrl,
+    // which overrides the OLLAMA_HOST env that install.sh sets to
+    // host.docker.internal, breaking Ollama in Docker. Issue #139 follow-up.
+    setCustomBaseUrl('');
     const newModels = PROVIDER_METADATA[newProvider]?.models ?? [];
     if (newModels.length > 0) {
       setModel(newModels[0]!.id);

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -286,7 +286,10 @@ export default function SetupPage() {
                     onClick={() => {
                       setProvider(key);
                       setCustomModel('');
-                      setCustomBaseUrl(config.defaultBaseUrl ?? '');
+                      // Empty so the default is a placeholder, not a saved value.
+                      // A persisted localhost would override the OLLAMA_HOST env
+                      // (host.docker.internal) and break Ollama in Docker. #139.
+                      setCustomBaseUrl('');
                       if (config.models[0]) setModel(config.models[0].id);
                       else setModel('');
                       fetchLocalModels(key);

--- a/apps/web/src/lib/scraper/ai-registry.test.ts
+++ b/apps/web/src/lib/scraper/ai-registry.test.ts
@@ -700,6 +700,23 @@ describe('ai-registry', () => {
         expect.any(Object)
       );
     });
+
+    it('probes OLLAMA_HOST for ollama instead of localhost (Docker; #139)', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', mockFetch);
+      const prev = process.env.OLLAMA_HOST;
+      process.env.OLLAMA_HOST = 'http://host.docker.internal:11434';
+      try {
+        await isLocalProviderReachable('ollama');
+        expect(mockFetch).toHaveBeenCalledWith(
+          'http://host.docker.internal:11434/api/tags',
+          expect.any(Object)
+        );
+      } finally {
+        if (prev === undefined) delete process.env.OLLAMA_HOST;
+        else process.env.OLLAMA_HOST = prev;
+      }
+    });
   });
 });
 

--- a/apps/web/src/lib/scraper/ai-registry.ts
+++ b/apps/web/src/lib/scraper/ai-registry.ts
@@ -433,7 +433,13 @@ export async function isLocalProviderReachable(provider: string): Promise<boolea
   const config = EXTRACTION_PROVIDERS[provider];
   if (!config) return false;
 
-  const baseUrl = config.defaultBaseUrl?.replace(/\/v1\/?$/, '') ?? '';
+  // Source the base URL the way extraction does, so the status probe agrees
+  // with what a real extract call would hit. For Ollama that means honouring
+  // OLLAMA_HOST (install.sh sets it to host.docker.internal in Docker); probing
+  // the localhost default would falsely report "unreachable" inside a container
+  // even though extraction works. Issue #139 follow-up.
+  const envBase = provider === 'ollama' ? process.env.OLLAMA_HOST : undefined;
+  const baseUrl = (envBase || config.defaultBaseUrl || '').replace(/\/v1\/?$/, '');
   const endpoint = provider === 'ollama'
     ? `${baseUrl || 'http://localhost:11434'}/api/tags`
     : `${baseUrl || 'http://localhost:8000'}/v1/models`;


### PR DESCRIPTION
Two version-independent fixes for reaching a host Ollama from the containerized app, surfaced while triaging #139 (and confirmed by a second-opinion review).

**Not a regression.** The Ollama URL logic is identical back through v0.8.0, and the rename migration preserves `.env` (it `mv`s `~/.fairtrail` and keeps the existing `.env`), so `OLLAMA_HOST` is never dropped. These are pre-existing inconsistencies, not something 0.12.0 broke.

**1. UI persisted the localhost default and it overrode the env.** The admin (`config/page.tsx`) and setup (`setup/page.tsx`) screens pre-filled the Ollama base URL with the metadata default `http://localhost:11434/v1` and saved it as `customBaseUrl`. The extractor prefers `customBaseUrl` over `OLLAMA_HOST`, and `install.sh` sets `OLLAMA_HOST=http://host.docker.internal:11434` in Docker — so a UI-configured Ollama silently saved the one address that cannot work in a container. Fix: leave the field empty so the default is a placeholder only; `OLLAMA_HOST` (or the localhost fallback on a bare host install) wins.

**2. The readiness probe ignored `OLLAMA_HOST`.** `isLocalProviderReachable()` probed the localhost default from metadata, so the provider status could report Ollama unreachable inside Docker even when extraction worked. Fix: source the probe URL from `OLLAMA_HOST` the same way extraction does.

Net effect: the UI, the status probe, and extraction now agree on how to reach Ollama in Docker. Existing users who already saved `localhost` still need to clear/repoint that value once (the issue reply covers the workaround), but no new config can fall into the trap. Adds a probe test asserting `OLLAMA_HOST` is honoured. Gate green: typecheck, lint, 58 ai-registry tests, build.
