### PR TITLE
test(desktop): verify restart_stack recreates the stack (#151)

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flight-finder/desktop",
-  "version": "0.1.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flight-finder/desktop",
-      "version": "0.1.0",
+      "version": "0.12.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -19,8 +19,14 @@ use std::thread;
 use std::time::Duration;
 use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 
-/// Default install directory used by install.sh (`~/.flight-finder`).
+/// Install directory used by install.sh. Honors `FLIGHT_FINDER_DIR` (the same
+/// override install.sh respects) and otherwise defaults to `~/.flight-finder`.
 fn install_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("FLIGHT_FINDER_DIR") {
+        if !dir.is_empty() {
+            return PathBuf::from(dir);
+        }
+    }
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_default();
@@ -164,10 +170,16 @@ fn stop_stack() -> Result<String, String> {
 #[tauri::command]
 fn restart_stack() -> Result<String, String> {
     let cmd = container_cmd().ok_or("Docker or Podman is required.")?;
+    restart_with(&cmd)
+}
+
+/// Recreate the stack with a resolved container command. Split out from the
+/// tauri command so it can be tested with a fake container binary.
+fn restart_with(cmd: &str) -> Result<String, String> {
     // `down` may exit non-zero if nothing is running; that is fine, only the
     // bring-up result decides success.
-    let _ = compose(&cmd, &["down"]).map_err(|e| e.to_string())?;
-    let out = compose(&cmd, &["up", "-d", "--force-recreate"]).map_err(|e| e.to_string())?;
+    let _ = compose(cmd, &["down"]).map_err(|e| e.to_string())?;
+    let out = compose(cmd, &["up", "-d", "--force-recreate"]).map_err(|e| e.to_string())?;
     if out.status.success() {
         Ok("restarted".into())
     } else {
@@ -358,4 +370,38 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running Flight Finder");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// restart_with must recreate the stack: `compose down` first, then
+    /// `compose up -d --force-recreate` (a plain `up -d` would not reload an
+    /// edited env_file). Drive it with a fake container binary that records its
+    /// args, and point FLIGHT_FINDER_DIR at a temp dir so compose() has a real
+    /// working directory. #151.
+    #[test]
+    fn restart_runs_down_then_force_recreate_up_in_order() {
+        let tmp = std::env::temp_dir().join(format!("ff-restart-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("FLIGHT_FINDER_DIR", &tmp);
+
+        let log = tmp.join("calls.log");
+        let _ = std::fs::remove_file(&log);
+        let shim = tmp.join("fake-container.sh");
+        std::fs::write(&shim, format!("#!/bin/sh\necho \"$@\" >> \"{}\"\n", log.display())).unwrap();
+        std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let res = restart_with(shim.to_str().unwrap());
+        assert!(res.is_ok(), "restart_with errored: {res:?}");
+
+        let calls = std::fs::read_to_string(&log).unwrap();
+        let lines: Vec<&str> = calls.lines().collect();
+        assert_eq!(lines, vec!["compose down", "compose up -d --force-recreate"]);
+
+        std::env::remove_var("FLIGHT_FINDER_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }

--- a/apps/web/src/desktop-launcher.test.ts
+++ b/apps/web/src/desktop-launcher.test.ts
@@ -1,0 +1,89 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Exercises the real Tauri desktop launcher UI (apps/desktop/src) from the web
+// test runner so it runs in `npm run ci`. The desktop package is intentionally
+// minimal (no JS test runner of its own), and main.js is plain DOM glue, so we
+// load the actual index.html + main.js into jsdom with a mocked Tauri bridge
+// and assert the behavior that #151 added: the Restart button and the .env
+// hint show only in the right states, and Restart invokes restart_stack.
+
+const desktopSrc = resolve(dirname(fileURLToPath(import.meta.url)), '../../desktop/src');
+const html = readFileSync(resolve(desktopSrc, 'index.html'), 'utf8');
+const mainJs = readFileSync(resolve(desktopSrc, 'main.js'), 'utf8');
+const bodyInner = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i)![1] ?? '';
+
+type Responses = Record<string, unknown>;
+
+// jsdom in this config exposes a `localStorage` object with no methods, so give
+// main.js (route() reads it on load) a working in-memory one.
+function installLocalStorage() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+  };
+  Object.defineProperty(window, 'localStorage', { value: stub, configurable: true, writable: true });
+}
+
+/** Render the real launcher markup, mock the Tauri bridge, and run main.js.
+ *  main.js is a non-module script: `new Function` runs it (its listeners close
+ *  over the same `invoke`) and returns the handles the tests drive. */
+function loadLauncher(responses: Responses) {
+  document.body.innerHTML = bodyInner; // <script> in innerHTML does not execute in jsdom
+  installLocalStorage();
+  const invoke = vi.fn((cmd: string) => Promise.resolve(responses[cmd]));
+  (window as unknown as { __TAURI__: unknown }).__TAURI__ = { core: { invoke } };
+  const factory = new Function(`${mainJs}\nreturn { refreshHost, setMode };`);
+  const api = factory() as { refreshHost: () => Promise<void>; setMode: (m: string | null) => void };
+  return { invoke, api };
+}
+
+const el = (id: string) => document.getElementById(id)!;
+
+describe('desktop launcher UI (#151)', () => {
+  beforeEach(() => {
+    // Freeze main.js's 5s refresh interval and waitHealthy's 1.5s sleep.
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows Restart and the .env hint when the stack is running', async () => {
+    const { api } = loadLauncher({ docker_available: true, installed: true, is_healthy: true });
+    await api.refreshHost();
+    expect(el('restart').hidden).toBe(false);
+    expect(el('config-hint').hidden).toBe(false);
+    expect(el('stop').hidden).toBe(false);
+    expect(el('start').hidden).toBe(true);
+  });
+
+  it('hides Restart when installed but stopped, still showing the .env hint', async () => {
+    const { api } = loadLauncher({ docker_available: true, installed: true, is_healthy: false });
+    await api.refreshHost();
+    expect(el('restart').hidden).toBe(true);
+    expect(el('start').hidden).toBe(false);
+    expect(el('config-hint').hidden).toBe(false);
+  });
+
+  it('hides Restart and the .env hint when not installed', async () => {
+    const { api } = loadLauncher({ docker_available: true, installed: false });
+    await api.refreshHost();
+    expect(el('restart').hidden).toBe(true);
+    expect(el('config-hint').hidden).toBe(true);
+  });
+
+  it('clicking Restart invokes restart_stack', async () => {
+    const { invoke, api } = loadLauncher({ docker_available: true, installed: true, is_healthy: true });
+    await api.refreshHost();
+    invoke.mockClear();
+    el('restart').dispatchEvent(new window.Event('click'));
+    expect(invoke).toHaveBeenCalledWith('restart_stack');
+  });
+});


### PR DESCRIPTION
Follow-up to #154: actually test the #151 Restart action instead of relying on inspection. Addresses #151.

- Extract restart_with(cmd) from the restart_stack tauri command so the recreate sequence is testable.
- install_dir() now honors FLIGHT_FINDER_DIR (the same override install.sh already uses), which also gives the test a real working directory.
- New Rust unit test drives restart_with with a fake container binary and asserts it runs `compose down` then `compose up -d --force-recreate` in order, the behavior that makes an edited .env reload.

Verified locally: tauri icons generated, full `cargo build` compiles and links cleanly (removes the earlier "compiles modulo gitignored icons" caveat), and `cargo test` passes the new test. Also syncs the stale desktop package-lock version (0.1.0 to 0.12.0).

Still manual-only: the GUI button render and a real click against a live stack, which the desktop-release build covers.