### PR TITLE
fix: format prices per-currency with Intl instead of a manual symbol table

### DIFF
--- a/apps/web/src/app/explore/[route]/page.tsx
+++ b/apps/web/src/app/explore/[route]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { prisma } from '@/lib/prisma';
+import { formatCurrency } from '@/lib/currency';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { Footer } from '@/components/Footer';
 import shell from '../page.module.css';
@@ -54,6 +55,11 @@ export default async function ExploreRoutePage({ params }: Props) {
   const airlines = Array.from(new Set(snapshots.map((s) => s.airline))).sort();
   const cabins = Array.from(new Set(snapshots.map((s) => s.cabinClass))).sort();
   const currencies = Array.from(new Set(snapshots.map((s) => s.currency))).sort();
+  // Mixed-currency aggregates cannot carry one code; the data window line
+  // below already discloses the mix, so fall back to a bare number there.
+  const statCurrency = currencies.length === 1 ? currencies[0] : null;
+  const stat = (v: number) =>
+    statCurrency ? formatCurrency(v, statCurrency) : v.toLocaleString('en-US');
   const recent = snapshots.slice(0, 25);
 
   // snapshots.length > 0 was guarded above with notFound(), so these are defined.
@@ -83,15 +89,15 @@ export default async function ExploreRoutePage({ params }: Props) {
       <div className={styles.statsGrid}>
         <div className={styles.stat}>
           <span className={styles.statLabel}>cheapest</span>
-          <span className={styles.statValue}>${min}</span>
+          <span className={styles.statValue}>{stat(min)}</span>
         </div>
         <div className={styles.stat}>
           <span className={styles.statLabel}>average</span>
-          <span className={styles.statValue}>${avg}</span>
+          <span className={styles.statValue}>{stat(avg)}</span>
         </div>
         <div className={styles.stat}>
           <span className={styles.statLabel}>highest</span>
-          <span className={styles.statValue}>${max}</span>
+          <span className={styles.statValue}>{stat(max)}</span>
         </div>
         <div className={styles.stat}>
           <span className={styles.statLabel}>data points</span>
@@ -144,7 +150,7 @@ export default async function ExploreRoutePage({ params }: Props) {
                   <td>{s.airline}</td>
                   <td>{s.stops === 0 ? 'nonstop' : String(s.stops)}</td>
                   <td>{s.cabinClass}</td>
-                  <td className={styles.priceCol}>${Math.round(s.price)}</td>
+                  <td className={styles.priceCol}>{formatCurrency(s.price, s.currency)}</td>
                 </tr>
               ))}
             </tbody>

--- a/apps/web/src/app/explore/page.tsx
+++ b/apps/web/src/app/explore/page.tsx
@@ -2,6 +2,7 @@ export const dynamic = 'force-dynamic';
 
 import Link from 'next/link';
 import { prisma } from '@/lib/prisma';
+import { formatCurrency } from '@/lib/currency';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { Footer } from '@/components/Footer';
 import styles from './page.module.css';
@@ -10,37 +11,55 @@ interface RouteData {
   origin: string;
   destination: string;
   count: number;
+  currency: string;
   avgPrice: number;
   minPrice: number;
   airlines: string[];
 }
 
 async function getRoutes(): Promise<RouteData[]> {
+  // Group by currency too: min/avg across mixed currencies is meaningless.
+  // A route's displayed prices come from its dominant currency's snapshots.
   const raw = await prisma.communitySnapshot.groupBy({
-    by: ['origin', 'destination'],
+    by: ['origin', 'destination', 'currency'],
     _count: { id: true },
     _avg: { price: true },
     _min: { price: true },
-    orderBy: { _count: { id: 'desc' } },
-    take: 100,
   });
+
+  const byRoute = new Map<string, { count: number; best: (typeof raw)[number] }>();
+  for (const g of raw) {
+    const key = `${g.origin}-${g.destination}`;
+    const entry = byRoute.get(key);
+    if (!entry) {
+      byRoute.set(key, { count: g._count.id, best: g });
+    } else {
+      entry.count += g._count.id;
+      if (g._count.id > entry.best._count.id) entry.best = g;
+    }
+  }
+
+  const top = Array.from(byRoute.values())
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 100);
 
   const routes: RouteData[] = [];
 
-  for (const r of raw) {
+  for (const { count, best } of top) {
     const airlines = await prisma.communitySnapshot.findMany({
-      where: { origin: r.origin, destination: r.destination },
+      where: { origin: best.origin, destination: best.destination },
       select: { airline: true },
       distinct: ['airline'],
       take: 10,
     });
 
     routes.push({
-      origin: r.origin,
-      destination: r.destination,
-      count: r._count.id,
-      avgPrice: Math.round(r._avg.price ?? 0),
-      minPrice: Math.round(r._min.price ?? 0),
+      origin: best.origin,
+      destination: best.destination,
+      count,
+      currency: best.currency,
+      avgPrice: Math.round(best._avg.price ?? 0),
+      minPrice: Math.round(best._min.price ?? 0),
       airlines: airlines.map((a: { airline: string }) => a.airline),
     });
   }
@@ -104,11 +123,11 @@ export default async function ExplorePage() {
               <div className={styles.cardPrices}>
                 <div className={styles.cardPrice}>
                   <span className={styles.cardPriceLabel}>from</span>
-                  <span className={styles.cardPriceValue}>${route.minPrice}</span>
+                  <span className={styles.cardPriceValue}>{formatCurrency(route.minPrice, route.currency)}</span>
                 </div>
                 <div className={styles.cardPrice}>
                   <span className={styles.cardPriceLabel}>avg</span>
-                  <span className={styles.cardPriceValue}>${route.avgPrice}</span>
+                  <span className={styles.cardPriceValue}>{formatCurrency(route.avgPrice, route.currency)}</span>
                 </div>
               </div>
               <div className={styles.cardMeta}>

--- a/apps/web/src/components/BestPrice.tsx
+++ b/apps/web/src/components/BestPrice.tsx
@@ -1,4 +1,4 @@
-import { currencySymbol } from '@/lib/currency';
+import { formatCurrency } from '@/lib/currency';
 import { safeHttpUrl } from '@/lib/safe-url';
 import styles from './BestPrice.module.css';
 
@@ -33,7 +33,7 @@ export function BestPrice({ snapshots }: { snapshots: Snapshot[] }) {
       </div>
       <div className={styles.content}>
         <span className={styles.price}>
-          {currencySymbol(best.currency)}{best.price.toLocaleString('en-US', { minimumFractionDigits: 0 })}
+          {formatCurrency(best.price, best.currency)}
         </span>
         <div className={styles.details}>
           <span className={styles.airline}>{best.airline}</span>

--- a/apps/web/src/components/ConfirmationCard.tsx
+++ b/apps/web/src/components/ConfirmationCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import type { Airport } from '@/lib/scraper/parse-query';
-import { currencySymbol } from '@/lib/currency';
+import { formatCurrency } from '@/lib/currency';
 import styles from './ConfirmationCard.module.css';
 
 export interface ParsedQuery {
@@ -214,7 +214,7 @@ export function ConfirmationCard({
       {hasFilters(parsed) && (
         <div className={styles.filters}>
           {parsed.maxPrice && (
-            <span className={styles.tag}>Under {currencySymbol(parsed.currency ?? 'USD')}{parsed.maxPrice}</span>
+            <span className={styles.tag}>Under {formatCurrency(parsed.maxPrice, parsed.currency ?? 'USD')}</span>
           )}
           {parsed.maxStops !== null && (
             <span className={styles.tag}>

--- a/apps/web/src/components/FlightPicker.tsx
+++ b/apps/web/src/components/FlightPicker.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import type { PriceData } from '@/lib/scraper/extract-prices';
-import { currencySymbol } from '@/lib/currency';
+import { formatCurrency } from '@/lib/currency';
 import styles from './FlightPicker.module.css';
 
 export interface RouteFlights {
@@ -162,7 +162,7 @@ export function FlightPicker({
                       )}
                     </div>
                     <div className={styles.airline}>{flight.airline}</div>
-                    <div className={styles.price}>{currencySymbol(flight.currency)}{flight.price}</div>
+                    <div className={styles.price}>{formatCurrency(flight.price, flight.currency)}</div>
                     <div className={styles.meta}>
                       <span className={styles.stops}>{formatStops(flight.stops)}</span>
                       {flight.duration && (

--- a/apps/web/src/components/PriceAlerts.tsx
+++ b/apps/web/src/components/PriceAlerts.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { formatCurrency } from '@/lib/currency';
 import styles from './PriceAlerts.module.css';
 
 interface Alert {
@@ -50,13 +51,4 @@ export function PriceAlerts() {
       ))}
     </div>
   );
-}
-
-function formatCurrency(amount: number, currency: string | null): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: currency ?? 'USD',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(amount);
 }

--- a/apps/web/src/components/PriceCalendar.tsx
+++ b/apps/web/src/components/PriceCalendar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { safeHttpUrl } from '@/lib/safe-url';
+import { formatCurrency } from '@/lib/currency';
 import styles from './PriceCalendar.module.css';
 
 interface Snapshot {
@@ -50,13 +51,6 @@ export function PriceCalendar({ snapshots, currency }: Props) {
   const maxPrice = Math.max(...prices);
   const range = maxPrice - minPrice || 1;
 
-  const fmt = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
-
   const formatDay = (iso: string) =>
     new Date(iso + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
@@ -75,10 +69,10 @@ export function PriceCalendar({ snapshots, currency }: Props) {
               rel="noopener noreferrer"
               className={`${styles.cell} ${isMin ? styles.cellBest : ''}`}
               style={{ '--intensity': intensity } as React.CSSProperties}
-              title={`${formatDay(d.date)}: ${fmt.format(d.minPrice)} (${d.airline})`}
+              title={`${formatDay(d.date)}: ${formatCurrency(d.minPrice, currency)} (${d.airline})`}
             >
               <span className={styles.cellDate}>{formatDay(d.date)}</span>
-              <span className={styles.cellPrice}>{fmt.format(d.minPrice)}</span>
+              <span className={styles.cellPrice}>{formatCurrency(d.minPrice, currency)}</span>
             </a>
           );
         })}

--- a/apps/web/src/components/PriceChart.tsx
+++ b/apps/web/src/components/PriceChart.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { currencySymbol } from '@/lib/currency';
+import { formatCurrency } from '@/lib/currency';
 import { safeHttpUrl } from '@/lib/safe-url';
 import styles from './PriceChart.module.css';
 
@@ -125,7 +125,7 @@ function usePlotTheme(): PlotTheme {
   return plotTheme;
 }
 
-function buildDetailTraces(snapshots: Snapshot[], sym: string, hasVpnData: boolean) {
+function buildDetailTraces(snapshots: Snapshot[], currency: string, hasVpnData: boolean) {
   const available = snapshots.filter((s) => s.status !== 'sold_out');
   const soldOut = snapshots.filter((s) => s.status === 'sold_out');
 
@@ -152,7 +152,7 @@ function buildDetailTraces(snapshots: Snapshot[], sym: string, hasVpnData: boole
       customdata: points.map((p) => [p.bookingUrl]),
       text: points.map((p) => {
         const lines = [
-          `<b>${sym}${p.price.toFixed(2)}</b> ${p.currency}`,
+          `<b>${formatCurrency(p.price, p.currency ?? currency)}</b>`,
           new Date(p.scrapedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }),
         ];
         if (p.departureTime || p.arrivalTime) {
@@ -179,7 +179,7 @@ function buildDetailTraces(snapshots: Snapshot[], sym: string, hasVpnData: boole
       customdata: soldOut.map((p) => [p.bookingUrl]),
       text: soldOut.map((p) => {
         const lines = [
-          `<b>${sym}${p.price.toFixed(2)}</b> (sold out)`,
+          `<b>${formatCurrency(p.price, p.currency ?? currency)}</b> (sold out)`,
           new Date(p.scrapedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }),
         ];
         if (p.departureTime || p.arrivalTime) {
@@ -195,7 +195,7 @@ function buildDetailTraces(snapshots: Snapshot[], sym: string, hasVpnData: boole
 }
 
 /** Comparison view: one line per country showing the cheapest price at each scrape time */
-function buildComparisonTraces(snapshots: Snapshot[], sym: string) {
+function buildComparisonTraces(snapshots: Snapshot[], currency: string) {
   const available = snapshots.filter((s) => s.status !== 'sold_out');
 
   // Group by country label
@@ -238,7 +238,7 @@ function buildComparisonTraces(snapshots: Snapshot[], sym: string) {
       customdata: cheapest.map((p) => [p.bookingUrl]),
       text: cheapest.map((p) => {
         const lines = [
-          `<b>${sym}${p.price.toFixed(2)}</b> cheapest from ${flag}${label}`,
+          `<b>${formatCurrency(p.price, p.currency ?? currency)}</b> cheapest from ${flag}${label}`,
           `${p.airline}`,
           new Date(p.scrapedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }),
         ];
@@ -257,7 +257,6 @@ interface Props {
 }
 
 export function PriceChart({ snapshots, allSnapshots, editEvents = [], currency = 'USD' }: Props) {
-  const sym = currencySymbol(currency);
   const plotTheme = usePlotTheme();
   const fullHistory = allSnapshots ?? snapshots;
   const hasFilteredHistory = fullHistory.length !== snapshots.length;
@@ -287,10 +286,10 @@ export function PriceChart({ snapshots, allSnapshots, editEvents = [], currency 
 
   const traces = useMemo(() => {
     if (view === 'comparison') {
-      return buildComparisonTraces(filteredSnapshots, sym);
+      return buildComparisonTraces(filteredSnapshots, currency);
     }
-    return buildDetailTraces(filteredSnapshots, sym, hasVpnData && view === 'all');
-  }, [filteredSnapshots, sym, view, hasVpnData]);
+    return buildDetailTraces(filteredSnapshots, currency, hasVpnData && view === 'all');
+  }, [filteredSnapshots, currency, view, hasVpnData]);
 
   const editShapes = useMemo(() => editEvents.map((event) => ({
     type: 'line' as const,
@@ -404,7 +403,6 @@ export function PriceChart({ snapshots, allSnapshots, editEvents = [], currency 
           },
           yaxis: {
             gridcolor: plotTheme.grid,
-            tickprefix: sym,
             title: { text: '' },
           },
           legend: {

--- a/apps/web/src/components/PriceChart.tsx
+++ b/apps/web/src/components/PriceChart.tsx
@@ -403,7 +403,7 @@ export function PriceChart({ snapshots, allSnapshots, editEvents = [], currency 
           },
           yaxis: {
             gridcolor: plotTheme.grid,
-            title: { text: '' },
+            title: { text: currency },
           },
           legend: {
             orientation: 'h',

--- a/apps/web/src/components/PriceHistory.test.tsx
+++ b/apps/web/src/components/PriceHistory.test.tsx
@@ -67,7 +67,7 @@ describe('PriceHistory: latest snapshot + full history (issue #89)', () => {
     const dataRows = screen
       .getAllByRole('row')
       .map((r) => r.textContent ?? '')
-      .filter((t) => t.includes('$'));
+      .filter((t) => t.includes('USD'));
 
     expect(dataRows[0]).toMatch(/Beta/); // 200
     expect(dataRows[1]).toMatch(/Alpha/); // 300

--- a/apps/web/src/components/PriceHistorySection.tsx
+++ b/apps/web/src/components/PriceHistorySection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { currencySymbol } from '@/lib/currency';
+import { formatCurrency } from '@/lib/currency';
 import { safeHttpUrl } from '@/lib/safe-url';
 import { useHydrated } from '@/lib/use-hydrated';
 import styles from './PriceHistory.module.css';
@@ -83,14 +83,12 @@ function TrendCell({ current, previous }: { current: Snapshot; previous: Snapsho
       </td>
     );
   }
-  const sym = currencySymbol(current.currency);
+  const up = diff > 0;
   return (
     <td>
-      {diff > 0 ? (
-        <span className={styles.trendUp}>+{sym}{Math.abs(diff).toFixed(0)}</span>
-      ) : (
-        <span className={styles.trendDown}>-{sym}{Math.abs(diff).toFixed(0)}</span>
-      )}
+      <span className={up ? styles.trendUp : styles.trendDown}>
+        {up ? '+' : '-'}{formatCurrency(Math.abs(diff), current.currency)}
+      </span>
     </td>
   );
 }
@@ -110,8 +108,7 @@ function FlightRow({
       <td>{flightName(s)}</td>
       <td className={styles.times}>{timesLabel(s)}</td>
       <td className={styles.price}>
-        {currencySymbol(s.currency)}
-        {s.price.toLocaleString('en-US')}
+        {formatCurrency(s.price, s.currency)}
       </td>
       <TrendCell current={s} previous={previous} />
       <td className={styles.stops}>{stopsLabel(s)}</td>

--- a/apps/web/src/lib/currency.test.ts
+++ b/apps/web/src/lib/currency.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { formatCurrency } from './currency';
+
+const norm = (s: string) => s.replace(/\s/g, ' ');
+
+describe('formatCurrency', () => {
+  it('shows the currency code and grouped amount with no decimals for an integer COP', () => {
+    expect(norm(formatCurrency(228290, 'COP'))).toBe('COP 228.290');
+  });
+
+  it('formats each currency in its own locale (COP dot-grouping, USD comma-grouping)', () => {
+    expect(norm(formatCurrency(1350.25, 'COP'))).toBe('COP 1.350,25');
+    expect(norm(formatCurrency(1234.5, 'USD'))).toBe('USD 1,234.50');
+  });
+
+  it('strips decimals for an integer USD amount', () => {
+    expect(norm(formatCurrency(250, 'USD'))).toBe('USD 250');
+  });
+
+  it('keeps two decimals for a non-integer USD amount', () => {
+    expect(norm(formatCurrency(1234.5, 'USD'))).toBe('USD 1,234.50');
+  });
+
+  it('returns empty string for null, undefined, NaN and Infinity', () => {
+    expect(formatCurrency(null, 'USD')).toBe('');
+    expect(formatCurrency(undefined, 'USD')).toBe('');
+    expect(formatCurrency(NaN, 'USD')).toBe('');
+    expect(formatCurrency(Infinity, 'USD')).toBe('');
+    expect(formatCurrency(-Infinity, 'USD')).toBe('');
+  });
+
+  it('upper-cases a lowercase currency code', () => {
+    expect(norm(formatCurrency(100, 'usd'))).toBe('USD 100');
+  });
+
+  it('defaults a missing currency to USD', () => {
+    expect(norm(formatCurrency(100, null))).toBe('USD 100');
+    expect(norm(formatCurrency(100, undefined))).toBe('USD 100');
+  });
+
+  it('falls back to amount plus code consistently for an invalid currency without throwing', () => {
+    expect(() => formatCurrency(10, 'ZZ')).not.toThrow();
+    expect(formatCurrency(10, 'ZZ')).toBe('10 ZZ');
+    expect(formatCurrency(10, 'ZZ')).toBe('10 ZZ');
+  });
+});

--- a/apps/web/src/lib/currency.ts
+++ b/apps/web/src/lib/currency.ts
@@ -1,32 +1,42 @@
-const SYMBOLS: Record<string, string> = {
-  USD: '$',
-  EUR: '€',
-  GBP: '£',
-  JPY: '¥',
-  CNY: '¥',
-  KRW: '₩',
-  INR: '₹',
-  CHF: 'CHF',
-  CAD: 'CA$',
-  AUD: 'A$',
-  NZD: 'NZ$',
-  HKD: 'HK$',
-  SGD: 'S$',
-  SEK: 'kr',
-  NOK: 'kr',
-  DKK: 'kr',
-  PLN: 'zł',
-  BRL: 'R$',
-  MXN: 'MX$',
-  THB: '฿',
-  TRY: '₺',
-  ZAR: 'R',
-  ILS: '₪',
-  COP: 'COL$',
+const CURRENCY_LOCALE: Record<string, string> = {
+  USD: 'en-US', EUR: 'de-DE', GBP: 'en-GB', JPY: 'ja-JP', CNY: 'zh-CN',
+  CHF: 'de-CH', CAD: 'en-CA', AUD: 'en-AU', NZD: 'en-NZ',
+  SEK: 'sv-SE', NOK: 'nb-NO', DKK: 'da-DK', PLN: 'pl-PL', RUB: 'ru-RU',
+  TRY: 'tr-TR', CZK: 'cs-CZ', UAH: 'uk-UA',
+  COP: 'es-CO', MXN: 'es-MX', ARS: 'es-AR', CLP: 'es-CL', PEN: 'es-PE',
+  BOB: 'es-BO', PYG: 'es-PY', UYU: 'es-UY', VES: 'es-VE', CRC: 'es-CR',
+  GTQ: 'es-GT', PAB: 'es-PA', DOP: 'es-DO', NIO: 'es-NI', HNL: 'es-HN',
+  CUP: 'es-CU', BRL: 'pt-BR',
+  INR: 'hi-IN', KRW: 'ko-KR', TWD: 'zh-TW', HKD: 'zh-HK', SGD: 'en-SG',
+  THB: 'th-TH', VND: 'vi-VN', IDR: 'id-ID', MYR: 'ms-MY', PHP: 'en-PH',
+  AED: 'ar-AE', SAR: 'ar-SA', ILS: 'he-IL', ZAR: 'en-ZA', NGN: 'en-NG',
 };
 
-export function currencySymbol(code: string): string {
-  return SYMBOLS[code] ?? code;
+const currencyFormatters = new Map<string, Intl.NumberFormat>();
+
+export function formatCurrency(
+  amount: number | null | undefined,
+  currency: string | null | undefined,
+): string {
+  if (amount == null || !Number.isFinite(amount)) return '';
+  const code = (currency || 'USD').toUpperCase();
+  const locale = CURRENCY_LOCALE[code] ?? 'en-US';
+  let formatter = currencyFormatters.get(code);
+  if (!formatter) {
+    try {
+      const options: Intl.NumberFormatOptions & { trailingZeroDisplay?: 'auto' | 'stripIfInteger' } = {
+        style: 'currency',
+        currency: code,
+        currencyDisplay: 'code',
+        trailingZeroDisplay: 'stripIfInteger',
+      };
+      formatter = new Intl.NumberFormat(locale, options);
+    } catch {
+      return `${new Intl.NumberFormat(locale, { style: 'decimal', maximumFractionDigits: 2 }).format(amount)} ${code}`;
+    }
+    currencyFormatters.set(code, formatter);
+  }
+  return formatter.format(amount);
 }
 
 /** Detect a likely currency from the user's browser locale. Server-safe fallback to USD. */

--- a/apps/web/src/lib/notifications/format.test.ts
+++ b/apps/web/src/lib/notifications/format.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { formatNewLowMessage, formatPrice } from './format';
 import type { NewLowAlert } from './detect';
 
+const norm = (s: string) => s.replace(/\s/g, ' ');
+
 const ALERT: NewLowAlert = {
   queryId: 'q-abc',
   currentMin: 250,
@@ -21,9 +23,9 @@ describe('formatNewLowMessage', () => {
       route: { origin: 'LHR', destination: 'JFK' },
       baseUrl: 'https://flights.example',
     });
-    expect(msg.title).toBe('New low: LHR to JFK $250');
-    expect(msg.body).toContain('dropped to $250 on United');
-    expect(msg.body).toContain('was $300, down $50');
+    expect(norm(msg.title)).toBe('New low: LHR to JFK USD 250');
+    expect(norm(msg.body)).toContain('dropped to USD 250 on United');
+    expect(norm(msg.body)).toContain('was USD 300, down USD 50');
     expect(msg.body).toContain('2026-08-01');
     expect(msg.url).toBe('https://flights.example/q/q-abc');
     expect(msg.data).toMatchObject({
@@ -64,7 +66,7 @@ describe('formatNewLowMessage', () => {
       baseUrl: null,
     });
     expect(msg.url).toBe('https://book/x');
-    expect(msg.body).toContain('dropped to $250'); // price/route still present
+    expect(norm(msg.body)).toContain('dropped to USD 250'); // price/route still present
   });
 
   it('emits no link when there is no base url and no usable booking url', () => {
@@ -74,7 +76,7 @@ describe('formatNewLowMessage', () => {
       baseUrl: null,
     });
     expect(msg.url).toBe('');
-    expect(msg.body).toContain('dropped to $250');
+    expect(norm(msg.body)).toContain('dropped to USD 250');
   });
 
   it('rejects a dangerous booking url scheme instead of linking to it', () => {
@@ -88,10 +90,10 @@ describe('formatNewLowMessage', () => {
 });
 
 describe('formatPrice', () => {
-  it('formats known currencies with their symbol and no decimals', () => {
-    expect(formatPrice(250, 'USD')).toBe('$250');
+  it('formats an integer amount with its code and no decimals', () => {
+    expect(norm(formatPrice(250, 'USD'))).toBe('USD 250');
     expect(formatPrice(250, 'EUR')).toContain('250');
-    expect(formatPrice(250, null)).toBe('$250');
+    expect(norm(formatPrice(250, null))).toBe('USD 250');
   });
 
   it('renders a well-formed but unknown currency code via Intl', () => {

--- a/apps/web/src/lib/notifications/format.ts
+++ b/apps/web/src/lib/notifications/format.ts
@@ -1,6 +1,7 @@
 import type { ChannelMessage } from './channels/types';
 import type { NewLowAlert } from './detect';
 import { safeHttpUrl } from '@/lib/safe-url';
+import { formatCurrency } from '@/lib/currency';
 
 export interface AlertRoute {
   origin: string;
@@ -52,14 +53,5 @@ export function formatNewLowMessage(params: {
 
 /** Format a price using the currency's locale rules, with a safe fallback. */
 export function formatPrice(amount: number, currency: string | null): string {
-  try {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currency ?? 'USD',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(amount);
-  } catch {
-    return `${Math.round(amount)} ${currency ?? 'USD'}`;
-  }
+  return formatCurrency(amount, currency);
 }


### PR DESCRIPTION
## Summary
Prices were formatted inconsistently across the app and relied on a manual,
incomplete symbol table. This replaces all of it with one `Intl.NumberFormat`-
based helper that formats each price in its own currency's locale.

## The problems
- **Inconsistent:** four separate code paths (a manual `SYMBOLS` table, raw
  numbers, `toLocaleString`, ad-hoc `Intl`). The same amount showed different
  symbols/grouping per screen; the flight list rendered raw unformatted numbers
  (e.g. `228290`).
- **Ambiguous symbols:** `$` was used for USD, COP, MXN…; COP's hand-written
  symbol was `COL$`.
- **Anglocentric grouping:** everything used `en-US`, so a Colombian price showed
  `228,290` when in Colombia it is written `228.290`.

## The fix
A single `formatCurrency(amount, currency)` in `lib/currency.ts`, backed by
`Intl.NumberFormat`:
- Shows the **ISO code** (`COP`, `USD`, `EUR`) instead of the ambiguous `$`.
- Correct **per-currency decimals** (COP/JPY none, USD/EUR two), with trailing
  zeros stripped on integers (`COP 228.290`, not `COP 228,290.00`).
- Formats each amount in its **currency's own locale** via a small
  currency→locale map (COP → `es-CO` → `228.290`; USD → `en-US` → `1,234.50`).
  Deterministic — the locale derives from the currency, so no SSR hydration risk.
- Deletes the manual `SYMBOLS` table and `currencySymbol`, and consolidates the
  six ad-hoc formatters (incl. `notifications/formatPrice`) into this one helper.

## Note on the design change
The old code deliberately used `en-US` everywhere. This switches to per-currency
locales — a visible formatting change. Currencies outside the map fall back to
`en-US` (still legible, correct code). Happy to discuss keeping uniform `en-US`,
or moving locale behind a user preference, if you'd prefer.

## Test plan
- New `lib/currency.test.ts` covering `formatCurrency` (per-currency grouping,
  decimals, null/NaN, invalid-code fallback).
- Updated existing tests that asserted the old symbol output.
- `lint`, `typecheck` (web + cli) and the full `test` suite green.

## before 
<img width="1952" height="1666" alt="Captura desde 2026-07-10 16-03-06" src="https://github.com/user-attachments/assets/b3f7694d-c96c-43ab-afe7-5a9a00cf66de" />

## afeter

<img width="1957" height="1958" alt="Captura desde 2026-07-10 17-58-14" src="https://github.com/user-attachments/assets/9a7ed1e0-127f-4b6e-b1d2-975a856e4661" />