### PR TITLE
feat: make tracker filters editable

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -44,12 +44,27 @@ model Query {
 
   snapshots PriceSnapshot[]
   fetchRuns FetchRun[]
+  editEvents QueryEditEvent[]
   user      User?           @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@index([active])
   @@index([expiresAt])
   @@index([isSeed])
   @@index([groupId])
+  @@index([userId])
+}
+
+model QueryEditEvent {
+  id        String   @id @default(cuid())
+  queryId   String
+  editedAt  DateTime @default(now())
+  userId    String?
+  summary   String
+  changes   Json
+
+  query Query @relation(fields: [queryId], references: [id], onDelete: Cascade)
+
+  @@index([queryId, editedAt])
   @@index([userId])
 }
 

--- a/apps/web/src/app/api/queries/[id]/prices/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/prices/route.test.ts
@@ -5,6 +5,7 @@ const mockQueryFindUnique = vi.fn();
 const mockSnapshotFindMany = vi.fn();
 const mockFetchRunFindFirst = vi.fn();
 const mockExtractionConfigFindFirst = vi.fn().mockResolvedValue({ scrapeInterval: 3 });
+const mockQueryEditEventFindMany = vi.fn();
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
@@ -12,6 +13,7 @@ vi.mock('@/lib/prisma', () => ({
     priceSnapshot: { findMany: (...args: unknown[]) => mockSnapshotFindMany(...args) },
     fetchRun: { findFirst: (...args: unknown[]) => mockFetchRunFindFirst(...args) },
     extractionConfig: { findFirst: (...args: unknown[]) => mockExtractionConfigFindFirst(...args) },
+    queryEditEvent: { findMany: (...args: unknown[]) => mockQueryEditEventFindMany(...args) },
   },
 }));
 
@@ -39,6 +41,7 @@ describe('GET /api/queries/[id]/prices', () => {
     mockExtractionConfigFindFirst.mockResolvedValue({ scrapeInterval: 3 });
     mockSnapshotFindMany.mockResolvedValue([]);
     mockFetchRunFindFirst.mockResolvedValue(null);
+    mockQueryEditEventFindMany.mockResolvedValue([]);
   });
 
   it('returns 404 for nonexistent query', async () => {
@@ -139,5 +142,49 @@ describe('GET /api/queries/[id]/prices', () => {
     expect(body.data.snapshots[0].id).toBe('s1');
     expect(body.data.snapshots[1].id).toBe('s2');
     expect(body.data.snapshots[2].id).toBe('s3');
+  });
+
+  it('filters snapshots by current tracker filters and reports total count', async () => {
+    mockQueryFindUnique.mockResolvedValue({
+      id: 'test-id',
+      expiresAt: futureDate(),
+      maxStops: 0,
+      maxPrice: null,
+      maxDurationHours: null,
+      preferredAirlines: [],
+    });
+    mockSnapshotFindMany.mockResolvedValue([
+      { id: 's2', price: 200, stops: 1, duration: null, airline: 'United', scrapedAt: '2026-02-01T00:00:00.000Z' },
+      { id: 's1', price: 300, stops: 0, duration: null, airline: 'Delta', scrapedAt: '2026-01-01T00:00:00.000Z' },
+    ]);
+
+    const res = await callGet();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.snapshots).toHaveLength(1);
+    expect(body.data.snapshots[0].id).toBe('s1');
+    expect(body.data.snapshotCount).toBe(1);
+    expect(body.data.totalSnapshotCount).toBe(2);
+  });
+
+  it('includes tracker edit events for chart annotations', async () => {
+    mockQueryFindUnique.mockResolvedValue({ id: 'test-id', expiresAt: futureDate() });
+    mockQueryEditEventFindMany.mockResolvedValue([
+      { id: 'e2', editedAt: new Date('2026-03-01T00:00:00Z'), summary: 'Price cap changed', changes: { changes: [] } },
+      { id: 'e1', editedAt: new Date('2026-02-01T00:00:00Z'), summary: 'Nonstop only enabled', changes: { changes: [] } },
+    ]);
+
+    const res = await callGet();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockQueryEditEventFindMany).toHaveBeenCalledWith(expect.objectContaining({
+      orderBy: { editedAt: 'desc' },
+      take: 25,
+    }));
+    expect(body.data.editEvents).toHaveLength(2);
+    expect(body.data.editEvents[0].summary).toBe('Nonstop only enabled');
+    expect(body.data.editEvents[1].summary).toBe('Price cap changed');
   });
 });

--- a/apps/web/src/app/api/queries/[id]/prices/route.ts
+++ b/apps/web/src/app/api/queries/[id]/prices/route.ts
@@ -3,8 +3,7 @@ import { apiSuccess, apiError } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
 import { cached } from '@/lib/redis';
 import { filterSnapshotsByTrackerFilters } from '@/lib/snapshot-filters';
-
-const MAX_EDIT_EVENTS = 25;
+import { MAX_TRACKER_EDIT_EVENTS } from '@/lib/tracker-edit-events';
 
 export async function GET(
   _request: NextRequest,
@@ -98,7 +97,7 @@ export async function GET(
     prisma.queryEditEvent.findMany({
       where: { queryId: id },
       orderBy: { editedAt: 'desc' },
-      take: MAX_EDIT_EVENTS,
+      take: MAX_TRACKER_EDIT_EVENTS,
       select: { id: true, editedAt: true, summary: true, changes: true },
     }),
   ]);

--- a/apps/web/src/app/api/queries/[id]/prices/route.ts
+++ b/apps/web/src/app/api/queries/[id]/prices/route.ts
@@ -2,6 +2,9 @@ import { NextRequest } from 'next/server';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
 import { cached } from '@/lib/redis';
+import { filterSnapshotsByTrackerFilters } from '@/lib/snapshot-filters';
+
+const MAX_EDIT_EVENTS = 25;
 
 export async function GET(
   _request: NextRequest,
@@ -22,6 +25,7 @@ export async function GET(
       flexibility: true,
       maxPrice: true,
       maxStops: true,
+      maxDurationHours: true,
       preferredAirlines: true,
       timePreference: true,
       cabinClass: true,
@@ -82,13 +86,23 @@ export async function GET(
     120 // 2 min cache for public page
   );
 
-  const snapshots = snapshotsDesc.slice().reverse();
+  const allSnapshots = snapshotsDesc.slice().reverse();
+  const snapshots = filterSnapshotsByTrackerFilters(allSnapshots, query);
 
-  const lastRun = await prisma.fetchRun.findFirst({
-    where: { queryId: id },
-    orderBy: { startedAt: 'desc' },
-    select: { startedAt: true, status: true },
-  });
+  const [lastRun, editEventsDesc] = await Promise.all([
+    prisma.fetchRun.findFirst({
+      where: { queryId: id },
+      orderBy: { startedAt: 'desc' },
+      select: { startedAt: true, status: true },
+    }),
+    prisma.queryEditEvent.findMany({
+      where: { queryId: id },
+      orderBy: { editedAt: 'desc' },
+      take: MAX_EDIT_EVENTS,
+      select: { id: true, editedAt: true, summary: true, changes: true },
+    }),
+  ]);
+  const editEvents = editEventsDesc.slice().reverse();
 
   const effectiveInterval = query.scrapeInterval ?? globalConfig?.scrapeInterval ?? 3;
 
@@ -98,6 +112,8 @@ export async function GET(
     lastChecked: lastRun?.startedAt ?? null,
     lastStatus: lastRun?.status ?? null,
     snapshotCount: snapshots.length,
+    totalSnapshotCount: allSnapshots.length,
+    editEvents,
     effectiveInterval,
   });
 }

--- a/apps/web/src/app/api/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/route.test.ts
@@ -7,9 +7,31 @@ const mockQueryDeleteMany = vi.fn();
 const mockQueryFindMany = vi.fn();
 const mockQueryUpdateMany = vi.fn();
 const mockQueryUpdate = vi.fn();
+const mockQueryEditEventCreateMany = vi.fn();
+
+interface MockTransactionClient {
+  query: {
+    updateMany: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+  };
+  queryEditEvent: {
+    createMany: (...args: unknown[]) => unknown;
+  };
+}
+
+const mockTransaction = vi.fn((callback: (tx: MockTransactionClient) => unknown) => callback({
+  query: {
+    updateMany: (...args: unknown[]) => mockQueryUpdateMany(...args),
+    update: (...args: unknown[]) => mockQueryUpdate(...args),
+  },
+  queryEditEvent: {
+    createMany: (...args: unknown[]) => mockQueryEditEventCreateMany(...args),
+  },
+}));
 
 vi.mock('@/lib/prisma', () => ({
   prisma: {
+    $transaction: (callback: (tx: MockTransactionClient) => unknown) => mockTransaction(callback),
     query: {
       findUnique: (...args: unknown[]) => mockQueryFindUnique(...args),
       delete: (...args: unknown[]) => mockQueryDelete(...args),
@@ -19,6 +41,9 @@ vi.mock('@/lib/prisma', () => ({
       update: (...args: unknown[]) => mockQueryUpdate(...args),
     },
     extractionConfig: { findUnique: async () => null },
+    queryEditEvent: {
+      createMany: (...args: unknown[]) => mockQueryEditEventCreateMany(...args),
+    },
   },
 }));
 
@@ -281,6 +306,7 @@ describe('PATCH /api/queries/[id]', () => {
     vi.clearAllMocks();
     mockQueryFindMany.mockResolvedValue([]);
     mockQueryUpdateMany.mockResolvedValue({ count: 1 });
+    mockQueryEditEventCreateMany.mockResolvedValue({ count: 0 });
     mockIsMultiUserEnabled.mockResolvedValue(false);
     mockGetCurrentUser.mockResolvedValue(null);
     delete process.env.SELF_HOSTED;
@@ -385,6 +411,92 @@ describe('PATCH /api/queries/[id]', () => {
       const res = await PATCH(...makePatchRequest('q1', { active: false }));
       expect(res.status).toBe(401);
       expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tracker filters', () => {
+    const editableQuery = {
+      id: 'q1',
+      deleteToken: null,
+      groupId: 'g1',
+      userId: null,
+      maxPrice: null,
+      maxStops: 1,
+      maxDurationHours: null,
+      preferredAirlines: [],
+      timePreference: 'any',
+      cabinClass: 'economy',
+      preferredAggregators: [],
+    };
+
+    it('updates tracker filters across grouped queries and records edit events', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockGetCurrentUser.mockResolvedValue({ id: 'user_1', isAdmin: false });
+      mockQueryFindUnique.mockResolvedValue(editableQuery);
+      mockQueryFindMany.mockResolvedValue([{
+        ...editableQuery,
+        id: 'q2',
+        maxStops: null,
+      }]);
+
+      const res = await PATCH(...makePatchRequest('q1', {
+        maxPrice: 500,
+        maxStops: 0,
+        maxDurationHours: 12,
+        preferredAirlines: [' Delta ', ''],
+      }));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.data).toMatchObject({
+        maxPrice: 500,
+        maxStops: 0,
+        maxDurationHours: 12,
+        preferredAirlines: ['Delta'],
+        updated: 2,
+      });
+      expect(mockQueryUpdateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['q1', 'q2'] } },
+        data: {
+          maxPrice: 500,
+          maxStops: 0,
+          maxDurationHours: 12,
+          preferredAirlines: ['Delta'],
+        },
+      });
+      expect(mockTransaction).toHaveBeenCalledTimes(1);
+      expect(mockQueryEditEventCreateMany).toHaveBeenCalledWith({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            queryId: 'q1',
+            userId: 'user_1',
+            summary: '4 tracker filters changed',
+            changes: {
+              changes: expect.arrayContaining([
+                expect.objectContaining({
+                  field: 'maxStops',
+                  beforeLabel: 'Max 1 stop',
+                  afterLabel: 'Nonstop only',
+                }),
+              ]),
+            },
+          }),
+          expect.objectContaining({ queryId: 'q2' }),
+        ]),
+      });
+    });
+
+    it('rejects invalid maxStops before updating', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue(editableQuery);
+
+      const res = await PATCH(...makePatchRequest('q1', { maxStops: 11 }));
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data.error).toContain('maxStops');
+      expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+      expect(mockQueryEditEventCreateMany).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/route.test.ts
@@ -498,6 +498,23 @@ describe('PATCH /api/queries/[id]', () => {
       expect(mockQueryUpdateMany).not.toHaveBeenCalled();
       expect(mockQueryEditEventCreateMany).not.toHaveBeenCalled();
     });
+
+    it('rejects time and cabin edits because snapshots cannot enforce them', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockQueryFindUnique.mockResolvedValue(editableQuery);
+
+      const res = await PATCH(...makePatchRequest('q1', {
+        timePreference: 'morning',
+        cabinClass: 'business',
+      }));
+      const data = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(data.error).toContain('No updatable fields');
+      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(mockQueryUpdateMany).not.toHaveBeenCalled();
+      expect(mockQueryEditEventCreateMany).not.toHaveBeenCalled();
+    });
   });
 
   describe('label', () => {

--- a/apps/web/src/app/api/queries/[id]/route.ts
+++ b/apps/web/src/app/api/queries/[id]/route.ts
@@ -129,18 +129,13 @@ function summarizeChanges(changes: TrackerEditChange[]): string {
   return `${changes.length} tracker filters changed`;
 }
 
-function editValueToJson(value: TrackerEditValue): Prisma.InputJsonValue | null {
-  if (Array.isArray(value)) return value;
-  return value;
-}
-
 function changesToJson(changes: TrackerEditChange[]): Prisma.InputJsonObject {
   return {
     changes: changes.map((change): Prisma.InputJsonObject => ({
       field: change.field,
       label: change.label,
-      before: editValueToJson(change.before),
-      after: editValueToJson(change.after),
+      before: change.before,
+      after: change.after,
       beforeLabel: change.beforeLabel,
       afterLabel: change.afterLabel,
     })),

--- a/apps/web/src/app/api/queries/[id]/route.ts
+++ b/apps/web/src/app/api/queries/[id]/route.ts
@@ -1,10 +1,151 @@
 import { NextRequest } from 'next/server';
+import type { Prisma } from '@/generated/prisma/client';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
 import { authorizeMutation } from '@/lib/query-auth';
+import { getCurrentUser } from '@/lib/user-auth';
 import { isAggregatorSource } from '@/lib/scraper/navigate';
 
 const ALLOWED_INTERVALS = [1, 3, 6, 12, 24];
+const MAX_PRICE_VALUE = 1_000_000;
+const MAX_STOPS_VALUE = 10;
+const MAX_AIRLINE_LENGTH = 100;
+
+type TrackerEditValue = string | number | boolean | string[] | null;
+type TrackerEditField =
+  | 'maxPrice'
+  | 'maxStops'
+  | 'maxDurationHours'
+  | 'preferredAirlines';
+
+interface EditableQuery {
+  id: string;
+  deleteToken: string | null;
+  groupId: string | null;
+  userId: string | null;
+  maxPrice: number | null;
+  maxStops: number | null;
+  maxDurationHours: number | null;
+  preferredAirlines: string[];
+  preferredAggregators: string[];
+}
+
+interface TrackerEditChange {
+  field: TrackerEditField;
+  label: string;
+  before: TrackerEditValue;
+  after: TrackerEditValue;
+  beforeLabel: string;
+  afterLabel: string;
+}
+
+interface QueryEditEventCreate {
+  queryId: string;
+  editedAt: Date;
+  userId: string | null;
+  summary: string;
+  changes: Prisma.InputJsonValue;
+}
+
+const EDIT_FIELD_LABELS: Record<TrackerEditField, string> = {
+  maxPrice: 'Max price',
+  maxStops: 'Stops',
+  maxDurationHours: 'Max duration',
+  preferredAirlines: 'Airlines',
+};
+
+function hasOwn(body: object, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(body, field);
+}
+
+function isFiniteNonNegative(n: number): boolean {
+  return Number.isFinite(n) && n >= 0;
+}
+
+function stringArraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+function editValuesEqual(before: TrackerEditValue, after: TrackerEditValue): boolean {
+  if (Array.isArray(before) && Array.isArray(after)) return stringArraysEqual(before, after);
+  return before === after;
+}
+
+function normalizeEditValue(field: TrackerEditField, value: unknown): TrackerEditValue {
+  if (field === 'preferredAirlines') {
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  return null;
+}
+
+function formatEditValue(field: TrackerEditField, value: TrackerEditValue): string {
+  if (value === null) {
+    if (field === 'maxStops' || field === 'maxPrice' || field === 'maxDurationHours') return 'Any';
+    return 'None';
+  }
+  if (Array.isArray(value)) return value.length > 0 ? value.join(', ') : 'Any';
+
+  switch (field) {
+    case 'maxPrice':
+      return `Under ${value}`;
+    case 'maxStops':
+      return value === 0 ? 'Nonstop only' : `Max ${value} stop${value === 1 ? '' : 's'}`;
+    case 'maxDurationHours':
+      return `Under ${value}h`;
+    case 'preferredAirlines':
+      return String(value);
+  }
+}
+
+function buildEditChanges(
+  target: EditableQuery,
+  data: Partial<Record<TrackerEditField, TrackerEditValue>>,
+): TrackerEditChange[] {
+  const changes: TrackerEditChange[] = [];
+  for (const field of Object.keys(data) as TrackerEditField[]) {
+    const after = normalizeEditValue(field, data[field]);
+    const before = normalizeEditValue(field, target[field]);
+    if (editValuesEqual(before, after)) continue;
+    changes.push({
+      field,
+      label: EDIT_FIELD_LABELS[field],
+      before,
+      after,
+      beforeLabel: formatEditValue(field, before),
+      afterLabel: formatEditValue(field, after),
+    });
+  }
+  return changes;
+}
+
+function summarizeChanges(changes: TrackerEditChange[]): string {
+  if (changes.length === 1) {
+    const change = changes[0]!;
+    if (change.field === 'maxStops' && change.after === 0) return 'Nonstop only enabled';
+    return `${change.label} changed`;
+  }
+  return `${changes.length} tracker filters changed`;
+}
+
+function editValueToJson(value: TrackerEditValue): Prisma.InputJsonValue | null {
+  if (Array.isArray(value)) return value;
+  return value;
+}
+
+function changesToJson(changes: TrackerEditChange[]): Prisma.InputJsonObject {
+  return {
+    changes: changes.map((change): Prisma.InputJsonObject => ({
+      field: change.field,
+      label: change.label,
+      before: editValueToJson(change.before),
+      after: editValueToJson(change.after),
+      beforeLabel: change.beforeLabel,
+      afterLabel: change.afterLabel,
+    })),
+  };
+}
 
 export async function PATCH(
   request: NextRequest,
@@ -17,22 +158,40 @@ export async function PATCH(
 
   const query = await prisma.query.findUnique({
     where: { id },
-    select: { deleteToken: true, groupId: true, userId: true },
+    select: {
+      id: true,
+      deleteToken: true,
+      groupId: true,
+      userId: true,
+      maxPrice: true,
+      maxStops: true,
+      maxDurationHours: true,
+      preferredAirlines: true,
+      preferredAggregators: true,
+    },
   });
 
   if (!query) return apiError('Tracker not found', 404);
 
   const auth = await authorizeMutation(query, token);
   if (!auth.ok) return apiError(auth.error ?? 'Forbidden', auth.status ?? 403);
+  const primaryTarget: EditableQuery = { ...query, id };
 
   // Group-cascading fields: applied to every sibling in the group via updateMany.
-  const cascadeData: { scrapeInterval?: number | null; active?: boolean } = {};
+  const cascadeData: {
+    scrapeInterval?: number | null;
+    active?: boolean;
+    maxPrice?: number | null;
+    maxStops?: number | null;
+    maxDurationHours?: number | null;
+    preferredAirlines?: string[];
+  } = {};
   // Per-row fields: applied only to the single id. preferredAggregators is
   // intentionally NOT cascaded — different siblings in a flex group can sit on
   // different aggregators (e.g. one experimental, one default).
   const singleRowData: { preferredAggregators?: string[]; label?: string | null } = {};
 
-  if (body && Object.prototype.hasOwnProperty.call(body, 'scrapeInterval')) {
+  if (body && hasOwn(body, 'scrapeInterval')) {
     let interval: number | null;
     if (body.scrapeInterval === null) {
       interval = null;
@@ -45,14 +204,69 @@ export async function PATCH(
     cascadeData.scrapeInterval = interval;
   }
 
-  if (body && Object.prototype.hasOwnProperty.call(body, 'active')) {
+  if (body && hasOwn(body, 'active')) {
     if (typeof body.active !== 'boolean') {
       return apiError('active must be a boolean', 400);
     }
     cascadeData.active = body.active;
   }
 
-  if (body && Object.prototype.hasOwnProperty.call(body, 'label')) {
+  if (body && hasOwn(body, 'maxPrice')) {
+    if (body.maxPrice === null) {
+      cascadeData.maxPrice = null;
+    } else {
+      const maxPrice = Number(body.maxPrice);
+      if (!isFiniteNonNegative(maxPrice) || maxPrice > MAX_PRICE_VALUE) {
+        return apiError(`maxPrice must be null or a finite number between 0 and ${MAX_PRICE_VALUE}`, 400);
+      }
+      cascadeData.maxPrice = maxPrice;
+    }
+  }
+
+  if (body && hasOwn(body, 'maxStops')) {
+    if (body.maxStops === null) {
+      cascadeData.maxStops = null;
+    } else {
+      const maxStops = Number(body.maxStops);
+      if (!Number.isInteger(maxStops) || maxStops < 0 || maxStops > MAX_STOPS_VALUE) {
+        return apiError(`maxStops must be null or an integer between 0 and ${MAX_STOPS_VALUE}`, 400);
+      }
+      cascadeData.maxStops = maxStops;
+    }
+  }
+
+  if (body && hasOwn(body, 'maxDurationHours')) {
+    if (body.maxDurationHours === null) {
+      cascadeData.maxDurationHours = null;
+    } else {
+      const maxDurationHours = Number(body.maxDurationHours);
+      if (!Number.isInteger(maxDurationHours) || maxDurationHours < 1 || maxDurationHours > 48) {
+        return apiError('maxDurationHours must be null or an integer between 1 and 48', 400);
+      }
+      cascadeData.maxDurationHours = maxDurationHours;
+    }
+  }
+
+  if (body && hasOwn(body, 'preferredAirlines')) {
+    if (!Array.isArray(body.preferredAirlines)) {
+      return apiError('preferredAirlines must be an array of strings', 422);
+    }
+    const airlines: string[] = [];
+    for (const airline of body.preferredAirlines) {
+      if (typeof airline !== 'string') {
+        return apiError('preferredAirlines must be an array of strings', 422);
+      }
+      const trimmed = airline.trim();
+      if (!trimmed) continue;
+      if (trimmed.length > MAX_AIRLINE_LENGTH) {
+        return apiError(`preferredAirlines entry must be ${MAX_AIRLINE_LENGTH} characters or fewer`, 400);
+      }
+      airlines.push(trimmed);
+    }
+    cascadeData.preferredAirlines = airlines;
+  }
+
+  if (body && hasOwn(body, 'label')) {
     if (body.label === null) {
       singleRowData.label = null;
     } else if (typeof body.label === 'string') {
@@ -66,7 +280,7 @@ export async function PATCH(
     }
   }
 
-  if (body && Object.prototype.hasOwnProperty.call(body, 'preferredAggregators')) {
+  if (body && hasOwn(body, 'preferredAggregators')) {
     if (!Array.isArray(body.preferredAggregators)) {
       return apiError('preferredAggregators must be an array of strings', 422);
     }
@@ -82,28 +296,66 @@ export async function PATCH(
     return apiError('No updatable fields supplied', 400);
   }
 
-  const idsToUpdate = [id];
+  const cascadeTargets: EditableQuery[] = [primaryTarget];
   if (query.groupId && Object.keys(cascadeData).length > 0) {
     const siblings = await prisma.query.findMany({
       where: { groupId: query.groupId, id: { not: id } },
-      select: { id: true },
+      select: {
+        id: true,
+        deleteToken: true,
+        groupId: true,
+        userId: true,
+        maxPrice: true,
+        maxStops: true,
+        maxDurationHours: true,
+        preferredAirlines: true,
+        preferredAggregators: true,
+      },
     });
-    idsToUpdate.push(...siblings.map((s) => s.id));
+    cascadeTargets.push(...siblings);
+  }
+  const idsToUpdate = cascadeTargets.map((target) => target.id);
+
+  const eventData: Partial<Record<TrackerEditField, TrackerEditValue>> = {};
+  if (hasOwn(cascadeData, 'maxPrice')) eventData.maxPrice = cascadeData.maxPrice ?? null;
+  if (hasOwn(cascadeData, 'maxStops')) eventData.maxStops = cascadeData.maxStops ?? null;
+  if (hasOwn(cascadeData, 'maxDurationHours')) eventData.maxDurationHours = cascadeData.maxDurationHours ?? null;
+  if (hasOwn(cascadeData, 'preferredAirlines')) eventData.preferredAirlines = cascadeData.preferredAirlines ?? [];
+
+  const editedAt = new Date();
+  const user = await getCurrentUser().catch(() => null);
+  const events: QueryEditEventCreate[] = [];
+  for (const target of cascadeTargets) {
+    const changes = buildEditChanges(target, eventData);
+    if (changes.length === 0) continue;
+    events.push({
+      queryId: target.id,
+      editedAt,
+      userId: user?.id ?? null,
+      summary: summarizeChanges(changes),
+      changes: changesToJson(changes),
+    });
   }
 
-  if (Object.keys(cascadeData).length > 0) {
-    await prisma.query.updateMany({
-      where: { id: { in: idsToUpdate } },
-      data: cascadeData,
-    });
-  }
+  await prisma.$transaction(async (tx) => {
+    if (Object.keys(cascadeData).length > 0) {
+      await tx.query.updateMany({
+        where: { id: { in: idsToUpdate } },
+        data: cascadeData,
+      });
+    }
 
-  if (Object.keys(singleRowData).length > 0) {
-    await prisma.query.update({
-      where: { id },
-      data: singleRowData,
-    });
-  }
+    if (Object.keys(singleRowData).length > 0) {
+      await tx.query.update({
+        where: { id },
+        data: singleRowData,
+      });
+    }
+
+    if (events.length > 0) {
+      await tx.queryEditEvent.createMany({ data: events });
+    }
+  });
 
   return apiSuccess({ ...cascadeData, ...singleRowData, updated: idsToUpdate.length });
 }

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -16,11 +16,15 @@ import { Footer } from '@/components/Footer';
 import { StackedSortControls, type StackedItem } from '@/components/StackedSortControls';
 import { ScrapeStatusDot } from '@/components/ScrapeStatusDot';
 import { ForceScrapeButton } from '@/components/ForceScrapeButton';
+import { TrackerFilters } from '@/components/TrackerFilters';
 import { aggregateScrapeStatus } from '@/lib/scrape-status';
 import { canManageQueryWithoutToken } from '@/lib/query-auth';
+import { filterSnapshotsByTrackerFilters } from '@/lib/snapshot-filters';
 import { groupDateRange } from './group-date-range';
 import { safeJsonLd } from './safe-json-ld';
 import styles from './page.module.css';
+
+const MAX_EDIT_EVENTS = 25;
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -69,6 +73,26 @@ function daysUntil(d: Date): number {
   return Math.max(0, Math.ceil((d.getTime() - Date.now()) / (1000 * 60 * 60 * 24)));
 }
 
+interface ChartSnapshot {
+  id: string;
+  travelDate: string;
+  price: number;
+  currency: string;
+  airline: string;
+  bookingUrl: string | null;
+  stops: number;
+  duration: string | null;
+  flightId: string | null;
+  flightNumber: string | null;
+  departureTime: string | null;
+  arrivalTime: string | null;
+  seatsLeft: number | null;
+  status: string;
+  airlineDirectPrice: number | null;
+  vpnCountry: string | null;
+  scrapedAt: string;
+}
+
 interface QueryWithSnapshots {
   query: {
     id: string;
@@ -82,6 +106,12 @@ interface QueryWithSnapshots {
     flexibility: number;
     tripType: string;
     active: boolean;
+    maxPrice: number | null;
+    maxStops: number | null;
+    maxDurationHours: number | null;
+    preferredAirlines: string[];
+    timePreference: string;
+    cabinClass: string;
     expiresAt: Date;
     createdAt: Date;
     firstViewedAt: Date | null;
@@ -93,24 +123,12 @@ interface QueryWithSnapshots {
     label: string | null;
     userId: string | null;
   };
-  snapshots: Array<{
+  snapshots: ChartSnapshot[];
+  allSnapshots: ChartSnapshot[];
+  editEvents: Array<{
     id: string;
-    travelDate: string;
-    price: number;
-    currency: string;
-    airline: string;
-    bookingUrl: string | null;
-    stops: number;
-    duration: string | null;
-    flightId: string | null;
-    flightNumber: string | null;
-    departureTime: string | null;
-    arrivalTime: string | null;
-    seatsLeft: number | null;
-    status: string;
-    airlineDirectPrice: number | null;
-    vpnCountry: string | null;
-    scrapedAt: string;
+    editedAt: string;
+    summary: string;
   }>;
   lastRun: { startedAt: Date; status: string; error: string | null } | null;
   globalScrapeInterval: number;
@@ -138,8 +156,13 @@ function renderRouteBlock(qData: QueryWithSnapshots, isMultiRoute: boolean) {
       )}
 
       <section className={styles.chart}>
-        <PriceChart snapshots={qData.snapshots} currency={qData.query.currency ?? 'USD'} />
-        {qData.query.vpnCountries.length > 0 && !qData.snapshots.some((s) => s.vpnCountry) && (
+        <PriceChart
+          snapshots={qData.snapshots}
+          allSnapshots={qData.allSnapshots}
+          editEvents={qData.editEvents}
+          currency={qData.query.currency ?? 'USD'}
+        />
+        {qData.query.vpnCountries.length > 0 && !qData.allSnapshots.some((s) => s.vpnCountry) && (
           <p className={styles.vpnPending}>
             VPN comparison in progress -- prices from {qData.query.vpnCountries.map((c) =>
               String.fromCodePoint(...c.split('').map((ch) => 0x1f1e6 + ch.charCodeAt(0) - 65)) + ' ' + c
@@ -239,12 +262,31 @@ async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | 
     select: { scrapeInterval: true },
   });
 
+  const editEventsDesc = await prisma.queryEditEvent.findMany({
+    where: { queryId: id },
+    orderBy: { editedAt: 'desc' },
+    take: MAX_EDIT_EVENTS,
+    select: {
+      id: true,
+      editedAt: true,
+      summary: true,
+    },
+  });
+
+  const allSnapshots = snapshots.map((s) => ({
+    ...s,
+    travelDate: s.travelDate.toISOString(),
+    scrapedAt: s.scrapedAt.toISOString(),
+  }));
+
   return {
     query,
-    snapshots: snapshots.map((s) => ({
-      ...s,
-      travelDate: s.travelDate.toISOString(),
-      scrapedAt: s.scrapedAt.toISOString(),
+    snapshots: filterSnapshotsByTrackerFilters(allSnapshots, query),
+    allSnapshots,
+    editEvents: editEventsDesc.slice().reverse().map((event) => ({
+      id: event.id,
+      editedAt: event.editedAt.toISOString(),
+      summary: event.summary,
     })),
     lastRun,
     globalScrapeInterval: globalConfig?.scrapeInterval ?? 3,
@@ -445,6 +487,16 @@ export default async function ChartPage({ params }: Props) {
                 <ForceScrapeButton queryId={id} ariaLabel="Refresh prices now" />
               )}
               <ScrapeInterval queryId={id} currentInterval={primary.query.scrapeInterval} canEdit={canEdit} />
+              <TrackerFilters
+                queryId={id}
+                filters={{
+                  maxPrice: primary.query.maxPrice,
+                  maxStops: primary.query.maxStops,
+                  maxDurationHours: primary.query.maxDurationHours,
+                  preferredAirlines: primary.query.preferredAirlines,
+                }}
+                canEdit={canEdit}
+              />
               <AggregatorPicker
                 queryId={id}
                 currentAggregators={primary.query.preferredAggregators}

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -20,11 +20,10 @@ import { TrackerFilters } from '@/components/TrackerFilters';
 import { aggregateScrapeStatus } from '@/lib/scrape-status';
 import { canManageQueryWithoutToken } from '@/lib/query-auth';
 import { filterSnapshotsByTrackerFilters } from '@/lib/snapshot-filters';
+import { MAX_TRACKER_EDIT_EVENTS } from '@/lib/tracker-edit-events';
 import { groupDateRange } from './group-date-range';
 import { safeJsonLd } from './safe-json-ld';
 import styles from './page.module.css';
-
-const MAX_EDIT_EVENTS = 25;
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -265,7 +264,7 @@ async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | 
   const editEventsDesc = await prisma.queryEditEvent.findMany({
     where: { queryId: id },
     orderBy: { editedAt: 'desc' },
-    take: MAX_EDIT_EVENTS,
+    take: MAX_TRACKER_EDIT_EVENTS,
     select: {
       id: true,
       editedAt: true,

--- a/apps/web/src/components/PriceChart.module.css
+++ b/apps/web/src/components/PriceChart.module.css
@@ -7,13 +7,54 @@
   overflow: hidden;
 }
 
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+.historyFilter {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.historyOption {
+  padding: 0.35rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--muted);
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--border);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+
+.historyOption:last-child {
+  border-right: 0;
+}
+
+.historyOption:hover {
+  color: var(--text-primary);
+  background: var(--elevated);
+}
+
+.historyOptionActive {
+  color: var(--accent);
+  background: var(--elevated);
+}
+
 .viewFilter {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-bottom: 0.75rem;
-  padding-bottom: 0.75rem;
-  border-bottom: 1px solid var(--border);
 }
 
 .viewSelect {

--- a/apps/web/src/components/PriceChart.module.css
+++ b/apps/web/src/components/PriceChart.module.css
@@ -42,7 +42,7 @@
 }
 
 .historyOption:hover {
-  color: var(--text-primary);
+  color: var(--text);
   background: var(--elevated);
 }
 

--- a/apps/web/src/components/PriceChart.tsx
+++ b/apps/web/src/components/PriceChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { currencySymbol } from '@/lib/currency';
 import { safeHttpUrl } from '@/lib/safe-url';
@@ -28,6 +28,29 @@ interface Snapshot {
 }
 
 type ChartView = 'all' | 'local' | 'comparison' | string; // string = specific country code
+type HistoryMode = 'current' | 'all';
+
+interface PlotTheme {
+  axisText: string;
+  grid: string;
+  accent: string;
+  surface: string;
+  text: string;
+}
+
+interface EditEvent {
+  id: string;
+  editedAt: string;
+  summary: string;
+}
+
+const DEFAULT_PLOT_THEME: PlotTheme = {
+  axisText: '#8b9ec2',
+  grid: '#243049',
+  accent: '#80a8a5',
+  surface: '#0e3640',
+  text: '#ecdfc0',
+};
 
 const AIRLINE_COLORS: Record<string, string> = {
   Delta: '#e31837',
@@ -56,6 +79,50 @@ function getAirlineColor(airline: string, index: number): string {
   }
   const fallback = ['#80a8a5', '#c1272d', '#d4a574', '#8b5cf6', '#ec4899', '#14b8a6', '#3b82f6', '#f97316'];
   return fallback[index % fallback.length]!;
+}
+
+function readCssVariable(styles: CSSStyleDeclaration, name: string, fallback: string): string {
+  return styles.getPropertyValue(name).trim() || fallback;
+}
+
+function readPlotTheme(): PlotTheme {
+  if (typeof window === 'undefined') return DEFAULT_PLOT_THEME;
+  const styles = getComputedStyle(document.documentElement);
+  return {
+    axisText: readCssVariable(styles, '--muted', DEFAULT_PLOT_THEME.axisText),
+    grid: readCssVariable(styles, '--border', DEFAULT_PLOT_THEME.grid),
+    accent: readCssVariable(styles, '--accent', DEFAULT_PLOT_THEME.accent),
+    surface: readCssVariable(styles, '--elevated', DEFAULT_PLOT_THEME.surface),
+    text: readCssVariable(styles, '--text', DEFAULT_PLOT_THEME.text),
+  };
+}
+
+function usePlotTheme(): PlotTheme {
+  const [plotTheme, setPlotTheme] = useState(DEFAULT_PLOT_THEME);
+
+  useEffect(() => {
+    const updateTheme = () => setPlotTheme(readPlotTheme());
+    updateTheme();
+
+    const media = window.matchMedia?.('(prefers-color-scheme: light)');
+    media?.addEventListener('change', updateTheme);
+
+    let observer: MutationObserver | null = null;
+    if (typeof MutationObserver !== 'undefined') {
+      observer = new MutationObserver(updateTheme);
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['data-theme', 'data-theme-mode'],
+      });
+    }
+
+    return () => {
+      media?.removeEventListener('change', updateTheme);
+      observer?.disconnect();
+    };
+  }, []);
+
+  return plotTheme;
 }
 
 function buildDetailTraces(snapshots: Snapshot[], sym: string, hasVpnData: boolean) {
@@ -182,29 +249,41 @@ function buildComparisonTraces(snapshots: Snapshot[], sym: string) {
   });
 }
 
-export function PriceChart({ snapshots, currency = 'USD' }: { snapshots: Snapshot[]; currency?: string }) {
+interface Props {
+  snapshots: Snapshot[];
+  allSnapshots?: Snapshot[];
+  editEvents?: EditEvent[];
+  currency?: string;
+}
+
+export function PriceChart({ snapshots, allSnapshots, editEvents = [], currency = 'USD' }: Props) {
   const sym = currencySymbol(currency);
+  const plotTheme = usePlotTheme();
+  const fullHistory = allSnapshots ?? snapshots;
+  const hasFilteredHistory = fullHistory.length !== snapshots.length;
+  const [historyMode, setHistoryMode] = useState<HistoryMode>('current');
+  const historySnapshots = historyMode === 'all' ? fullHistory : snapshots;
 
   // Detect VPN data and available countries
   const vpnCountries = useMemo(() => {
     const countries = new Set<string>();
-    for (const s of snapshots) {
+    for (const s of historySnapshots) {
       if (s.vpnCountry) countries.add(s.vpnCountry);
     }
     return Array.from(countries).sort();
-  }, [snapshots]);
+  }, [historySnapshots]);
 
   const hasVpnData = vpnCountries.length > 0;
   const [view, setView] = useState<ChartView>('all');
 
   // Filter snapshots based on selected view
   const filteredSnapshots = useMemo(() => {
-    if (view === 'all') return snapshots;
-    if (view === 'local') return snapshots.filter((s) => !s.vpnCountry);
-    if (view === 'comparison') return snapshots; // comparison uses all data but builds different traces
+    if (view === 'all') return historySnapshots;
+    if (view === 'local') return historySnapshots.filter((s) => !s.vpnCountry);
+    if (view === 'comparison') return historySnapshots; // comparison uses all data but builds different traces
     // Specific country code
-    return snapshots.filter((s) => s.vpnCountry === view);
-  }, [snapshots, view]);
+    return historySnapshots.filter((s) => s.vpnCountry === view);
+  }, [historySnapshots, view]);
 
   const traces = useMemo(() => {
     if (view === 'comparison') {
@@ -213,19 +292,54 @@ export function PriceChart({ snapshots, currency = 'USD' }: { snapshots: Snapsho
     return buildDetailTraces(filteredSnapshots, sym, hasVpnData && view === 'all');
   }, [filteredSnapshots, sym, view, hasVpnData]);
 
-  if (snapshots.length === 0) {
-    return (
-      <div className={styles.empty}>
-        <p className={styles.emptyText}>No price data yet</p>
-        <p className={styles.emptyHint}>
-          Prices will appear after the first scrape runs. Check back soon.
-        </p>
-      </div>
-    );
-  }
+  const editShapes = useMemo(() => editEvents.map((event) => ({
+    type: 'line' as const,
+    xref: 'x' as const,
+    yref: 'paper' as const,
+    x0: event.editedAt,
+    x1: event.editedAt,
+    y0: 0,
+    y1: 1,
+    line: { color: plotTheme.accent, width: 1, dash: 'dot' as const },
+  })), [editEvents, plotTheme.accent]);
 
-  return (
-    <div className={styles.root}>
+  const editAnnotations = useMemo(() => editEvents.map((event, index) => ({
+    x: event.editedAt,
+    y: 1,
+    xref: 'x' as const,
+    yref: 'paper' as const,
+    text: index === editEvents.length - 1 ? event.summary : 'Edited',
+    showarrow: false,
+    xanchor: 'left' as const,
+    yanchor: 'bottom' as const,
+    yshift: 4,
+    font: { family: 'IBM Plex Mono, monospace', color: plotTheme.accent, size: 10 },
+    bgcolor: plotTheme.surface,
+    bordercolor: plotTheme.accent,
+    borderwidth: 1,
+    borderpad: 3,
+  })), [editEvents, plotTheme.accent, plotTheme.surface]);
+
+  const controls = (
+    <>
+      {hasFilteredHistory && (
+        <div className={styles.historyFilter}>
+          <button
+            className={`${styles.historyOption} ${historyMode === 'current' ? styles.historyOptionActive : ''}`}
+            onClick={() => setHistoryMode('current')}
+            type="button"
+          >
+            Current filters
+          </button>
+          <button
+            className={`${styles.historyOption} ${historyMode === 'all' ? styles.historyOptionActive : ''}`}
+            onClick={() => setHistoryMode('all')}
+            type="button"
+          >
+            All history
+          </button>
+        </div>
+      )}
       {hasVpnData && (
         <div className={styles.viewFilter}>
           <select
@@ -244,20 +358,52 @@ export function PriceChart({ snapshots, currency = 'USD' }: { snapshots: Snapsho
           </select>
         </div>
       )}
+    </>
+  );
+  const hasControls = hasFilteredHistory || hasVpnData;
+
+  if (fullHistory.length === 0) {
+    return (
+      <div className={styles.empty}>
+        <p className={styles.emptyText}>No price data yet</p>
+        <p className={styles.emptyHint}>
+          Prices will appear after the first scrape runs. Check back soon.
+        </p>
+      </div>
+    );
+  }
+
+  if (filteredSnapshots.length === 0) {
+    return (
+      <div className={styles.root}>
+        {hasControls && <div className={styles.controls}>{controls}</div>}
+        <div className={styles.empty}>
+          <p className={styles.emptyText}>No price data for this view</p>
+          <p className={styles.emptyHint}>
+            Switch views or wait for the next scrape to collect prices under the current filters.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.root}>
+      {hasControls && <div className={styles.controls}>{controls}</div>}
       <Plot
         data={traces}
         layout={{
           paper_bgcolor: 'transparent',
           plot_bgcolor: 'transparent',
-          font: { family: 'IBM Plex Mono, monospace', color: '#8b9ec2', size: 11 },
+          font: { family: 'IBM Plex Mono, monospace', color: plotTheme.axisText, size: 11 },
           margin: { t: 20, r: 20, b: 50, l: 60 },
           xaxis: {
-            gridcolor: '#243049',
+            gridcolor: plotTheme.grid,
             tickformat: '%b %d %H:%M',
             title: { text: '' },
           },
           yaxis: {
-            gridcolor: '#243049',
+            gridcolor: plotTheme.grid,
             tickprefix: sym,
             title: { text: '' },
           },
@@ -266,14 +412,16 @@ export function PriceChart({ snapshots, currency = 'USD' }: { snapshots: Snapsho
             y: -0.15,
             font: { size: 11 },
           },
+          shapes: editShapes,
+          annotations: editAnnotations,
           // Opaque hover box. The unified label otherwise inherits the
           // transparent paper_bgcolor, so the x axis date ticks bled through
           // it into unreadable text-on-text when hovering a low point (#97).
           // A solid surface cleanly occludes whatever sits behind the box.
           hoverlabel: {
-            bgcolor: '#0e3640',
-            bordercolor: '#80a8a5',
-            font: { family: 'IBM Plex Mono, monospace', color: '#ecdfc0', size: 11 },
+            bgcolor: plotTheme.surface,
+            bordercolor: plotTheme.accent,
+            font: { family: 'IBM Plex Mono, monospace', color: plotTheme.text, size: 11 },
             align: 'left',
           },
           hovermode: 'x unified',

--- a/apps/web/src/components/TrackerFilters.module.css
+++ b/apps/web/src/components/TrackerFilters.module.css
@@ -1,0 +1,158 @@
+.root {
+  position: relative;
+  display: inline-flex;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.trigger:hover,
+.triggerOpen {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--elevated);
+}
+
+.count {
+  min-width: 1rem;
+  height: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.25rem;
+  color: var(--bg);
+  background: var(--accent);
+  border-radius: var(--radius-sm);
+  font-size: 0.625rem;
+}
+
+.panel {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.5rem);
+  z-index: 20;
+  width: min(34rem, calc(100vw - 2rem));
+  padding: 0.875rem;
+  background: var(--elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.airlines {
+  grid-column: span 2;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--muted);
+}
+
+.input {
+  width: 100%;
+  min-height: 2rem;
+  padding: 0.35rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.input:focus {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.error {
+  margin-top: 0.625rem;
+  font-size: 0.75rem;
+  color: var(--price-up);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.875rem;
+}
+
+.clear {
+  margin-right: auto;
+}
+
+.primary,
+.secondary {
+  padding: 0.375rem 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.primary {
+  color: var(--bg);
+  background: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+.secondary {
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border);
+}
+
+.primary:disabled,
+.secondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .root {
+    position: static;
+  }
+
+  .panel {
+    position: fixed;
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    width: auto;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .airlines {
+    grid-column: auto;
+  }
+}

--- a/apps/web/src/components/TrackerFilters.tsx
+++ b/apps/web/src/components/TrackerFilters.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getDeleteToken } from '@/lib/tracker-storage';
+import styles from './TrackerFilters.module.css';
+
+interface TrackerFilterState {
+  maxPrice: number | null;
+  maxStops: number | null;
+  maxDurationHours: number | null;
+  preferredAirlines: string[];
+}
+
+interface Props {
+  queryId: string;
+  filters: TrackerFilterState;
+  canEdit?: boolean;
+}
+
+function countActiveFilters(filters: TrackerFilterState): number {
+  return [
+    filters.maxPrice !== null,
+    filters.maxStops !== null,
+    filters.maxDurationHours !== null,
+    filters.preferredAirlines.length > 0,
+  ].filter(Boolean).length;
+}
+
+function parseOptionalNumber(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : Number.NaN;
+}
+
+export function TrackerFilters({ queryId, filters, canEdit = false }: Props) {
+  const router = useRouter();
+  const token = typeof window !== 'undefined' ? getDeleteToken(queryId) : null;
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [maxPrice, setMaxPrice] = useState(filters.maxPrice?.toString() ?? '');
+  const [maxStops, setMaxStops] = useState(filters.maxStops?.toString() ?? '');
+  const [maxDurationHours, setMaxDurationHours] = useState(filters.maxDurationHours?.toString() ?? '');
+  const [preferredAirlines, setPreferredAirlines] = useState(filters.preferredAirlines.join(', '));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeCount = useMemo(() => countActiveFilters(filters), [filters]);
+
+  const syncDraftFromFilters = useCallback(() => {
+    setMaxPrice(filters.maxPrice?.toString() ?? '');
+    setMaxStops(filters.maxStops?.toString() ?? '');
+    setMaxDurationHours(filters.maxDurationHours?.toString() ?? '');
+    setPreferredAirlines(filters.preferredAirlines.join(', '));
+    setError(null);
+  }, [filters.maxDurationHours, filters.maxPrice, filters.maxStops, filters.preferredAirlines]);
+
+  const closePanel = useCallback(() => {
+    syncDraftFromFilters();
+    setOpen(false);
+  }, [syncDraftFromFilters]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closePanel();
+    };
+
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (target instanceof Node && rootRef.current?.contains(target)) return;
+      closePanel();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [closePanel, open]);
+
+  if (!token && !canEdit) return null;
+
+  const openPanel = () => {
+    syncDraftFromFilters();
+    setOpen(true);
+  };
+
+  const togglePanel = () => {
+    if (open) {
+      closePanel();
+      return;
+    }
+    openPanel();
+  };
+
+  const clearDraft = () => {
+    setMaxPrice('');
+    setMaxStops('');
+    setMaxDurationHours('');
+    setPreferredAirlines('');
+    setError(null);
+  };
+
+  const save = async () => {
+    setError(null);
+
+    const nextMaxPrice = parseOptionalNumber(maxPrice);
+    if (
+      nextMaxPrice !== null &&
+      (Number.isNaN(nextMaxPrice) || nextMaxPrice < 0 || nextMaxPrice > 1_000_000)
+    ) {
+      setError('Max price must be between 0 and 1,000,000.');
+      return;
+    }
+
+    const nextMaxStops = parseOptionalNumber(maxStops);
+    if (
+      nextMaxStops !== null &&
+      (Number.isNaN(nextMaxStops) || !Number.isInteger(nextMaxStops) || nextMaxStops < 0 || nextMaxStops > 10)
+    ) {
+      setError('Max stops must be a whole number from 0 to 10.');
+      return;
+    }
+
+    const nextMaxDurationHours = parseOptionalNumber(maxDurationHours);
+    if (
+      nextMaxDurationHours !== null &&
+      (
+        Number.isNaN(nextMaxDurationHours) ||
+        !Number.isInteger(nextMaxDurationHours) ||
+        nextMaxDurationHours < 1 ||
+        nextMaxDurationHours > 48
+      )
+    ) {
+      setError('Max duration must be a whole number from 1 to 48.');
+      return;
+    }
+
+    const airlines = preferredAirlines
+      .split(',')
+      .map((airline) => airline.trim())
+      .filter(Boolean);
+
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/queries/${queryId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deleteToken: token,
+          maxPrice: nextMaxPrice,
+          maxStops: nextMaxStops,
+          maxDurationHours: nextMaxDurationHours,
+          preferredAirlines: airlines,
+        }),
+      });
+      const data = await res.json();
+      if (!data.ok) {
+        setError(data.error || 'Could not update filters.');
+        return;
+      }
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setError('Network error. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={styles.root} ref={rootRef}>
+      <button
+        className={`${styles.trigger} ${open ? styles.triggerOpen : ''}`}
+        type="button"
+        onClick={togglePanel}
+        aria-expanded={open}
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+          <path d="M2 4h12M4 8h8M6 12h4" />
+        </svg>
+        Filters
+        {activeCount > 0 && <span className={styles.count}>{activeCount}</span>}
+      </button>
+
+      {open && (
+        <div className={styles.panel}>
+          <div className={styles.grid}>
+            <label className={styles.field}>
+              <span className={styles.label}>Max stops</span>
+              <input
+                className={styles.input}
+                type="number"
+                min={0}
+                max={10}
+                step={1}
+                placeholder="Any"
+                value={maxStops}
+                onChange={(event) => setMaxStops(event.target.value)}
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.label}>Max price</span>
+              <input
+                className={styles.input}
+                type="number"
+                min={0}
+                max={1_000_000}
+                step={1}
+                placeholder="Any"
+                value={maxPrice}
+                onChange={(event) => setMaxPrice(event.target.value)}
+              />
+            </label>
+
+            <label className={styles.field}>
+              <span className={styles.label}>Max duration</span>
+              <input
+                className={styles.input}
+                type="number"
+                min={1}
+                max={48}
+                step={1}
+                placeholder="Any"
+                value={maxDurationHours}
+                onChange={(event) => setMaxDurationHours(event.target.value)}
+              />
+            </label>
+
+            <label className={`${styles.field} ${styles.airlines}`}>
+              <span className={styles.label}>Airlines</span>
+              <input
+                className={styles.input}
+                type="text"
+                placeholder="Any airline"
+                value={preferredAirlines}
+                onChange={(event) => setPreferredAirlines(event.target.value)}
+              />
+            </label>
+          </div>
+
+          {error && <p className={styles.error}>{error}</p>}
+
+          <div className={styles.actions}>
+            <button className={`${styles.secondary} ${styles.clear}`} type="button" onClick={clearDraft} disabled={saving}>
+              Clear filters
+            </button>
+            <button className={styles.secondary} type="button" onClick={closePanel} disabled={saving}>
+              Cancel
+            </button>
+            <button className={styles.primary} type="button" onClick={save} disabled={saving}>
+              {saving ? 'Saving...' : 'Apply'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/snapshot-filters.test.ts
+++ b/apps/web/src/lib/snapshot-filters.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { filterSnapshotsByTrackerFilters } from './snapshot-filters';
+
+const baseSnapshot = {
+  price: 300,
+  stops: 0,
+  duration: '2h 30m',
+  airline: 'Delta Air Lines',
+};
+
+describe('filterSnapshotsByTrackerFilters', () => {
+  it('keeps snapshots at price and stop boundaries', () => {
+    const snapshots = [
+      { ...baseSnapshot, price: 500, stops: 1, airline: 'Delta' },
+      { ...baseSnapshot, price: 501, stops: 1, airline: 'Delta' },
+      { ...baseSnapshot, price: 500, stops: 2, airline: 'Delta' },
+    ];
+
+    const result = filterSnapshotsByTrackerFilters(snapshots, {
+      maxPrice: 500,
+      maxStops: 1,
+      maxDurationHours: null,
+      preferredAirlines: [],
+    });
+
+    expect(result).toEqual([snapshots[0]]);
+  });
+
+  it('filters parseable durations above the hour cap but keeps unknown durations', () => {
+    const snapshots = [
+      { ...baseSnapshot, duration: '3h 30m' },
+      { ...baseSnapshot, duration: '4h 01m' },
+      { ...baseSnapshot, duration: 'PT4H' },
+    ];
+
+    const result = filterSnapshotsByTrackerFilters(snapshots, {
+      maxPrice: null,
+      maxStops: null,
+      maxDurationHours: 4,
+      preferredAirlines: [],
+    });
+
+    expect(result).toEqual([snapshots[0], snapshots[2]]);
+  });
+
+  it('matches preferred airlines only against non-empty snapshot airline names', () => {
+    const snapshots = [
+      { ...baseSnapshot, airline: 'Delta Connection' },
+      { ...baseSnapshot, airline: 'WestJet' },
+      { ...baseSnapshot, airline: 'KLM Royal Dutch' },
+      { ...baseSnapshot, airline: '' },
+    ];
+
+    const result = filterSnapshotsByTrackerFilters(snapshots, {
+      maxPrice: null,
+      maxStops: null,
+      maxDurationHours: null,
+      preferredAirlines: ['Delta', 'Jet', 'KLM'],
+    });
+
+    expect(result).toEqual([snapshots[0], snapshots[2]]);
+  });
+
+  it('does not reverse-match broad airline fragments', () => {
+    const snapshots = [
+      { ...baseSnapshot, airline: 'American' },
+      { ...baseSnapshot, airline: 'American Airlines' },
+    ];
+
+    const result = filterSnapshotsByTrackerFilters(snapshots, {
+      maxPrice: null,
+      maxStops: null,
+      maxDurationHours: null,
+      preferredAirlines: ['American Airlines'],
+    });
+
+    expect(result).toEqual([snapshots[1]]);
+  });
+});

--- a/apps/web/src/lib/snapshot-filters.ts
+++ b/apps/web/src/lib/snapshot-filters.ts
@@ -18,6 +18,8 @@ function airlineMatches(snapshotAirline: string, preferredAirline: string): bool
   const snapshot = snapshotAirline.trim().toLowerCase();
   const preferred = preferredAirline.trim().toLowerCase();
   if (!snapshot || !preferred) return false;
+  // Snapshot airlines are provider display names, not normalized airline IDs,
+  // so retroactive airline filtering is necessarily name-based.
   if (preferred.length < 4) {
     return (
       snapshot === preferred ||
@@ -46,6 +48,8 @@ export function filterSnapshotsByTrackerFilters<T extends FilterableSnapshot>(
 
     if (filters.maxDurationHours !== null && filters.maxDurationHours !== undefined) {
       const minutes = parseDurationToMinutes(snapshot.duration);
+      // Keep unknown durations: older/provider snapshots can lack a parseable
+      // duration, and hiding them would drop otherwise valid historical fares.
       if (minutes !== null && minutes > filters.maxDurationHours * 60) return false;
     }
 

--- a/apps/web/src/lib/snapshot-filters.ts
+++ b/apps/web/src/lib/snapshot-filters.ts
@@ -1,0 +1,58 @@
+import { parseDurationToMinutes } from '@/lib/scraper/duration';
+
+export interface TrackerSnapshotFilters {
+  maxPrice: number | null | undefined;
+  maxStops: number | null | undefined;
+  maxDurationHours: number | null | undefined;
+  preferredAirlines: readonly string[] | null | undefined;
+}
+
+interface FilterableSnapshot {
+  price: number;
+  stops: number;
+  duration: string | null;
+  airline: string;
+}
+
+function airlineMatches(snapshotAirline: string, preferredAirline: string): boolean {
+  const snapshot = snapshotAirline.trim().toLowerCase();
+  const preferred = preferredAirline.trim().toLowerCase();
+  if (!snapshot || !preferred) return false;
+  if (preferred.length < 4) {
+    return (
+      snapshot === preferred ||
+      snapshot.startsWith(`${preferred} `) ||
+      snapshot.endsWith(` ${preferred}`) ||
+      snapshot.includes(` ${preferred} `)
+    );
+  }
+  return snapshot.includes(preferred);
+}
+
+export function filterSnapshotsByTrackerFilters<T extends FilterableSnapshot>(
+  snapshots: T[],
+  filters: TrackerSnapshotFilters,
+): T[] {
+  const preferredAirlines = filters.preferredAirlines?.filter((airline) => airline.trim()) ?? [];
+
+  return snapshots.filter((snapshot) => {
+    if (filters.maxPrice !== null && filters.maxPrice !== undefined && snapshot.price > filters.maxPrice) {
+      return false;
+    }
+
+    if (filters.maxStops !== null && filters.maxStops !== undefined && snapshot.stops > filters.maxStops) {
+      return false;
+    }
+
+    if (filters.maxDurationHours !== null && filters.maxDurationHours !== undefined) {
+      const minutes = parseDurationToMinutes(snapshot.duration);
+      if (minutes !== null && minutes > filters.maxDurationHours * 60) return false;
+    }
+
+    if (preferredAirlines.length > 0 && !preferredAirlines.some((airline) => airlineMatches(snapshot.airline, airline))) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/apps/web/src/lib/tracker-edit-events.ts
+++ b/apps/web/src/lib/tracker-edit-events.ts
@@ -1,0 +1,1 @@
+export const MAX_TRACKER_EDIT_EVENTS = 25;


### PR DESCRIPTION
## Summary
- Adds editable tracker filters for active trackers so users can remove non-direct and otherwise unwanted results without recreating the tracker.
- Re-filters historical chart data through the current tracker filters while preserving an "All history" chart view.
- Records bounded tracker edit events and shows edit markers on the price chart.

## Changes
- Adds `QueryEditEvent` for tracker edit history.
- Allows PATCH updates for snapshot-enforceable tracker filters: max price, max stops, max duration, and preferred airlines.
- Keeps time preference and cabin class out of this edit surface because existing snapshots do not carry those abstract preferences.
- Applies grouped filter updates transactionally with their edit-history rows.
- Adds `TrackerFilters` UI with Apply, Cancel, Clear filters, Escape dismiss, and outside-click dismiss behavior.
- Adds snapshot filtering tests and API regression coverage for edit events and non-editable time/cabin fields.

## Testing
- [x] `npm run ci`

## Related
Refs #162
