### PR TITLE
feat(config): set provider API keys from the admin UI and setup wizard

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -116,6 +116,13 @@ model ExtractionConfig {
   defaultCurrency      String?   // ISO 4217 (EUR, GBP). null = Google auto-detects
   defaultCountry       String?   // ISO 3166-1 alpha-2 (DE, GB). null = Google auto-detects
   customBaseUrl        String?   // e.g. http://localhost:11434/v1
+  // Admin-entered provider API keys, encrypted at rest via lib/secret-crypto
+  // (AES-256-GCM, keyed on ADMIN_SESSION_SECRET) exactly like vpnActivationCode.
+  // Resolved BEFORE the matching env var so a self-hosted user can set a key in
+  // the GUI without editing ~/.flight-finder/.env or restarting the stack (#149).
+  anthropicApiKey      String?   // encrypted ANTHROPIC_API_KEY override
+  openaiApiKey         String?   // encrypted OPENAI_API_KEY override
+  googleApiKey         String?   // encrypted GOOGLE_AI_API_KEY override
   vpnProvider          String?   // 'none' | 'expressvpn'
   vpnCountries         String[]  @default([]) // default VPN countries (used when query has none)
   vpnActivationCode    String?   // encrypted VPN activation code

--- a/apps/web/src/app/admin/(dashboard)/config/page.module.css
+++ b/apps/web/src/app/admin/(dashboard)/config/page.module.css
@@ -208,6 +208,18 @@
   font-size: 0.75rem;
 }
 
+/* Provider readiness badge (#149). Defined after .toggleHint so the colour
+   wins when both classes are applied to the same element. */
+.statusReady {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.statusNotReady {
+  color: var(--price-up);
+  font-weight: 600;
+}
+
 .vpnCountries {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/app/admin/(dashboard)/config/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/config/page.tsx
@@ -21,6 +21,9 @@ interface Config {
   defaultSearchMethod: 'ai' | 'manual';
   customBaseUrl: string | null;
   extractTimeoutSeconds: number;
+  hasAnthropicKey: boolean;
+  hasOpenaiKey: boolean;
+  hasGoogleKey: boolean;
   vpnProvider: string | null;
   vpnCountries: string[];
   hasVpnActivationCode: boolean;
@@ -58,6 +61,11 @@ export default function ConfigPage() {
   const [defaultCountry, setDefaultCountry] = useState('');
   const [defaultSearchMethod, setDefaultSearchMethod] = useState<'ai' | 'manual'>('ai');
   const [customBaseUrl, setCustomBaseUrl] = useState('');
+  // Provider API key the admin types in (#149). Never pre-filled from the
+  // server (keys never cross the wire); blank means "leave the saved key
+  // unchanged". setProviderStatuses tracks readiness from /api/admin/providers.
+  const [apiKey, setApiKey] = useState('');
+  const [providerStatuses, setProviderStatuses] = useState<Record<string, string>>({});
   const [vpnProvider, setVpnProvider] = useState('none');
   const [vpnCountries, setVpnCountries] = useState<string[]>([]);
   const [aggregatorsEnabled, setAggregatorsEnabled] = useState<string[]>(['google_flights', 'airline_direct']);
@@ -105,6 +113,26 @@ export default function ConfigPage() {
       .finally(() => setLocalModelsLoading(false));
   }, []);
 
+  // Real-time readiness per provider (ready / no_key / unreachable / not_installed)
+  // so the admin can see which providers will actually work (#149).
+  const fetchProviderStatuses = useCallback(() => {
+    fetch('/api/admin/providers')
+      .then((r) => r.json())
+      .then((d) => {
+        if (!d.ok) return;
+        const map: Record<string, string> = {};
+        for (const [key, s] of Object.entries(d.data as Record<string, { status: string }>)) {
+          map[key] = s.status;
+        }
+        setProviderStatuses(map);
+      })
+      .catch(() => { /* readiness is advisory; ignore fetch errors */ });
+  }, []);
+
+  useEffect(() => {
+    fetchProviderStatuses();
+  }, [fetchProviderStatuses]);
+
   useEffect(() => {
     fetch('/api/admin/config')
       .then((r) => r.json())
@@ -147,10 +175,27 @@ export default function ConfigPage() {
 
   const providerConfig = PROVIDER_METADATA[provider];
   const models = providerConfig?.models ?? [];
+  // Whether a key is already stored for the selected provider (from the GET
+  // booleans) and its live readiness, to drive the API-key field's hint (#149).
+  const hasStoredKey =
+    provider === 'anthropic' ? !!config?.hasAnthropicKey
+    : provider === 'openai' ? !!config?.hasOpenaiKey
+    : provider === 'google' ? !!config?.hasGoogleKey
+    : false;
+  const providerStatus = providerStatuses[provider];
+  const STATUS_LABEL: Record<string, string> = {
+    ready: 'Ready',
+    no_key: 'No key configured',
+    unreachable: 'Not reachable',
+    not_installed: 'Not installed',
+  };
 
   const handleProviderChange = (newProvider: string) => {
     setProvider(newProvider);
     setCustomModel('');
+    // Clear the key field so a key typed for one provider can't be saved
+    // against another. The saved key (if any) stays in the DB untouched.
+    setApiKey('');
     // Leave the base URL empty so the default is only a placeholder, not a saved
     // value. Persisting the localhost default would be stored as customBaseUrl,
     // which overrides the OLLAMA_HOST env that install.sh sets to
@@ -176,6 +221,8 @@ export default function ConfigPage() {
     setMessage('');
 
     const newBaseUrl = customBaseUrl.trim() || null;
+    // apiKey: a blank field is sent as undefined (dropped by JSON.stringify) so
+    // it leaves the saved key untouched; only a typed value is stored (#149).
     const res = await fetch('/api/admin/config', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -192,6 +239,7 @@ export default function ConfigPage() {
         defaultCountry: defaultCountry.trim().toUpperCase() || null,
         defaultSearchMethod,
         customBaseUrl: newBaseUrl,
+        apiKey: apiKey.trim() || undefined,
         vpnProvider: vpnProvider === 'none' ? null : vpnProvider,
         vpnCountries,
         aggregatorsEnabled,
@@ -208,6 +256,9 @@ export default function ConfigPage() {
     if (data.ok) {
       setConfig(data.data);
       setMessage('Config saved');
+      // Clear the typed key and refresh readiness now that it's stored.
+      setApiKey('');
+      fetchProviderStatuses();
       // Re-fetch models if the base URL changed (cache key includes host)
       if (LOCAL_PROVIDERS.has(provider)) {
         fetchLocalModels(provider);
@@ -260,6 +311,11 @@ export default function ConfigPage() {
               <option key={key} value={key}>{p.displayName}</option>
             ))}
           </select>
+          {providerStatus && (
+            <span className={`${styles.toggleHint} ${providerStatus === 'ready' ? styles.statusReady : styles.statusNotReady}`}>
+              Status: {STATUS_LABEL[providerStatus] ?? providerStatus}
+            </span>
+          )}
           {(provider === 'claude-code' || provider === 'codex') && (
             <div className={styles.info}>
               <div className={styles.infoTitle}>Security note</div>
@@ -271,6 +327,25 @@ export default function ConfigPage() {
             </div>
           )}
         </div>
+
+        {providerConfig?.envKey && (
+          <div className={styles.field}>
+            <label className={styles.label}>API Key</label>
+            <input
+              type="password"
+              className={styles.input}
+              autoComplete="off"
+              placeholder={hasStoredKey ? 'Saved — paste a new key to replace' : `Paste your ${providerConfig.displayName} API key`}
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+            />
+            <span className={styles.toggleHint}>
+              {hasStoredKey
+                ? `A key is saved. Leave blank to keep it, or paste a new one to replace it. Stored encrypted; falls back to the ${providerConfig.envKey} environment variable.`
+                : `Paste a key to store it (encrypted) here, or set the ${providerConfig.envKey} environment variable. No restart needed.`}
+            </span>
+          </div>
+        )}
 
         <div className={styles.field}>
           <label className={styles.label}>Model</label>
@@ -675,7 +750,8 @@ export default function ConfigPage() {
           <strong>API key:</strong>{' '}
           {providerConfig?.envKey ? (
             <>
-              read from <code className={styles.code}>{providerConfig.envKey}</code>
+              entered above (stored encrypted), or read from{' '}
+              <code className={styles.code}>{providerConfig.envKey}</code> if none is set
             </>
           ) : (
             'not required — this provider signs in through its local CLI, no API key needed'

--- a/apps/web/src/app/api/admin/config/route.test.ts
+++ b/apps/web/src/app/api/admin/config/route.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockUpsert = vi.fn();
+const mockFindFirst = vi.fn().mockResolvedValue(null);
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
     extractionConfig: {
       upsert: (...args: unknown[]) => mockUpsert(...args),
+      findFirst: (...args: unknown[]) => mockFindFirst(...args),
     },
   },
 }));
@@ -20,7 +22,10 @@ vi.mock('@/lib/cron', () => ({
 
 vi.mock('@/lib/scraper/ai-registry', () => ({
   EXTRACTION_PROVIDERS: {
-    anthropic: { displayName: 'Anthropic', models: [] },
+    anthropic: { displayName: 'Anthropic', envKey: 'ANTHROPIC_API_KEY', allowCustomModel: true, models: [] },
+    openai: { displayName: 'OpenAI', envKey: 'OPENAI_API_KEY', allowCustomModel: true, allowCustomBaseUrl: true, models: [] },
+    google: { displayName: 'Google', envKey: 'GOOGLE_AI_API_KEY', allowCustomModel: true, models: [] },
+    ollama: { displayName: 'Ollama', allowCustomModel: true, models: [] },
   },
 }));
 
@@ -297,5 +302,112 @@ describe('GET /api/admin/config: secret redaction (CRYPTO-5/COMM-8)', () => {
     expect(json.data.adminPasswordHash).toBeUndefined();
     expect(json.data.hasAdminPassword).toBe(true);
     expect(json.data.communityApiKey).toBeNull();
+  });
+
+  it('exposes hasXKey booleans but never the stored provider key (#149)', async () => {
+    mockUpsert.mockResolvedValue({
+      id: 'singleton',
+      openaiApiKey: 'iv:tag:ciphertext',
+      anthropicApiKey: null,
+      googleApiKey: null,
+      communityApiKey: null,
+    });
+
+    const res = await GET();
+    const json = (await res.json()) as { data: Record<string, unknown> };
+    expect(json.data.hasOpenaiKey).toBe(true);
+    expect(json.data.hasAnthropicKey).toBe(false);
+    expect(json.data.hasGoogleKey).toBe(false);
+    // The ciphertext (masked or not) must never cross the wire.
+    expect(json.data).not.toHaveProperty('openaiApiKey');
+    expect(JSON.stringify(json.data)).not.toContain('iv:tag:ciphertext');
+  });
+});
+
+describe('PATCH /api/admin/config — provider API keys (#149)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindFirst.mockResolvedValue(null);
+    mockUpsert.mockImplementation((args: { update: Record<string, unknown> }) =>
+      Promise.resolve({ id: 'singleton', ...args.update }),
+    );
+  });
+
+  it('rejects selecting an env-backed provider with no usable key, without writing', async () => {
+    const orig = process.env.GOOGLE_AI_API_KEY;
+    delete process.env.GOOGLE_AI_API_KEY; // no env key, no stored key, no local endpoint
+    try {
+      const res = await PATCH(patchRequest({ provider: 'google', model: 'gemini-2.5-flash' }));
+      expect(res.status).toBe(400);
+      expect(mockUpsert).not.toHaveBeenCalled();
+    } finally {
+      if (orig === undefined) delete process.env.GOOGLE_AI_API_KEY;
+      else process.env.GOOGLE_AI_API_KEY = orig;
+    }
+  });
+
+  it('accepts the same provider when an API key is entered, and stores it encrypted', async () => {
+    const { decryptSecret } = await import('@/lib/secret-crypto');
+    const orig = process.env.GOOGLE_AI_API_KEY;
+    delete process.env.GOOGLE_AI_API_KEY;
+    try {
+      const res = await PATCH(patchRequest({ provider: 'google', model: 'gemini-2.5-flash', apiKey: 'g-secret-123' }));
+      expect(res.status).toBe(200);
+      const update = (mockUpsert.mock.calls[0]![0] as { update: Record<string, unknown> }).update;
+      expect(update.googleApiKey).toEqual(expect.any(String));
+      expect(update.googleApiKey).not.toBe('g-secret-123');
+      expect(decryptSecret(update.googleApiKey as string)).toBe('g-secret-123');
+    } finally {
+      if (orig === undefined) delete process.env.GOOGLE_AI_API_KEY;
+      else process.env.GOOGLE_AI_API_KEY = orig;
+    }
+  });
+
+  it('accepts switching to a provider that already has a stored key (no re-entry needed)', async () => {
+    const orig = process.env.GOOGLE_AI_API_KEY;
+    delete process.env.GOOGLE_AI_API_KEY;
+    mockFindFirst.mockResolvedValue({ googleApiKey: 'iv:tag:cipher' }); // already stored
+    try {
+      const res = await PATCH(patchRequest({ provider: 'google', model: 'gemini-2.5-flash' }));
+      expect(res.status).toBe(200);
+    } finally {
+      if (orig === undefined) delete process.env.GOOGLE_AI_API_KEY;
+      else process.env.GOOGLE_AI_API_KEY = orig;
+    }
+  });
+
+  it('clears a stored key when apiKey is null', async () => {
+    // env key present so clearing the stored key does not trip the keyless guard
+    const res = await PATCH(patchRequest({ provider: 'anthropic', model: 'claude-haiku-4-5-20251001', apiKey: null }));
+    expect(res.status).toBe(200);
+    const update = (mockUpsert.mock.calls[0]![0] as { update: Record<string, unknown> }).update;
+    expect(update.anthropicApiKey).toBeNull();
+  });
+
+  it('lets a local provider save without any API key', async () => {
+    const res = await PATCH(patchRequest({ provider: 'ollama', model: 'llama3' }));
+    expect(res.status).toBe(200);
+    expect(mockFindFirst).not.toHaveBeenCalled();
+  });
+
+  // Recurrence net: every env-backed provider must round-trip a GUI-entered key
+  // (writable -> encrypted at rest -> exposed only as a boolean). A new provider
+  // wired up incompletely fails here.
+  describe.each([
+    { provider: 'anthropic', model: 'claude-haiku-4-5-20251001', column: 'anthropicApiKey', has: 'hasAnthropicKey' },
+    { provider: 'openai', model: 'gpt-4.1-mini', column: 'openaiApiKey', has: 'hasOpenaiKey' },
+    { provider: 'google', model: 'gemini-2.5-flash', column: 'googleApiKey', has: 'hasGoogleKey' },
+  ])('contract: $provider', ({ provider, model, column, has }) => {
+    it('persists an entered key encrypted and exposes only a boolean', async () => {
+      const { decryptSecret } = await import('@/lib/secret-crypto');
+      const secret = `secret-for-${provider}`;
+      const res = await PATCH(patchRequest({ provider, model, apiKey: secret }));
+      expect(res.status).toBe(200);
+      const update = (mockUpsert.mock.calls[0]![0] as { update: Record<string, unknown> }).update;
+      expect(decryptSecret(update[column] as string)).toBe(secret);
+      const json = (await res.json()) as { data: Record<string, unknown> };
+      expect(json.data[has]).toBe(true);
+      expect(json.data).not.toHaveProperty(column);
+    });
   });
 });

--- a/apps/web/src/app/api/admin/config/route.ts
+++ b/apps/web/src/app/api/admin/config/route.ts
@@ -22,7 +22,11 @@ function maskSecret(value: string): string {
 }
 
 function stripHashes(config: Record<string, unknown>) {
-  const { adminPasswordHash, vpnActivationCode, communityApiKey, ...rest } = config;
+  const {
+    adminPasswordHash, vpnActivationCode, communityApiKey,
+    anthropicApiKey, openaiApiKey, googleApiKey,
+    ...rest
+  } = config;
   return {
     ...rest,
     // Never return the community API key in plaintext. The GET response is
@@ -30,6 +34,11 @@ function stripHashes(config: Record<string, unknown>) {
     communityApiKey: typeof communityApiKey === 'string' ? maskSecret(communityApiKey) : null,
     hasAdminPassword: !!adminPasswordHash,
     hasVpnActivationCode: !!vpnActivationCode,
+    // Provider API keys (#149): never cross the wire, even masked. The UI only
+    // needs to know whether one is stored so it can show a "saved" state.
+    hasAnthropicKey: !!anthropicApiKey,
+    hasOpenaiKey: !!openaiApiKey,
+    hasGoogleKey: !!googleApiKey,
     isSelfHosted: process.env.SELF_HOSTED === 'true',
   };
 }
@@ -72,6 +81,47 @@ export async function PATCH(request: NextRequest) {
   const data: Record<string, unknown> = {};
   if (provider) data.provider = provider;
   if (model) data.model = model;
+
+  // Provider API key (#149): admins enter the key in the GUI instead of editing
+  // .env. Store it encrypted in the per-provider column (a non-empty string
+  // sets it, null/'' clears it, absent leaves it unchanged), keyed to the
+  // provider in this same request. Only env-backed providers have a column;
+  // CLI/local providers need no key. Then reject selecting an env-backed
+  // provider with no usable key (stored, env, or an openai local endpoint) so
+  // the save fails loudly here instead of silently at the next scrape.
+  if (provider) {
+    const KEY_COLUMN: Record<string, 'anthropicApiKey' | 'openaiApiKey' | 'googleApiKey'> = {
+      anthropic: 'anthropicApiKey',
+      openai: 'openaiApiKey',
+      google: 'googleApiKey',
+    };
+    const envKey = EXTRACTION_PROVIDERS[provider]?.envKey;
+    const column = KEY_COLUMN[provider];
+    if (envKey) {
+      const incomingKey = typeof body.apiKey === 'string' && body.apiKey.length > 0;
+      const clearing = body.apiKey === '' || body.apiKey === null;
+      if (column && typeof body.apiKey === 'string') {
+        data[column] = incomingKey ? encryptSecret(body.apiKey) : null;
+      } else if (column && body.apiKey === null) {
+        data[column] = null;
+      }
+      const existing = column ? await prisma.extractionConfig.findFirst({ where: { id: 'singleton' } }) : null;
+      const storedKey = !clearing && !!(column && existing && existing[column]);
+      const envPresent = !!process.env[envKey];
+      const baseUrl =
+        (typeof body.customBaseUrl === 'string' && body.customBaseUrl) ||
+        existing?.customBaseUrl ||
+        process.env.OPENAI_BASE_URL;
+      const openaiLocal = provider === 'openai' && !!baseUrl;
+      if (!incomingKey && !storedKey && !envPresent && !openaiLocal) {
+        return apiError(
+          `Provider "${provider}" needs an API key. Enter one here or set the ${envKey} environment variable.`,
+          400,
+        );
+      }
+    }
+  }
+
   if (body.theme !== undefined) {
     if (typeof body.theme !== 'string' || !isThemeId(body.theme)) {
       return apiError('theme must be a valid theme id', 400);

--- a/apps/web/src/app/api/setup/route.test.ts
+++ b/apps/web/src/app/api/setup/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockUpsert = vi.fn();
+const mockFindFirst = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    extractionConfig: {
+      upsert: (...args: unknown[]) => mockUpsert(...args),
+      findFirst: (...args: unknown[]) => mockFindFirst(...args),
+    },
+  },
+}));
+
+vi.mock('@/lib/community-sync', () => ({
+  registerForCommunity: vi.fn().mockResolvedValue('comm_key'),
+}));
+
+import { POST } from './route';
+
+function setupRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost:3003/api/setup', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/setup — provider API key (#149)', () => {
+  const savedSelfHosted = process.env.SELF_HOSTED;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Self-hosted so no admin password is required; isolates the key behavior.
+    process.env.SELF_HOSTED = 'true';
+    mockFindFirst.mockResolvedValue(null); // setup not yet completed
+    mockUpsert.mockResolvedValue({ id: 'singleton' });
+  });
+
+  afterEach(() => {
+    if (savedSelfHosted === undefined) delete process.env.SELF_HOSTED;
+    else process.env.SELF_HOSTED = savedSelfHosted;
+  });
+
+  it('stores an entered key encrypted in the matching column (both upsert branches)', async () => {
+    const { decryptSecret } = await import('@/lib/secret-crypto');
+    const res = await POST(setupRequest({ provider: 'openai', model: 'gpt-4.1-mini', apiKey: 'sk-secret-123' }));
+    expect(res.status).toBe(200);
+
+    const args = mockUpsert.mock.calls[0]![0] as { create: Record<string, unknown>; update: Record<string, unknown> };
+    expect(args.create.openaiApiKey).toEqual(expect.any(String));
+    expect(args.create.openaiApiKey).not.toBe('sk-secret-123'); // never plaintext
+    expect(decryptSecret(args.create.openaiApiKey as string)).toBe('sk-secret-123');
+    expect(decryptSecret(args.update.openaiApiKey as string)).toBe('sk-secret-123');
+  });
+
+  it('omits the key column entirely when no apiKey is provided', async () => {
+    const res = await POST(setupRequest({ provider: 'anthropic', model: 'claude-haiku-4-5-20251001' }));
+    expect(res.status).toBe(200);
+    const args = mockUpsert.mock.calls[0]![0] as { create: Record<string, unknown> };
+    expect(args.create).not.toHaveProperty('anthropicApiKey');
+    expect(args.create).not.toHaveProperty('openaiApiKey');
+  });
+
+  it('ignores an API key for a provider with no key column (local/CLI)', async () => {
+    const res = await POST(setupRequest({ provider: 'ollama', model: 'llama3', apiKey: 'should-be-ignored' }));
+    expect(res.status).toBe(200);
+    const args = mockUpsert.mock.calls[0]![0] as { create: Record<string, unknown> };
+    expect(JSON.stringify(args.create)).not.toContain('should-be-ignored');
+  });
+});

--- a/apps/web/src/app/api/setup/route.ts
+++ b/apps/web/src/app/api/setup/route.ts
@@ -2,6 +2,15 @@ import { prisma } from '@/lib/prisma';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { hashPassword } from '@/lib/password';
 import { registerForCommunity } from '@/lib/community-sync';
+import { encryptSecret } from '@/lib/secret-crypto';
+
+// Env-backed provider -> the ExtractionConfig column that stores its key,
+// encrypted at rest (#149). Keep in sync with STORED_KEY_FIELD in ai-registry.
+const PROVIDER_KEY_COLUMN: Record<string, 'anthropicApiKey' | 'openaiApiKey' | 'googleApiKey'> = {
+  anthropic: 'anthropicApiKey',
+  openai: 'openaiApiKey',
+  google: 'googleApiKey',
+};
 
 export async function POST(request: Request) {
   // Only allow setup if no config exists yet
@@ -14,13 +23,14 @@ export async function POST(request: Request) {
   }
 
   const body = await request.json();
-  const { adminPassword, provider, model, communitySharing, customBaseUrl, publicBaseUrl } = body as {
+  const { adminPassword, provider, model, communitySharing, customBaseUrl, publicBaseUrl, apiKey } = body as {
     adminPassword: string;
     provider: string;
     model: string;
     communitySharing?: boolean;
     customBaseUrl?: string | null;
     publicBaseUrl?: string | null;
+    apiKey?: string | null;
   };
 
   // Optional public URL the user plans to reach the instance at (for /connect's
@@ -52,6 +62,14 @@ export async function POST(request: Request) {
     ? 'self-hosted'
     : await hashPassword(adminPassword);
 
+  // Store the entered provider key encrypted at rest (#149), so a self-hosted
+  // user can configure a keyed provider in the wizard without editing .env.
+  const providerKeyData: Record<string, string> = {};
+  if (typeof apiKey === 'string' && apiKey.length > 0) {
+    const column = PROVIDER_KEY_COLUMN[provider];
+    if (column) providerKeyData[column] = encryptSecret(apiKey);
+  }
+
   // Register for community API key if opted in
   let communityApiKey: string | null = null;
   if (communitySharing) {
@@ -74,6 +92,7 @@ export async function POST(request: Request) {
       communityApiKey,
       customBaseUrl: customBaseUrl || null,
       publicBaseUrl: normalizedPublicBaseUrl,
+      ...providerKeyData,
     },
     update: {
       provider,
@@ -83,6 +102,7 @@ export async function POST(request: Request) {
       communityApiKey,
       customBaseUrl: customBaseUrl || null,
       publicBaseUrl: normalizedPublicBaseUrl,
+      ...providerKeyData,
     },
   });
 

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -26,6 +26,8 @@ export default function SetupPage() {
   const [model, setModel] = useState('');
   const [customModel, setCustomModel] = useState('');
   const [customBaseUrl, setCustomBaseUrl] = useState('');
+  // Provider API key entered during first-run setup (#149); stored encrypted.
+  const [apiKey, setApiKey] = useState('');
   const [communitySharing, setCommunitySharing] = useState(false);
   const [enableMultiUser, setEnableMultiUser] = useState(false);
   const [multiUserUsername, setMultiUserUsername] = useState('');
@@ -150,7 +152,7 @@ export default function SetupPage() {
     const res = await fetch('/api/setup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ adminPassword: password, provider, model: effectiveModel, communitySharing, customBaseUrl: customBaseUrl.trim() || null, publicBaseUrl: publicBaseUrl.trim() || null }),
+      body: JSON.stringify({ adminPassword: password, provider, model: effectiveModel, communitySharing, customBaseUrl: customBaseUrl.trim() || null, publicBaseUrl: publicBaseUrl.trim() || null, apiKey: apiKey.trim() || null }),
     });
 
     if (!res.ok) {
@@ -286,6 +288,9 @@ export default function SetupPage() {
                     onClick={() => {
                       setProvider(key);
                       setCustomModel('');
+                      // Clear the key field when switching providers so a key
+                      // typed for one is never submitted for another.
+                      setApiKey('');
                       // Empty so the default is a placeholder, not a saved value.
                       // A persisted localhost would override the OLLAMA_HOST env
                       // (host.docker.internal) and break Ollama in Docker. #139.
@@ -359,6 +364,23 @@ export default function SetupPage() {
                     value={customModel}
                     onChange={(e) => setCustomModel(e.target.value)}
                   />
+                )}
+                {PROVIDER_METADATA[provider]!.envKey && (
+                  <>
+                    <input
+                      type="password"
+                      className={styles.input}
+                      autoComplete="off"
+                      placeholder={detectedProviders.includes(provider)
+                        ? `API key (optional — ${PROVIDER_METADATA[provider]!.envKey} is already set)`
+                        : `Paste your ${PROVIDER_METADATA[provider]!.displayName} API key`}
+                      value={apiKey}
+                      onChange={(e) => setApiKey(e.target.value)}
+                    />
+                    <span className={styles.hint}>
+                      Stored encrypted. You can also set the {PROVIDER_METADATA[provider]!.envKey} environment variable instead.
+                    </span>
+                  </>
                 )}
                 {PROVIDER_METADATA[provider]!.allowCustomBaseUrl && (
                   <input

--- a/apps/web/src/lib/preview-runner.test.ts
+++ b/apps/web/src/lib/preview-runner.test.ts
@@ -151,6 +151,25 @@ beforeEach(() => {
   });
 });
 
+describe('runPreview API key resolution (#149)', () => {
+  it('threads the DB-stored key (decrypted) into the extractPrices override', async () => {
+    const { encryptSecret } = await import('@/lib/secret-crypto');
+    mockExtractionConfigFindFirst.mockResolvedValue({
+      id: 'singleton',
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      defaultCurrency: 'USD',
+      anthropicApiKey: encryptSecret('stored-preview-key'),
+    });
+
+    await runPreview(makePayload(), { concurrency: 1 });
+
+    expect(mockExtractPrices).toHaveBeenCalled();
+    const override = mockExtractPrices.mock.calls[0]![8] as { apiKey?: string };
+    expect(override.apiKey).toBe('stored-preview-key');
+  });
+});
+
 describe('runPreview hoist invariant', () => {
   it('reads extractionConfig exactly once across many tasks (issue #65 hoist)', async () => {
     const payload = makePayload({

--- a/apps/web/src/lib/preview-runner.ts
+++ b/apps/web/src/lib/preview-runner.ts
@@ -15,7 +15,7 @@ import {
   type PreviewResultPayload,
   type RouteResultPayload,
 } from '@/lib/preview-run';
-import { getModelCosts } from '@/lib/scraper/ai-registry';
+import { getModelCosts, resolveApiKey } from '@/lib/scraper/ai-registry';
 import { isKnownAirline } from '@/lib/scraper/airline-urls';
 import { extractPrices, type ExtractionFailureReason, type PriceData } from '@/lib/scraper/extract-prices';
 import { navigateAirlineDirect, navigateGoogleFlights } from '@/lib/scraper/navigate';
@@ -168,6 +168,9 @@ export interface ExtractionContext {
   model: string;
   customBaseUrl: string | null;
   extractTimeoutSeconds: number | null;
+  /** Pre-resolved API key (DB-stored key decrypted, else env), resolved once
+   *  per preview so workers don't decrypt on every attempt (#149). */
+  apiKey: string;
   costs: { costPer1kInput: number; costPer1kOutput: number };
 }
 
@@ -331,6 +334,7 @@ async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
         model: params.context.model,
         customBaseUrl: params.context.customBaseUrl,
         extractTimeoutSeconds: params.context.extractTimeoutSeconds,
+        apiKey: params.context.apiKey,
       }
     );
 
@@ -427,6 +431,7 @@ export async function runPreview(
     model,
     customBaseUrl: config?.customBaseUrl ?? null,
     extractTimeoutSeconds: config?.extractTimeoutSeconds ?? null,
+    apiKey: resolveApiKey(provider, config),
     costs: getModelCosts(provider, model),
   };
   const outboundDates = payload.outboundDates;

--- a/apps/web/src/lib/scraper/ai-registry.test.ts
+++ b/apps/web/src/lib/scraper/ai-registry.test.ts
@@ -33,10 +33,20 @@ vi.mock('openai', () => ({
   }),
 }));
 
+// detectAvailableProviders reads the ExtractionConfig singleton to honor
+// DB-stored keys (#149), so prisma must be mocked or the call hits a real DB.
+// findFirst returns null by default (env-only detection, preserving prior
+// behavior) and is overridable per test with mockResolvedValueOnce.
+const mockConfigFindFirst = vi.fn().mockResolvedValue(null);
+vi.mock('@/lib/prisma', () => ({
+  prisma: { extractionConfig: { findFirst: (...args: unknown[]) => mockConfigFindFirst(...args) } },
+}));
+
 // Must import after mocks
-const { EXTRACTION_PROVIDERS, LOCAL_PROVIDERS, detectAvailableProviders, ensureV1Suffix, filterCliStderr, isLocalProviderReachable } = await import(
+const { EXTRACTION_PROVIDERS, LOCAL_PROVIDERS, detectAvailableProviders, resolveApiKey, ensureV1Suffix, filterCliStderr, isLocalProviderReachable } = await import(
   './ai-registry'
 );
+const { encryptSecret } = await import('@/lib/secret-crypto');
 
 /** Create a fake ChildProcess-like EventEmitter with stdin/stdout/stderr */
 function createFakeProc() {
@@ -149,6 +159,78 @@ describe('ai-registry', () => {
 
       expect(providers).not.toContain('ollama');
       expect(providers).not.toContain('llamacpp');
+    });
+
+    it('counts a DB-stored key even when the matching env var is unset (#149)', async () => {
+      // env keys are cleared by the describe beforeEach; supply only a stored key.
+      mockConfigFindFirst.mockResolvedValueOnce({ googleApiKey: encryptSecret('stored-google-key') });
+
+      const providers = await detectAvailableProviders();
+
+      expect(providers).toContain('google');
+    });
+
+    it('counts a stored customBaseUrl for openai when no env key/endpoint is set', async () => {
+      const savedBase = process.env.OPENAI_BASE_URL;
+      delete process.env.OPENAI_BASE_URL; // setup.ts sets this globally
+      mockConfigFindFirst.mockResolvedValueOnce({ customBaseUrl: 'http://localhost:1234/v1' });
+
+      const providers = await detectAvailableProviders();
+
+      expect(providers).toContain('openai');
+      if (savedBase === undefined) delete process.env.OPENAI_BASE_URL;
+      else process.env.OPENAI_BASE_URL = savedBase;
+    });
+
+    it('skips the DB read when passed null and detects from env only', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+
+      const providers = await detectAvailableProviders(null);
+
+      expect(providers).toContain('anthropic');
+      expect(mockConfigFindFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveApiKey (#149)', () => {
+    const saved: Record<string, string | undefined> = {};
+    beforeEach(() => {
+      for (const k of ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_AI_API_KEY']) {
+        saved[k] = process.env[k];
+        delete process.env[k];
+      }
+    });
+    afterEach(() => {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    });
+
+    it('prefers a DB-stored key over the env var', () => {
+      process.env.OPENAI_API_KEY = 'env-key';
+      expect(resolveApiKey('openai', { openaiApiKey: encryptSecret('stored-key') })).toBe('stored-key');
+    });
+
+    it('falls back to the env var when there is no stored key', () => {
+      process.env.OPENAI_API_KEY = 'env-key';
+      expect(resolveApiKey('openai', null)).toBe('env-key');
+      expect(resolveApiKey('openai', {})).toBe('env-key');
+    });
+
+    it('falls back to env when a stored value cannot be decrypted (rotated secret)', () => {
+      process.env.OPENAI_API_KEY = 'env-key';
+      expect(resolveApiKey('openai', { openaiApiKey: 'not-valid-ciphertext' })).toBe('env-key');
+    });
+
+    it('resolves anthropic and google stored keys too (multi-provider parity)', () => {
+      expect(resolveApiKey('anthropic', { anthropicApiKey: encryptSecret('stored-a') })).toBe('stored-a');
+      expect(resolveApiKey('google', { googleApiKey: encryptSecret('stored-g') })).toBe('stored-g');
+    });
+
+    it('returns empty string for CLI/local providers (no key needed)', () => {
+      expect(resolveApiKey('ollama', null)).toBe('');
+      expect(resolveApiKey('claude-code', null)).toBe('');
     });
   });
 

--- a/apps/web/src/lib/scraper/ai-registry.ts
+++ b/apps/web/src/lib/scraper/ai-registry.ts
@@ -7,6 +7,8 @@ import {
   type ModelInfo,
   type ProviderMeta,
 } from './provider-metadata';
+import { prisma } from '@/lib/prisma';
+import { decryptSecret } from '@/lib/secret-crypto';
 
 // Client-safe metadata lives in provider-metadata.ts so the settings/setup/admin
 // client pages can render the provider UI without pulling this module (and the
@@ -25,6 +27,45 @@ export type { ModelInfo, ProviderMeta };
 const PARSED_TIMEOUT = parseInt(process.env.EXTRACT_TIMEOUT_MS ?? '90000', 10);
 export const EXTRACT_TIMEOUT_MS =
   Number.isFinite(PARSED_TIMEOUT) && PARSED_TIMEOUT > 0 ? PARSED_TIMEOUT : 90_000;
+
+/** Structural subset of ExtractionConfig carrying the encrypted per-provider
+ *  key columns. Typed as a subset (not the generated Prisma type) so this
+ *  module stays decoupled from the generated client path. */
+export type StoredKeyConfig = {
+  anthropicApiKey?: string | null;
+  openaiApiKey?: string | null;
+  googleApiKey?: string | null;
+};
+
+/** Env-backed provider -> the ExtractionConfig column that stores its
+ *  admin-entered key (encrypted). Only the three providers with an `envKey`
+ *  appear here; CLI/local providers need no key. */
+export const STORED_KEY_FIELD: Record<string, keyof StoredKeyConfig> = {
+  anthropic: 'anthropicApiKey',
+  openai: 'openaiApiKey',
+  google: 'googleApiKey',
+};
+
+/**
+ * Resolve a provider's API key. An admin-entered key stored in the DB
+ * (decrypted) takes precedence over the environment variable, so a self-hosted
+ * user can configure a key in the GUI without editing .env or restarting the
+ * stack (#149). A stored value that fails to decrypt (eg. ADMIN_SESSION_SECRET
+ * was rotated) is treated as absent and falls through to the env var. Returns
+ * '' when neither source has a key (CLI/local providers, which need none).
+ */
+export function resolveApiKey(provider: string, config: StoredKeyConfig | null | undefined): string {
+  const field = STORED_KEY_FIELD[provider];
+  if (field && config) {
+    const encrypted = config[field];
+    if (encrypted) {
+      const decrypted = decryptSecret(encrypted);
+      if (decrypted) return decrypted;
+    }
+  }
+  const envKey = PROVIDER_METADATA[provider]?.envKey;
+  return (envKey ? process.env[envKey] : '') ?? '';
+}
 
 export interface ExtractionUsage {
   inputTokens: number;
@@ -452,12 +493,22 @@ export async function isLocalProviderReachable(provider: string): Promise<boolea
   }
 }
 
-export async function detectAvailableProviders(): Promise<string[]> {
+export async function detectAvailableProviders(
+  storedConfig?: (StoredKeyConfig & { customBaseUrl?: string | null }) | null,
+): Promise<string[]> {
   const available: string[] = [];
 
   const isSelfHosted = process.env.SELF_HOSTED === 'true';
 
-  for (const [key, config] of Object.entries(EXTRACTION_PROVIDERS)) {
+  // A stored key/customBaseUrl can make a provider available even when the env
+  // var is unset (#149). Callers that pass nothing get a fresh DB read so the
+  // status reflects keys saved after first-run setup; `null` skips the read.
+  const cfg =
+    storedConfig !== undefined
+      ? storedConfig
+      : await prisma.extractionConfig.findFirst({ where: { id: 'singleton' } });
+
+  for (const [key] of Object.entries(EXTRACTION_PROVIDERS)) {
     // Local providers: only on self-hosted, and only if reachable
     if (LOCAL_PROVIDERS.has(key)) {
       if (isSelfHosted && await isLocalProviderReachable(key)) {
@@ -478,8 +529,10 @@ export async function detectAvailableProviders(): Promise<string[]> {
       }
       continue;
     }
-    const hasKey = config.envKey && process.env[config.envKey];
-    const hasLocalEndpoint = key === 'openai' && process.env.OPENAI_BASE_URL;
+    // Env-backed (anthropic/openai/google): a stored key OR an env key makes it
+    // available; openai is also usable via a custom local endpoint.
+    const hasKey = !!resolveApiKey(key, cfg);
+    const hasLocalEndpoint = key === 'openai' && (cfg?.customBaseUrl || process.env.OPENAI_BASE_URL);
     if (hasKey || hasLocalEndpoint) {
       available.push(key);
     }

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -15,18 +15,24 @@ vi.mock('@/lib/prisma', () => ({
   },
 }));
 
-vi.mock('./ai-registry', () => ({
-  EXTRACTION_PROVIDERS: {
-    anthropic: {
-      displayName: 'Anthropic',
-      envKey: 'ANTHROPIC_API_KEY',
-      models: [],
-      extract: mockExtract,
+// Keep the real ai-registry (so resolveApiKey is exercised end to end), but
+// swap the anthropic provider's extract fn for a spy.
+vi.mock('./ai-registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./ai-registry')>();
+  return {
+    ...actual,
+    EXTRACTION_PROVIDERS: {
+      anthropic: {
+        displayName: 'Anthropic',
+        envKey: 'ANTHROPIC_API_KEY',
+        models: [],
+        extract: mockExtract,
+      },
     },
-  },
-  CLI_PROVIDERS: {},
-  LOCAL_PROVIDERS: new Set(),
-}));
+    CLI_PROVIDERS: {},
+    LOCAL_PROVIDERS: new Set(),
+  };
+});
 
 process.env.ANTHROPIC_API_KEY = 'test-key';
 
@@ -318,6 +324,56 @@ describe('extractPrices', () => {
     } finally {
       process.env.ANTHROPIC_API_KEY = origKey;
     }
+  });
+
+  it('passes the DB-stored key to the provider, preferring it over the env var (#149)', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { encryptSecret } = await import('@/lib/secret-crypto');
+    vi.mocked(prisma.extractionConfig.findFirst).mockResolvedValueOnce({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      anthropicApiKey: encryptSecret('stored-anthropic-key'),
+    } as never);
+    mockExtract.mockResolvedValue({ content: '[]', usage: { inputTokens: 1, outputTokens: 1 } });
+
+    await extractPrices('page', 'https://flights.google.com', '2026-06-15');
+
+    // process.env.ANTHROPIC_API_KEY is 'test-key'; the stored key must win.
+    expect(mockExtract.mock.calls[0]![0]).toBe('stored-anthropic-key');
+  });
+
+  it('does not throw "Missing API key" when only a DB-stored key is present (#149)', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { encryptSecret } = await import('@/lib/secret-crypto');
+    const origKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    vi.mocked(prisma.extractionConfig.findFirst).mockResolvedValueOnce({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      anthropicApiKey: encryptSecret('stored-only-key'),
+    } as never);
+    mockExtract.mockResolvedValue({ content: '[]', usage: { inputTokens: 0, outputTokens: 0 } });
+
+    try {
+      await expect(
+        extractPrices('content', 'https://example.com', '2026-06-15')
+      ).resolves.toBeDefined();
+      expect(mockExtract.mock.calls[0]![0]).toBe('stored-only-key');
+    } finally {
+      process.env.ANTHROPIC_API_KEY = origKey;
+    }
+  });
+
+  it('uses the pre-resolved override apiKey on the preview path (#149)', async () => {
+    mockExtract.mockResolvedValue({ content: '[]', usage: { inputTokens: 0, outputTokens: 0 } });
+
+    await extractPrices(
+      'content', 'https://example.com', '2026-06-15',
+      undefined, undefined, true, undefined, null,
+      { provider: 'anthropic', model: 'claude-haiku-4-5-20251001', customBaseUrl: null, apiKey: 'override-key' },
+    );
+
+    expect(mockExtract.mock.calls[0]![0]).toBe('override-key');
   });
 
   // Issue #65: previously, if the LLM rejected (timeout, rate limit, etc.)

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -1,4 +1,4 @@
-import { EXTRACTION_PROVIDERS, CLI_PROVIDERS, LOCAL_PROVIDERS, type ExtractionUsage } from './ai-registry';
+import { EXTRACTION_PROVIDERS, CLI_PROVIDERS, LOCAL_PROVIDERS, resolveApiKey, type ExtractionUsage } from './ai-registry';
 import { prisma } from '@/lib/prisma';
 import { parseDurationToMinutes } from './duration';
 import type { NavigationSource } from './navigate';
@@ -392,6 +392,9 @@ export interface ExtractionConfigOverride {
   customBaseUrl: string | null;
   extractTimeoutSeconds?: number | null;
   maxFlightsPerDate?: number | null;
+  /** Pre-resolved API key (stored key decrypted, else env). Lets the caller
+   *  resolve once up front instead of decrypting on every per-attempt call. */
+  apiKey?: string;
 }
 
 export async function extractPrices(
@@ -413,6 +416,9 @@ export async function extractPrices(
   // When the caller already resolved the config (eg. preview-runner hoists
   // it once per preview), skip the DB read. Backwards compatible for the
   // /api/test/scrape endpoint and tests that pass minimal args.
+  const dbConfig = configOverride
+    ? null
+    : await prisma.extractionConfig.findFirst({ where: { id: 'singleton' } });
   const config = configOverride
     ? {
         provider: configOverride.provider,
@@ -421,7 +427,7 @@ export async function extractPrices(
         extractTimeoutSeconds: configOverride.extractTimeoutSeconds ?? null,
         maxFlightsPerDate: configOverride.maxFlightsPerDate ?? null,
       }
-    : await prisma.extractionConfig.findFirst({ where: { id: 'singleton' } });
+    : dbConfig;
 
   const effectiveMaxResults = config?.maxFlightsPerDate ?? maxResults;
 
@@ -438,7 +444,11 @@ export async function extractPrices(
   const hasLocalEndpoint =
     (provider === 'openai' && (config?.customBaseUrl || process.env.OPENAI_BASE_URL)) ||
     isLocalProvider;
-  const apiKey = isCliProvider ? '' : (providerConfig.envKey ? process.env[providerConfig.envKey] : '') ?? '';
+  // Override path may carry a pre-resolved key (preview-runner decrypts once);
+  // otherwise (or when the override omits it) resolve from the DB-stored key,
+  // falling back to the env var (#149). dbConfig is null on the override path,
+  // so resolveApiKey there yields the env var.
+  const apiKey = isCliProvider ? '' : (configOverride?.apiKey || resolveApiKey(provider, dbConfig));
   if (!apiKey && !isCliProvider && !hasLocalEndpoint) {
     throw new Error(`Missing API key: ${providerConfig.envKey}`);
   }

--- a/apps/web/src/lib/scraper/parse-query.test.ts
+++ b/apps/web/src/lib/scraper/parse-query.test.ts
@@ -15,26 +15,32 @@ vi.mock('@/lib/prisma', () => ({
   },
 }));
 
-vi.mock('./ai-registry', () => ({
-  EXTRACTION_PROVIDERS: {
-    anthropic: {
-      displayName: 'Anthropic',
-      envKey: 'ANTHROPIC_API_KEY',
-      models: [],
-      extract: mockExtract,
+// Keep the real ai-registry (so resolveApiKey is exercised end to end), but
+// swap the provider extract fns for a spy.
+vi.mock('./ai-registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./ai-registry')>();
+  return {
+    ...actual,
+    EXTRACTION_PROVIDERS: {
+      anthropic: {
+        displayName: 'Anthropic',
+        envKey: 'ANTHROPIC_API_KEY',
+        models: [],
+        extract: mockExtract,
+      },
+      ollama: {
+        displayName: 'Ollama',
+        envKey: undefined,
+        allowCustomModel: true,
+        allowCustomBaseUrl: true,
+        models: [],
+        extract: mockExtract,
+      },
     },
-    ollama: {
-      displayName: 'Ollama',
-      envKey: undefined,
-      allowCustomModel: true,
-      allowCustomBaseUrl: true,
-      models: [],
-      extract: mockExtract,
-    },
-  },
-  CLI_PROVIDERS: {},
-  LOCAL_PROVIDERS: new Set(['ollama']),
-}));
+    CLI_PROVIDERS: {},
+    LOCAL_PROVIDERS: new Set(['ollama']),
+  };
+});
 
 // Provide a fake API key so the provider check passes
 process.env.ANTHROPIC_API_KEY = 'test-key';
@@ -802,5 +808,34 @@ describe('parseFlightQuery', () => {
     } finally {
       process.env.ANTHROPIC_API_KEY = origKey;
     }
+  });
+
+  it('uses the DB-stored key over the env var when parsing (#149 parity)', async () => {
+    const { prisma } = await import('@/lib/prisma');
+    const { encryptSecret } = await import('@/lib/secret-crypto');
+    vi.mocked(prisma.extractionConfig.findFirst).mockResolvedValueOnce({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      anthropicApiKey: encryptSecret('stored-parse-key'),
+    } as never);
+    mockExtract.mockResolvedValue({
+      content: makeLlmResponse({
+        confidence: 'high',
+        ambiguities: [],
+        parsed: {
+          origins: [{ code: 'JFK', name: 'New York JFK' }],
+          destinations: [{ code: 'LAX', name: 'Los Angeles' }],
+          dateFrom: '2026-06-15', dateTo: '2026-06-22', flexibility: 0,
+          maxPrice: null, maxStops: null, preferredAirlines: [],
+          timePreference: 'any', cabinClass: 'economy', tripType: 'round_trip', currency: 'USD',
+        },
+      }),
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+
+    await parseFlightQuery('JFK to LAX June 15-22');
+
+    // env ANTHROPIC_API_KEY is 'test-key'; the stored key must win.
+    expect(mockExtract.mock.calls[0]![0]).toBe('stored-parse-key');
   });
 });

--- a/apps/web/src/lib/scraper/parse-query.ts
+++ b/apps/web/src/lib/scraper/parse-query.ts
@@ -1,4 +1,4 @@
-import { EXTRACTION_PROVIDERS, CLI_PROVIDERS, LOCAL_PROVIDERS, type ExtractionResult } from './ai-registry';
+import { EXTRACTION_PROVIDERS, CLI_PROVIDERS, LOCAL_PROVIDERS, resolveApiKey, type ExtractionResult } from './ai-registry';
 import { prisma } from '@/lib/prisma';
 
 export interface Airport {
@@ -239,7 +239,9 @@ export async function parseFlightQuery(
   const hasLocalEndpoint =
     (provider === 'openai' && (config?.customBaseUrl || process.env.OPENAI_BASE_URL)) ||
     isLocalProvider;
-  const apiKey = isCliProvider ? '' : (providerConfig.envKey ? process.env[providerConfig.envKey] : '') ?? '';
+  // DB-stored key takes precedence over the env var so a GUI-entered key works
+  // without editing .env or restarting the stack (#149).
+  const apiKey = isCliProvider ? '' : resolveApiKey(provider, config);
   if (!apiKey && !isCliProvider && !hasLocalEndpoint) {
     throw new Error(`Missing API key: ${providerConfig.envKey}`);
   }

--- a/apps/web/src/lib/scraper/settings-parity.test.ts
+++ b/apps/web/src/lib/scraper/settings-parity.test.ts
@@ -74,7 +74,7 @@ describe('settings page parity with admin config', () => {
     // aggregator allowlist that only an admin should configure). Core
     // data fields must exist in both.
     const coreFields = adminFields.filter(
-      (f) => !['hasAdminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'maxTrackedPerRoute', 'previewMaxCombos', 'aggregatorsEnabled', 'anthropicRpm', 'googleRpm', 'openaiRpm', 'groqRpm', 'previewConcurrency', 'previewAdmissionCap'].includes(f)
+      (f) => !['hasAdminPassword', 'hasAnthropicKey', 'hasOpenaiKey', 'hasGoogleKey', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'maxTrackedPerRoute', 'previewMaxCombos', 'aggregatorsEnabled', 'anthropicRpm', 'googleRpm', 'openaiRpm', 'groqRpm', 'previewConcurrency', 'previewAdmissionCap'].includes(f)
     );
 
     for (const field of coreFields) {
@@ -94,7 +94,7 @@ describe('settings page parity with admin config', () => {
     // allowlist) that settings doesn't surface. All other extraction-related
     // fields should be in both.
     const extractionFields = adminSaveFields.filter(
-      (f) => !['adminPassword', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'maxTrackedPerRoute', 'previewMaxCombos', 'aggregatorsEnabled', 'anthropicRpm', 'googleRpm', 'openaiRpm', 'groqRpm', 'previewConcurrency', 'previewAdmissionCap'].includes(f)
+      (f) => !['adminPassword', 'apiKey', 'extractTimeoutSeconds', 'maxFlightsPerDate', 'maxTrackedPerRoute', 'previewMaxCombos', 'aggregatorsEnabled', 'anthropicRpm', 'googleRpm', 'openaiRpm', 'groqRpm', 'previewConcurrency', 'previewAdmissionCap'].includes(f)
     );
 
     for (const field of extractionFields) {

--- a/packages/cli/src/lib/secret-crypto.ts
+++ b/packages/cli/src/lib/secret-crypto.ts
@@ -1,0 +1,8 @@
+// CLI shim for `@/lib/secret-crypto`. The shared scraper (apps/web's
+// ai-registry.ts) imports `@/lib/secret-crypto` to decrypt DB-stored provider
+// keys (#149). Under the CLI's tsconfig (`@/*` -> ./src/*) that bare import
+// would not resolve, so re-export the real implementation here. tsup's
+// `@` -> apps/web/src alias inlines the same module at build time, and the dev
+// loader resolves this relative path to it — so the behavior is always the
+// real crypto, never a stub. Same shim role as ./prisma.ts and ./redis.ts.
+export { encryptSecret, decryptSecret } from '../../../../apps/web/src/lib/secret-crypto.js';


### PR DESCRIPTION
Self hosted and desktop installs could pick a provider in the GUI but had no way to give it a key. Keys were read only from process.env at scrape time, so a desktop user whose install auto detected Ollama was stuck on it, and editing a .env did nothing. Addresses #149.

Now you enter the key in the admin config (or the first run setup wizard) and it is stored encrypted in the DB (AES-256-GCM, the same at rest scheme as vpnActivationCode), resolved before the env var, so it takes effect with no .env edit and no stack restart. Covers anthropic, openai, and google, not just openai. Selecting an env backed provider with no usable key now returns a 400 instead of saving and then failing every scrape with "Missing API key". The config page also shows a live readiness badge per provider.

One shared resolveApiKey seam feeds every path that needs a key: cron scrape, query parse, the create time preview, and provider detection. run-scrape re-reads the config so it inherits the stored key with no change.

CI is green across web and cli: lint, typecheck, 1326 tests, both builds. New tests cover the encrypt round trip, stored key beating the env var, an undecryptable value falling back to env, multi provider parity, the keyless save 400, and a parametrized provider contract test as a recurrence net.

Related and likely the same root cause: #9, #112, #8. Already working: #7, #81, #88.

Three follow ups will be filed separately: a desktop restart button plus showing the ~/.flight-finder/.env path, a non destructive .env merge in install.sh on re-run, and a customBaseUrl reachability probe on save.