### PR TITLE
web: i18n follow-ups to #174

### DIFF
--- a/apps/web/messages/de/pages.json
+++ b/apps/web/messages/de/pages.json
@@ -266,6 +266,7 @@
     "settingUp": "Wird eingerichtet...",
     "completeSetupAccounts": "Einrichtung abschließen und Konten aktivieren",
     "completeSetup": "Einrichtung abschließen",
-    "next": "Weiter"
+    "next": "Weiter",
+    "language": "Sprache"
   }
 }

--- a/apps/web/messages/en/pages.json
+++ b/apps/web/messages/en/pages.json
@@ -266,6 +266,7 @@
     "settingUp": "Setting up...",
     "completeSetupAccounts": "Complete setup and enable accounts",
     "completeSetup": "Complete Setup",
-    "next": "Next"
+    "next": "Next",
+    "language": "Language"
   }
 }

--- a/apps/web/messages/es/pages.json
+++ b/apps/web/messages/es/pages.json
@@ -266,6 +266,7 @@
     "settingUp": "Configurando...",
     "completeSetupAccounts": "Completar configuración y habilitar cuentas",
     "completeSetup": "Completar configuración",
-    "next": "Siguiente"
+    "next": "Siguiente",
+    "language": "Idioma"
   }
 }

--- a/apps/web/messages/fr/pages.json
+++ b/apps/web/messages/fr/pages.json
@@ -266,6 +266,7 @@
     "settingUp": "Configuration...",
     "completeSetupAccounts": "Terminer la configuration et activer les comptes",
     "completeSetup": "Terminer la configuration",
-    "next": "Suivant"
+    "next": "Suivant",
+    "language": "Langue"
   }
 }

--- a/apps/web/messages/pt/pages.json
+++ b/apps/web/messages/pt/pages.json
@@ -266,6 +266,7 @@
     "settingUp": "Configurando...",
     "completeSetupAccounts": "Concluir a configuração e ativar contas",
     "completeSetup": "Concluir Configuração",
-    "next": "Avançar"
+    "next": "Avançar",
+    "language": "Idioma"
   }
 }

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -1,0 +1,14 @@
+import { NextIntlClientProvider } from 'next-intl';
+import { getLocale, getMessages } from 'next-intl/server';
+
+// The root layout strips admin-only namespaces from the client payload on
+// public pages; re-provide the full message set for everything under /admin.
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { prisma } from '@/lib/prisma';
 import { isMultiUserEnabled } from '@/lib/multi-user';
 import { getCurrentUser } from '@/lib/user-auth';
 import { THEME_OPTIONS, getThemeMode, isThemeId, DEFAULT_THEME } from '@/lib/theme';
+import adminNamespaces from '../../messages/en/admin.json';
 
 const isSelfHosted = process.env.SELF_HOSTED === 'true';
 
@@ -125,7 +126,11 @@ export default async function RootLayout({
   const perUserScript = `window.__ftPerUserTheme = ${perUserTheme};`;
 
   const locale = await getLocale();
-  const messages = await getMessages();
+  // Admin-only namespaces stay out of the client payload on public pages;
+  // apps/web/src/app/admin/layout.tsx re-provides the full message set.
+  const messages = Object.fromEntries(
+    Object.entries(await getMessages()).filter(([namespace]) => !(namespace in adminNamespaces)),
+  );
 
   return (
     <html lang={locale} suppressHydrationWarning data-theme={theme} data-theme-mode={getThemeMode(theme)}>

--- a/apps/web/src/app/setup/page.module.css
+++ b/apps/web/src/app/setup/page.module.css
@@ -291,3 +291,32 @@
   background: var(--accent);
   border-color: var(--accent);
 }
+
+.languageRow {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.languageLabel {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.languageSelect {
+  padding: 0.35rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.languageSelect:focus {
+  border-color: var(--accent);
+}

--- a/apps/web/src/app/setup/page.tsx
+++ b/apps/web/src/app/setup/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useTranslations, useLocale } from 'next-intl';
+import { LOCALES, LOCALE_LABELS, LOCALE_COOKIE, isLocale } from '@/i18n/locales';
 import styles from './page.module.css';
 import { PROVIDER_METADATA, LOCAL_PROVIDERS } from '@/lib/scraper/provider-metadata';
 import { AvatarPicker } from '@/components/AvatarPicker/AvatarPicker';
@@ -20,6 +22,15 @@ interface SetupStatus {
 
 export default function SetupPage() {
   const t = useTranslations('Setup');
+  const locale = useLocale();
+  const router = useRouter();
+  const changeLocale = (value: string) => {
+    if (!isLocale(value)) return;
+    document.cookie = `${LOCALE_COOKIE}=${value}; path=/; max-age=31536000; samesite=lax`;
+    // Soft refresh: re-renders server components with the new locale while
+    // preserving wizard state entered so far.
+    router.refresh();
+  };
   const [status, setStatus] = useState<SetupStatus | null>(null);
   const [step, setStep] = useState(0);
   const [password, setPassword] = useState('');
@@ -252,6 +263,22 @@ export default function SetupPage() {
             </>
           )}
         </div>
+
+        {step === (isSelfHosted ? 1 : 0) && (
+          <div className={styles.languageRow}>
+            <label className={styles.languageLabel} htmlFor="setup-language">{t('language')}</label>
+            <select
+              id="setup-language"
+              className={styles.languageSelect}
+              defaultValue={locale}
+              onChange={(e) => changeLocale(e.target.value)}
+            >
+              {LOCALES.map((l) => (
+                <option key={l} value={l}>{LOCALE_LABELS[l]}</option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {step === 0 && (
           <div className={styles.fields}>

--- a/apps/web/src/i18n/messages-parity.test.ts
+++ b/apps/web/src/i18n/messages-parity.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { LOCALES, DEFAULT_LOCALE } from './locales';
+
+const MESSAGES_DIR = resolve(__dirname, '../../messages');
+
+function flattenKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) =>
+    value && typeof value === 'object'
+      ? flattenKeys(value as Record<string, unknown>, `${prefix}${key}.`)
+      : [`${prefix}${key}`],
+  );
+}
+
+function localeKeys(locale: string): Map<string, string[]> {
+  const files = readdirSync(resolve(MESSAGES_DIR, locale)).filter((f) => f.endsWith('.json'));
+  return new Map(
+    files.map((file) => [
+      file,
+      flattenKeys(JSON.parse(readFileSync(resolve(MESSAGES_DIR, locale, file), 'utf-8'))).sort(),
+    ]),
+  );
+}
+
+describe('message key parity across locales', () => {
+  const english = localeKeys(DEFAULT_LOCALE);
+  const others = LOCALES.filter((l) => l !== DEFAULT_LOCALE);
+
+  it.each(others)('%s has the same files and keys as English', (locale) => {
+    const keys = localeKeys(locale);
+    expect([...keys.keys()].sort()).toEqual([...english.keys()].sort());
+    for (const [file, enKeys] of english) {
+      const locKeys = keys.get(file) ?? [];
+      const missing = enKeys.filter((k) => !locKeys.includes(k));
+      const extra = locKeys.filter((k) => !enKeys.includes(k));
+      expect({ file, missing, extra }).toEqual({ file, missing: [], extra: [] });
+    }
+  });
+});

--- a/apps/web/src/i18n/request.ts
+++ b/apps/web/src/i18n/request.ts
@@ -4,11 +4,28 @@ import { DEFAULT_LOCALE, LOCALE_COOKIE, isLocale, type Locale } from './locales'
 
 const AREAS = ['common', 'components', 'pages', 'settings', 'admin'] as const;
 
-async function loadMessages(locale: Locale): Promise<Record<string, unknown>> {
+type Messages = Record<string, unknown>;
+
+async function loadMessages(locale: Locale): Promise<Messages> {
   const areas = await Promise.all(
     AREAS.map(async (area) => (await import(`../../messages/${locale}/${area}.json`)).default),
   );
   return Object.assign({}, ...areas);
+}
+
+// Recursive merge so a locale missing a nested key falls back to the English
+// string instead of rendering the raw key. A shallow spread would replace a
+// whole namespace object when any key inside it drifts.
+function deepMerge(fallback: Messages, override: Messages): Messages {
+  const out: Messages = { ...fallback };
+  for (const [key, value] of Object.entries(override)) {
+    const base = out[key];
+    out[key] =
+      value && typeof value === 'object' && base && typeof base === 'object'
+        ? deepMerge(base as Messages, value as Messages)
+        : value;
+  }
+  return out;
 }
 
 export default getRequestConfig(async () => {
@@ -17,7 +34,8 @@ export default getRequestConfig(async () => {
   const locale = isLocale(cookieLocale) ? cookieLocale : DEFAULT_LOCALE;
 
   const fallback = await loadMessages(DEFAULT_LOCALE);
-  const messages = locale === DEFAULT_LOCALE ? fallback : { ...fallback, ...(await loadMessages(locale)) };
+  const messages =
+    locale === DEFAULT_LOCALE ? fallback : deepMerge(fallback, await loadMessages(locale));
 
   return { locale, messages };
 });


### PR DESCRIPTION
Three small hardenings on top of the i18n merge:

1. A key parity test: flattens every `messages/en/*.json` key path and asserts es/pt/de/fr match exactly, so translation drift fails CI instead of rendering raw keys.
2. Deep merge for the English fallback. The previous spread was shallow at namespace level, so one missing nested key would drop a whole English namespace.
3. Admin translations no longer ship in the client payload of public pages. The root layout strips the `admin.json` namespaces and a nested provider under `/admin` re-supplies them.
4. The setup wizard now has a language picker on its first step, reusing the `ft-locale` cookie pattern from Settings. Switching language mid-wizard preserves anything already entered.

All five locales stay at 1031 keys. Full CI green.