### PR TITLE
fix: allow flight prices in high-denomination currencies (COP, JPY, VND…)

### DIFF
--- a/apps/web/src/app/api/community/ingest/route.test.ts
+++ b/apps/web/src/app/api/community/ingest/route.test.ts
@@ -143,8 +143,16 @@ describe('POST /api/community/ingest', () => {
     expect(body.data.rejected).toBe(1);
   });
 
-  it('rejects a price outside the sane positive range', async () => {
-    const res = await POST(makeRequest({ snapshots: [validSnapshot({ price: 999999 })] }));
+  it('accepts a high denomination currency price above the old 50k cap', async () => {
+    const res = await POST(makeRequest({ snapshots: [validSnapshot({ price: 2_550_760, currency: 'COP' })] }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.accepted).toBe(1);
+    expect(body.data.rejected).toBe(0);
+  });
+
+  it('rejects a price beyond the safe integer ceiling', async () => {
+    const res = await POST(makeRequest({ snapshots: [validSnapshot({ price: Number.MAX_SAFE_INTEGER + 2 })] }));
     const body = await res.json();
     expect(body.data.accepted).toBe(0);
     expect(body.data.rejected).toBe(1);

--- a/apps/web/src/app/api/community/ingest/route.ts
+++ b/apps/web/src/app/api/community/ingest/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { apiSuccess, apiError } from '@/lib/api-response';
 import { isValidIATA } from '@/lib/iata-codes';
+import { isValidPriceAmount } from '@/lib/limits';
 import { redis } from '@/lib/redis';
 import { timingSafeEqual } from 'crypto';
 
@@ -8,8 +9,10 @@ const MAX_BATCH_SIZE = 1000;
 const RATE_LIMIT_WINDOW = 3600; // 1 hour per API key
 
 // Snapshot field bounds. Values outside these ranges are almost certainly
-// malformed or hostile, so the whole batch is rejected.
-const MAX_PRICE = 50000;
+// malformed or hostile, so the whole batch is rejected. Prices carry an
+// arbitrary currency, and high denomination currencies (COP, JPY, VND) put
+// ordinary fares in the millions, so the only price bounds are positive and
+// within the shared safe integer ceiling.
 const MAX_STOPS = 5;
 const MAX_AIRLINE_LEN = 100;
 const MAX_CABIN_LEN = 20;
@@ -127,7 +130,7 @@ export async function POST(request: Request) {
     // permissive client cannot smuggle in unnormalized routes).
     if (typeof s.origin !== 'string' || !isValidIATA(s.origin)) { errors.push(`[${i}] invalid origin: ${s.origin}`); continue; }
     if (typeof s.destination !== 'string' || !isValidIATA(s.destination)) { errors.push(`[${i}] invalid destination: ${s.destination}`); continue; }
-    if (typeof s.price !== 'number' || !Number.isFinite(s.price) || s.price <= 0 || s.price > MAX_PRICE) { errors.push(`[${i}] invalid price: ${s.price}`); continue; }
+    if (typeof s.price !== 'number' || s.price <= 0 || !isValidPriceAmount(s.price)) { errors.push(`[${i}] invalid price: ${s.price}`); continue; }
     if (typeof s.stops !== 'number' || !Number.isInteger(s.stops) || s.stops < 0 || s.stops > MAX_STOPS) { errors.push(`[${i}] invalid stops: ${s.stops}`); continue; }
 
     const scrapedAt = new Date(s.scrapedAt);

--- a/apps/web/src/app/api/queries/[id]/route.test.ts
+++ b/apps/web/src/app/api/queries/[id]/route.test.ts
@@ -499,6 +499,19 @@ describe('PATCH /api/queries/[id]', () => {
       expect(mockQueryEditEventCreateMany).not.toHaveBeenCalled();
     });
 
+    it('accepts a high denomination maxPrice above the old 1M cap', async () => {
+      process.env.SELF_HOSTED = 'true';
+      mockGetCurrentUser.mockResolvedValue({ id: 'user_1', isAdmin: false });
+      mockQueryFindUnique.mockResolvedValue(editableQuery);
+      mockQueryFindMany.mockResolvedValue([]);
+
+      const res = await PATCH(...makePatchRequest('q1', { maxPrice: 2_550_760 }));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.data).toMatchObject({ maxPrice: 2_550_760 });
+    });
+
     it('rejects time and cabin edits because snapshots cannot enforce them', async () => {
       process.env.SELF_HOSTED = 'true';
       mockQueryFindUnique.mockResolvedValue(editableQuery);

--- a/apps/web/src/app/api/queries/[id]/route.ts
+++ b/apps/web/src/app/api/queries/[id]/route.ts
@@ -5,9 +5,9 @@ import { prisma } from '@/lib/prisma';
 import { authorizeMutation } from '@/lib/query-auth';
 import { getCurrentUser } from '@/lib/user-auth';
 import { isAggregatorSource } from '@/lib/scraper/navigate';
+import { isValidPriceAmount } from '@/lib/limits';
 
 const ALLOWED_INTERVALS = [1, 3, 6, 12, 24];
-const MAX_PRICE_VALUE = 1_000_000;
 const MAX_STOPS_VALUE = 10;
 const MAX_AIRLINE_LENGTH = 100;
 
@@ -56,10 +56,6 @@ const EDIT_FIELD_LABELS: Record<TrackerEditField, string> = {
 
 function hasOwn(body: object, field: string): boolean {
   return Object.prototype.hasOwnProperty.call(body, field);
-}
-
-function isFiniteNonNegative(n: number): boolean {
-  return Number.isFinite(n) && n >= 0;
 }
 
 function stringArraysEqual(a: readonly string[], b: readonly string[]): boolean {
@@ -211,8 +207,8 @@ export async function PATCH(
       cascadeData.maxPrice = null;
     } else {
       const maxPrice = Number(body.maxPrice);
-      if (!isFiniteNonNegative(maxPrice) || maxPrice > MAX_PRICE_VALUE) {
-        return apiError(`maxPrice must be null or a finite number between 0 and ${MAX_PRICE_VALUE}`, 400);
+      if (!isValidPriceAmount(maxPrice)) {
+        return apiError('maxPrice must be null or a finite non-negative number', 400);
       }
       cascadeData.maxPrice = maxPrice;
     }

--- a/apps/web/src/app/api/queries/route.test.ts
+++ b/apps/web/src/app/api/queries/route.test.ts
@@ -414,8 +414,8 @@ describe('POST /api/queries', () => {
     expect(mockQueryCreate).not.toHaveBeenCalled();
   });
 
-  it('rejects maxPrice that exceeds the ceiling with 400', async () => {
-    const res = await POST(makeRequest({ ...validBody, maxPrice: 1_000_001 }));
+  it('rejects maxPrice above the safe-integer ceiling with 400', async () => {
+    const res = await POST(makeRequest({ ...validBody, maxPrice: Number.MAX_SAFE_INTEGER + 1 }));
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toContain('maxPrice');

--- a/apps/web/src/app/api/queries/route.test.ts
+++ b/apps/web/src/app/api/queries/route.test.ts
@@ -422,6 +422,26 @@ describe('POST /api/queries', () => {
     expect(mockQueryCreate).not.toHaveBeenCalled();
   });
 
+  // A COP fare of ~USD 600 is 2,550,760 pesos; the old 1M cap rejected it at
+  // the route level, so guard acceptance here and not only in the helper test.
+  it('accepts a high denomination maxPrice and selected flight price above the old 1M cap', async () => {
+    const res = await POST(makeRequest({
+      ...validBody,
+      maxPrice: 3_000_000,
+      currency: 'COP',
+      routes: [{
+        ...validBody.routes[0],
+        selectedFlights: [
+          { travelDate: '2026-06-15', price: 2_550_760, airline: 'Avianca', bookingUrl: 'https://avianca.com' },
+        ],
+      }],
+    }));
+    expect(res.status).toBe(201);
+    const createArg = mockQueryCreate.mock.calls[0]![0] as { data: { maxPrice: number } };
+    expect(createArg.data.maxPrice).toBe(3_000_000);
+    expect(mockSnapshotCreateMany).toHaveBeenCalled();
+  });
+
   it('rejects maxStops outside 0-10 range with 400', async () => {
     const res = await POST(makeRequest({ ...validBody, maxStops: 11 }));
     expect(res.status).toBe(400);

--- a/apps/web/src/app/api/queries/route.ts
+++ b/apps/web/src/app/api/queries/route.ts
@@ -8,6 +8,7 @@ import { isAggregatorSource } from '@/lib/scraper/navigate';
 import { getClientIp } from '@/lib/trusted-ip';
 import { redis } from '@/lib/redis';
 import { safeHttpUrl } from '@/lib/safe-url';
+import { isValidPriceAmount } from '@/lib/limits';
 
 const MAX_ROUTES = 20;
 const MAX_FLIGHTS_PER_ROUTE = 50;
@@ -29,7 +30,6 @@ const MAX_DURATION_LENGTH = 20;
 const MAX_CURRENCY_LENGTH = 3;
 
 // Numeric field bounds
-const MAX_PRICE_VALUE = 1_000_000;
 const MAX_STOPS_VALUE = 10;
 
 interface RouteInput {
@@ -49,10 +49,6 @@ interface RouteInput {
     duration?: string | null;
     flightNumber?: string | null;
   }>;
-}
-
-function isFinitePositive(n: number): boolean {
-  return Number.isFinite(n) && n >= 0;
 }
 
 /**
@@ -148,8 +144,8 @@ export async function POST(request: NextRequest) {
   let maxPriceValidated: number | null = null;
   if (maxPrice !== undefined && maxPrice !== null) {
     const n = Number(maxPrice);
-    if (!isFinitePositive(n) || n > MAX_PRICE_VALUE) {
-      return apiError(`maxPrice must be a finite number between 0 and ${MAX_PRICE_VALUE}`, 400);
+    if (!isValidPriceAmount(n)) {
+      return apiError('maxPrice must be a finite non-negative number', 400);
     }
     maxPriceValidated = n;
   }
@@ -228,8 +224,8 @@ export async function POST(request: NextRequest) {
       }
 
       const price = Number(f.price);
-      if (!isFinitePositive(price) || price > MAX_PRICE_VALUE) {
-        return apiError(`Selected flight price must be a finite number between 0 and ${MAX_PRICE_VALUE}`, 400);
+      if (!isValidPriceAmount(price)) {
+        return apiError('Selected flight price must be a finite non-negative number', 400);
       }
 
       if (typeof f.airline === 'string' && f.airline.length > MAX_AIRLINE_LENGTH) {

--- a/apps/web/src/components/TrackerFilters.tsx
+++ b/apps/web/src/components/TrackerFilters.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { getDeleteToken } from '@/lib/tracker-storage';
+import { MAX_PRICE_VALUE } from '@/lib/limits';
 import styles from './TrackerFilters.module.css';
 
 interface TrackerFilterState {
@@ -111,9 +112,9 @@ export function TrackerFilters({ queryId, filters, canEdit = false }: Props) {
     const nextMaxPrice = parseOptionalNumber(maxPrice);
     if (
       nextMaxPrice !== null &&
-      (Number.isNaN(nextMaxPrice) || nextMaxPrice < 0 || nextMaxPrice > 1_000_000)
+      (Number.isNaN(nextMaxPrice) || nextMaxPrice < 0 || nextMaxPrice > MAX_PRICE_VALUE)
     ) {
-      setError('Max price must be between 0 and 1,000,000.');
+      setError('Max price must be a positive number.');
       return;
     }
 
@@ -210,7 +211,7 @@ export function TrackerFilters({ queryId, filters, canEdit = false }: Props) {
                 className={styles.input}
                 type="number"
                 min={0}
-                max={1_000_000}
+                max={MAX_PRICE_VALUE}
                 step={1}
                 placeholder="Any"
                 value={maxPrice}

--- a/apps/web/src/components/TrackerFilters.tsx
+++ b/apps/web/src/components/TrackerFilters.tsx
@@ -114,7 +114,7 @@ export function TrackerFilters({ queryId, filters, canEdit = false }: Props) {
       nextMaxPrice !== null &&
       (Number.isNaN(nextMaxPrice) || nextMaxPrice < 0 || nextMaxPrice > MAX_PRICE_VALUE)
     ) {
-      setError('Max price must be a positive number.');
+      setError('Max price cannot be negative.');
       return;
     }
 
@@ -211,7 +211,6 @@ export function TrackerFilters({ queryId, filters, canEdit = false }: Props) {
                 className={styles.input}
                 type="number"
                 min={0}
-                max={MAX_PRICE_VALUE}
                 step={1}
                 placeholder="Any"
                 value={maxPrice}

--- a/apps/web/src/lib/limits.test.ts
+++ b/apps/web/src/lib/limits.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { MAX_PRICE_VALUE, isValidPriceAmount } from './limits';
+
+describe('isValidPriceAmount', () => {
+  it('accepts high-denomination currency prices that exceeded the old 1M cap', () => {
+    expect(isValidPriceAmount(2_550_760)).toBe(true);
+    expect(isValidPriceAmount(50_000_000)).toBe(true);
+    expect(isValidPriceAmount(1_000_000)).toBe(true);
+  });
+
+  it('accepts ordinary small prices and zero', () => {
+    expect(isValidPriceAmount(0)).toBe(true);
+    expect(isValidPriceAmount(450)).toBe(true);
+  });
+
+  it('rejects negatives, NaN and non-finite values', () => {
+    expect(isValidPriceAmount(-1)).toBe(false);
+    expect(isValidPriceAmount(NaN)).toBe(false);
+    expect(isValidPriceAmount(Infinity)).toBe(false);
+    expect(isValidPriceAmount(-Infinity)).toBe(false);
+  });
+
+  it('rejects values beyond the safe-integer ceiling', () => {
+    expect(isValidPriceAmount(Number.MAX_SAFE_INTEGER)).toBe(true);
+    expect(isValidPriceAmount(Number.MAX_SAFE_INTEGER + 1)).toBe(false);
+  });
+
+  it('uses the JS safe-integer ceiling, not an arbitrary business number', () => {
+    expect(MAX_PRICE_VALUE).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});

--- a/apps/web/src/lib/limits.ts
+++ b/apps/web/src/lib/limits.ts
@@ -1,0 +1,5 @@
+export const MAX_PRICE_VALUE = Number.MAX_SAFE_INTEGER;
+
+export function isValidPriceAmount(value: number): boolean {
+  return Number.isFinite(value) && value >= 0 && value <= MAX_PRICE_VALUE;
+}

--- a/apps/web/src/lib/preview-runner.test.ts
+++ b/apps/web/src/lib/preview-runner.test.ts
@@ -428,6 +428,19 @@ describe('validatePreviewPayload combo cap (issue #89, configurable)', () => {
   });
 });
 
+describe('validatePreviewPayload maxPrice', () => {
+  it('rejects NaN, negative, and non-finite maxPrice', () => {
+    for (const bad of [NaN, -1, Infinity, Number.MAX_SAFE_INTEGER + 2]) {
+      expect(() => validatePreviewPayload(makePayload({ maxPrice: bad }))).toThrow(/maxPrice/);
+    }
+  });
+
+  it('accepts null and high denomination currency values', () => {
+    expect(() => validatePreviewPayload(makePayload({ maxPrice: null }))).not.toThrow();
+    expect(() => validatePreviewPayload(makePayload({ maxPrice: 2_550_760 }))).not.toThrow();
+  });
+});
+
 describe('preview admission gate (audit M5 TOCTOU, finding F)', () => {
   /**
    * Backs the gate with a per-key integer counter that mirrors how the atomic

--- a/apps/web/src/lib/preview-runner.ts
+++ b/apps/web/src/lib/preview-runner.ts
@@ -15,6 +15,7 @@ import {
   type PreviewResultPayload,
   type RouteResultPayload,
 } from '@/lib/preview-run';
+import { isValidPriceAmount } from '@/lib/limits';
 import { getModelCosts, resolveApiKey } from '@/lib/scraper/ai-registry';
 import { isKnownAirline } from '@/lib/scraper/airline-urls';
 import { extractPrices, type ExtractionFailureReason, type PriceData } from '@/lib/scraper/extract-prices';
@@ -259,6 +260,12 @@ export function validatePreviewPayload(
   const isOneWay = tripType === 'one_way';
   if (!isOneWay && from >= to) {
     throw new Error('dateFrom must be before dateTo');
+  }
+
+  // Number(body.maxPrice) in the route can produce NaN or garbage; stop it
+  // here so it never reaches the DB or the extraction prompt.
+  if (payload.maxPrice !== null && !isValidPriceAmount(payload.maxPrice)) {
+    throw new Error('maxPrice must be a finite non-negative number');
   }
 
   const combos = origins.length * destinations.length;

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -491,6 +491,12 @@ describe('coercePrice (issue #139 — string/symbol/grouped prices)', () => {
     expect(coercePrice(NaN)).toBe(0);
     expect(coercePrice(Infinity)).toBe(0);
   });
+  it('accepts high denomination fares but drops absurd finite values beyond the safe integer ceiling', () => {
+    expect(coercePrice(2_550_760)).toBe(2_550_760);
+    expect(coercePrice('COL$2,550,760')).toBe(2_550_760);
+    expect(coercePrice(1e300)).toBe(0);
+    expect(coercePrice('9007199254740993')).toBe(0);
+  });
   it('strips a currency symbol', () => {
     expect(coercePrice('$189')).toBe(189);
     expect(coercePrice('£1234')).toBe(1234);

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -1,4 +1,5 @@
 import { EXTRACTION_PROVIDERS, CLI_PROVIDERS, LOCAL_PROVIDERS, resolveApiKey, type ExtractionUsage } from './ai-registry';
+import { MAX_PRICE_VALUE } from '@/lib/limits';
 import { prisma } from '@/lib/prisma';
 import { parseDurationToMinutes } from './duration';
 import type { NavigationSource } from './navigate';
@@ -248,7 +249,7 @@ export function extractJsonArray(
  * on every search. Issue #139.
  */
 export function coercePrice(value: unknown): number {
-  if (typeof value === 'number') return Number.isFinite(value) && value > 0 ? value : 0;
+  if (typeof value === 'number') return Number.isFinite(value) && value > 0 && value <= MAX_PRICE_VALUE ? value : 0;
   if (typeof value !== 'string') return 0;
   let s = value.replace(/[^0-9.,]/g, '');
   if (!s) return 0;
@@ -271,7 +272,7 @@ export function coercePrice(value: unknown): number {
     if (dotCount > 1 || s.length - lastDot - 1 === 3) s = s.replace(/\./g, '');
   }
   const n = parseFloat(s);
-  return Number.isFinite(n) && n > 0 ? n : 0;
+  return Number.isFinite(n) && n > 0 && n <= MAX_PRICE_VALUE ? n : 0;
 }
 
 /** Coerce `stops` into a non-negative integer. Accepts numbers, "1 stop",

--- a/packages/cli/src/lib/limits.ts
+++ b/packages/cli/src/lib/limits.ts
@@ -1,0 +1,7 @@
+// CLI shim for `@/lib/limits`. The shared scraper (apps/web's
+// extract-prices.ts) imports `@/lib/limits` to bound coerced prices. Under
+// the CLI's tsconfig (`@/*` -> ./src/*) that bare import would not resolve,
+// so re-export the real implementation here. tsup's `@` -> apps/web/src
+// alias inlines the same module at build time, and the dev loader resolves
+// this relative path to it. Same shim role as ./prisma.ts and ./redis.ts.
+export { MAX_PRICE_VALUE, isValidPriceAmount } from '../../../../apps/web/src/lib/limits.js';


### PR DESCRIPTION
## Summary
The price validation rejected legitimate flight prices in high-denomination
currencies. This raises the cap to the datatype's real bound and consolidates
the duplicated checks.

## The bug
`MAX_PRICE_VALUE = 1_000_000` capped **both** the scraped flight price and the
user's `maxPrice` filter. In currencies like **COP, JPY, VND, KRW, IDR**, a single
flight routinely costs millions, so tracking failed with:
> Selected flight price must be a finite number between 0 and 1000000

A domestic COPA fare of **COL$2,550,760** (~USD 600) is rejected today.

## Why raising the cap is safe
The upper cap was cosmetic, not a security boundary:
- `price` / `maxPrice` are `Float` in Prisma — no integer-overflow risk.
- They're only compared numerically (not buffer lengths / indices / allocations).
- The real guard — rejecting non-finite, NaN and negative values — stays.

## The fix
- New `lib/limits.ts` with `isValidPriceAmount()` and
  `MAX_PRICE_VALUE = Number.MAX_SAFE_INTEGER` (the datatype's real bound, not an
  arbitrary business number).
- Consolidates the duplicated `isFinitePositive` / `isFiniteNonNegative` checks
  from both query routes into that one helper.
- `TrackerFilters` input uses the shared constant.

## Test plan
- New `lib/limits.test.ts` (accepts COP/VND-scale fares; rejects negatives, NaN,
  Infinity and values beyond MAX_SAFE_INTEGER).
- Updated the route test that asserted the old 1M ceiling.
- `lint`, `typecheck` (web + cli) and the full `test` suite (1307 passing) green.