### PR TITLE
fix(extract): tolerate typo'd/aliased field keys (gemma3n airliine) (#139)

### DIFF
--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -566,6 +566,18 @@ describe('readField (issue #139 — typo/aliased keys)', () => {
     // 'stops' is far from 'price'; a stops key must not satisfy a price read.
     expect(readField({ stops: 1 }, 'price')).toBeUndefined();
   });
+  it('never cross-maps one canonical field key to another (locks the edit-distance-1 safety)', () => {
+    // Every canonical field name must stay >1 edit from every other, or the
+    // fuzzy match could grab the wrong value. This guards the invariant if a
+    // near-duplicate field name is ever added (Codex review of PR #146).
+    const canonical = ['travelDate', 'price', 'currency', 'airline', 'bookingUrl', 'stops', 'duration', 'departureTime', 'arrivalTime', 'seatsLeft', 'flightNumber'];
+    for (const a of canonical) {
+      for (const b of canonical) {
+        if (a === b) continue;
+        expect(readField({ [a]: 'X' }, b)).toBeUndefined();
+      }
+    }
+  });
 });
 
 describe('extractPrices end-to-end shape robustness (issue #139)', () => {

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -30,7 +30,7 @@ vi.mock('./ai-registry', () => ({
 
 process.env.ANTHROPIC_API_KEY = 'test-key';
 
-import { extractPrices, sanitizeScrapedHtml, coercePrice, coerceStops, extractJsonArray, type QueryFilters } from './extract-prices';
+import { extractPrices, sanitizeScrapedHtml, coercePrice, coerceStops, extractJsonArray, readField, type QueryFilters } from './extract-prices';
 
 describe('sanitizeScrapedHtml (Finding 4: untrusted scraped input)', () => {
   it('strips scripts, styles, comments, noscript, and svg while keeping visible price text', () => {
@@ -541,6 +541,33 @@ describe('extractJsonArray (issue #139 — wrappers around the array)', () => {
   });
 });
 
+describe('readField (issue #139 — typo/aliased keys)', () => {
+  it('returns the exact key when present', () => {
+    expect(readField({ airline: 'Delta' }, 'airline')).toBe('Delta');
+  });
+  it('matches a single-character key typo (gemma3n emits airliine)', () => {
+    expect(readField({ airliine: 'Delta' }, 'airline')).toBe('Delta');
+  });
+  it('matches a case/separator variant', () => {
+    expect(readField({ Airline: 'Delta' }, 'airline')).toBe('Delta');
+    expect(readField({ flight_number: 'DL 12' }, 'flightNumber')).toBe('DL 12');
+  });
+  it('falls back to an explicit alias before fuzzy matching', () => {
+    expect(readField({ carrier: 'Delta' }, 'airline', ['carrier'])).toBe('Delta');
+    expect(readField({ cost: 189 }, 'price', ['cost', 'fare'])).toBe(189);
+  });
+  it('prefers the exact key over a typo when both exist', () => {
+    expect(readField({ airline: 'Delta', airliine: 'WRONG' }, 'airline')).toBe('Delta');
+  });
+  it('returns undefined when nothing is close', () => {
+    expect(readField({ destination: 'LAX' }, 'airline')).toBeUndefined();
+  });
+  it('does not cross-map distinct fields (price stays separate from stops)', () => {
+    // 'stops' is far from 'price'; a stops key must not satisfy a price read.
+    expect(readField({ stops: 1 }, 'price')).toBeUndefined();
+  });
+});
+
 describe('extractPrices end-to-end shape robustness (issue #139)', () => {
   beforeEach(() => mockExtract.mockReset());
 
@@ -647,5 +674,19 @@ describe('extractPrices end-to-end shape robustness (issue #139)', () => {
     ]));
     expect(result.failureReason).toBeUndefined();
     expect(result.prices.map((p) => p.airline).sort()).toEqual(['Delta', 'Spirit']);
+  });
+
+  it('recovers flights when the model misspells the airline key (gemma3n:e2b emits "airliine")', async () => {
+    // Exact shape captured from gemma3n:e2b: valid prices, every other key
+    // correct, but the airline key is consistently typo'd. Pre-fix this dropped
+    // every row as all_filtered_out. Issue #139.
+    const result = await run(JSON.stringify([
+      { travelDate: '2026-06-15', price: 189, currency: 'USD', airliine: 'Delta', stops: 0, duration: '6h 15m' },
+      { travelDate: '2026-06-15', price: 98, currency: 'USD', airliine: 'Spirit', stops: 1, duration: '9h 45m' },
+    ]));
+    expect(result.failureReason).toBeUndefined();
+    expect(result.prices).toHaveLength(2);
+    expect(result.prices.map((p) => p.airline).sort()).toEqual(['Delta', 'Spirit']);
+    expect(result.prices.map((p) => p.price).sort((a, b) => a - b)).toEqual([98, 189]);
   });
 });

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -302,26 +302,81 @@ function coerceSeatsLeft(value: unknown): number | null {
   return null;
 }
 
+/** Levenshtein distance between two short strings, with an early-exit when the
+ * lengths differ by more than 2. Only used to match field-name keys, so the
+ * naive table is fine. */
+function editDistance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (Math.abs(m - n) > 2) return 99;
+  const row = Array.from({ length: n + 1 }, (_, j) => j);
+  for (let i = 1; i <= m; i++) {
+    let diag = row[0]!;
+    row[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const tmp = row[j]!;
+      row[j] = Math.min(row[j]! + 1, row[j - 1]! + 1, diag + (a[i - 1] === b[j - 1] ? 0 : 1));
+      diag = tmp;
+    }
+  }
+  return row[n]!;
+}
+
+/**
+ * Read a field from a loosely-typed model row, tolerating misspelled or aliased
+ * keys. A small model otherwise drops an otherwise-perfect row over a single
+ * typo: gemma3n:e2b consistently emits "airliine" for "airline", so the airline
+ * read returned undefined and every row failed the validity gate (#139).
+ *
+ * Resolution order: exact key, then explicit aliases, then any key whose
+ * letters/digits-only lowercased form is within edit distance 1 of the
+ * canonical name. Distance 1 only catches single-character typos and cannot
+ * cross-map our fields, since no two canonical names are within 2 edits.
+ */
+export function readField(e: Record<string, unknown>, canonical: string, aliases: string[] = []): unknown {
+  if (e[canonical] !== undefined) return e[canonical];
+  for (const alias of aliases) {
+    if (e[alias] !== undefined) return e[alias];
+  }
+  const target = canonical.toLowerCase();
+  for (const key of Object.keys(e)) {
+    const norm = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (editDistance(norm, target) <= 1) return e[key];
+  }
+  return undefined;
+}
+
 /**
  * Normalize one raw model entry into a fully typed PriceData. Every field is
- * defended against the wrong type (e.g. qwen3 emits `stops` as an array), so a
- * single loosely-typed field can never silently drop a real flight.
+ * read tolerantly (typo'd or aliased keys, see readField) and defended against
+ * the wrong type (e.g. qwen3 emits `stops` as an array), so neither a key
+ * misspelling nor a loosely-typed value can silently drop a real flight.
  */
 function normalizeEntry(entry: unknown, travelDateFallback: string, currency: string | null): PriceData | null {
   if (typeof entry !== 'object' || entry === null) return null;
   const e = entry as Record<string, unknown>;
+
+  const travelDate = readField(e, 'travelDate', ['date', 'departDate']);
+  const currencyVal = readField(e, 'currency');
+  const airline = readField(e, 'airline', ['carrier', 'airlineName', 'airline_name']);
+  const bookingUrl = readField(e, 'bookingUrl', ['url', 'link', 'bookingLink']);
+  const duration = readField(e, 'duration');
+  const departureTime = readField(e, 'departureTime', ['departure', 'departTime']);
+  const arrivalTime = readField(e, 'arrivalTime', ['arrival', 'arriveTime']);
+  const flightNumber = readField(e, 'flightNumber', ['flightNo', 'flight']);
+
   return {
-    travelDate: typeof e.travelDate === 'string' && e.travelDate ? e.travelDate : travelDateFallback,
-    price: coercePrice(e.price),
-    currency: typeof e.currency === 'string' && e.currency ? e.currency : (currency ?? 'USD'),
-    airline: typeof e.airline === 'string' ? e.airline.trim() : '',
-    bookingUrl: typeof e.bookingUrl === 'string' ? e.bookingUrl : '',
-    stops: coerceStops(e.stops),
-    duration: typeof e.duration === 'string' ? e.duration : null,
-    departureTime: typeof e.departureTime === 'string' ? e.departureTime : null,
-    arrivalTime: typeof e.arrivalTime === 'string' ? e.arrivalTime : null,
-    seatsLeft: coerceSeatsLeft(e.seatsLeft),
-    flightNumber: typeof e.flightNumber === 'string' ? e.flightNumber : null,
+    travelDate: typeof travelDate === 'string' && travelDate ? travelDate : travelDateFallback,
+    price: coercePrice(readField(e, 'price', ['cost', 'fare', 'totalPrice'])),
+    currency: typeof currencyVal === 'string' && currencyVal ? currencyVal : (currency ?? 'USD'),
+    airline: typeof airline === 'string' ? airline.trim() : '',
+    bookingUrl: typeof bookingUrl === 'string' ? bookingUrl : '',
+    stops: coerceStops(readField(e, 'stops', ['stopCount', 'numStops'])),
+    duration: typeof duration === 'string' ? duration : null,
+    departureTime: typeof departureTime === 'string' ? departureTime : null,
+    arrivalTime: typeof arrivalTime === 'string' ? arrivalTime : null,
+    seatsLeft: coerceSeatsLeft(readField(e, 'seatsLeft', ['seats', 'seatsRemaining'])),
+    flightNumber: typeof flightNumber === 'string' ? flightNumber : null,
   };
 }
 


### PR DESCRIPTION
Root cause of the reporter's remaining `all_filtered_out` (#139), reproduced on the exact model.

`gemma3n:e2b` (which our README recommends) extracts flights correctly — valid prices, right airlines, times, stops — but consistently misspells one key: it emits `"airliine"` instead of `"airline"` (3/3 runs, deterministic). `normalizeEntry` read `e.airline`, got `undefined`, so every row failed the `price > 0 && airline` validity gate and the whole search collapsed to `all_filtered_out`. The model was fine; our parser was brittle to a one-character key typo.

Fix: `normalizeEntry` now reads each field through `readField`:
1. exact key,
2. then a few explicit aliases (`carrier`/`airlineName` for airline, `cost`/`fare`/`totalPrice` for price, etc.),
3. then any key whose letters/digits-only lowercased form is within **edit distance 1** of the canonical name.

Distance 1 only catches single-character typos and cannot cross-map our fields, since no two canonical names are within 2 edits of each other. Field values are still type-defended and coerced exactly as before, so correct keys behave identically.

Verified end to end against the live model: `gemma3n:e2b` now returns all 6 fixture flights (`failureReason` OK) where it previously returned `all_filtered_out`. Adds `readField` unit tests (exact, alias, the `airliine` typo, no cross-map) and an end-to-end test using the exact captured shape. Gate green: 66 extract tests, 501 scraper/preview, typecheck, lint, build.

This is the same robustness philosophy as #140/#141: tolerate real model output drift rather than dropping good data.
