### PR TITLE
fix(scraper): drop Sec-Fetch-* stealth headers that hang Google Flights results

### DIFF
--- a/apps/web/src/lib/scraper/browser.test.ts
+++ b/apps/web/src/lib/scraper/browser.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Browser, BrowserContext } from 'playwright';
+import { createStealthContext } from './browser';
+
+describe('createStealthContext', () => {
+  it('leaves Fetch Metadata headers to Chromium so subrequests retain their request-specific values', async () => {
+    const context = {
+      addInitScript: vi.fn().mockResolvedValue(undefined),
+    } as unknown as BrowserContext;
+    const newContext = vi.fn().mockResolvedValue(context);
+    const browser = { newContext } as unknown as Browser;
+
+    await createStealthContext(browser);
+
+    expect(newContext).toHaveBeenCalledOnce();
+    const [options] = newContext.mock.calls[0]!;
+    expect(options.extraHTTPHeaders).toEqual({
+      'Accept-Language': 'en-US,en;q=0.9',
+      'Accept-Encoding': 'gzip, deflate, br',
+      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+      'Upgrade-Insecure-Requests': '1',
+    });
+    expect(options.extraHTTPHeaders).not.toHaveProperty('Sec-Fetch-Dest');
+    expect(options.extraHTTPHeaders).not.toHaveProperty('Sec-Fetch-Mode');
+    expect(options.extraHTTPHeaders).not.toHaveProperty('Sec-Fetch-Site');
+    expect(options.extraHTTPHeaders).not.toHaveProperty('Sec-Fetch-User');
+  });
+});

--- a/apps/web/src/lib/scraper/browser.ts
+++ b/apps/web/src/lib/scraper/browser.ts
@@ -89,15 +89,18 @@ export async function createStealthContext(browser: Browser, options: StealthCon
     geolocation: profile?.geolocation,
     permissions: profile?.geolocation ? ['geolocation'] : [],
     proxy,
+    // NOTE: do NOT set Sec-Fetch-* here. extraHTTPHeaders applies to *every*
+    // request, so hardcoding Sec-Fetch-Dest=document / Mode=navigate / Site=none
+    // poisons Google Flights' results XHR (which must send Mode=cors,
+    // Site=same-origin, Dest=empty). Google's backend then never resolves that
+    // fetch and the page hangs forever on "Loading results" — reproduced
+    // deterministically on MEL→TWU. Chromium already sets correct per-request
+    // Sec-Fetch-* values on its own, so overriding them adds no stealth value.
     extraHTTPHeaders: {
       'Accept-Language': profile?.acceptLanguage ?? 'en-US,en;q=0.9',
       'Accept-Encoding': 'gzip, deflate, br',
       'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
       'Upgrade-Insecure-Requests': '1',
-      'Sec-Fetch-Dest': 'document',
-      'Sec-Fetch-Mode': 'navigate',
-      'Sec-Fetch-Site': 'none',
-      'Sec-Fetch-User': '?1',
     },
   });
 


### PR DESCRIPTION
## Summary

Flight searches for slower, multi-connection routes were hanging on "Loading results" and returning no prices. Reproduced deterministically on **MEL→TWU** (Melbourne → Tawau): the page sat at a 523-char "Loading results" shell for 48s+ across every attempt, so extraction always came back empty.

## Root cause

`extraHTTPHeaders` in `createStealthContext` applies to **every** request the context makes, not just the top-level navigation. Hardcoding `Sec-Fetch-Dest=document` / `Sec-Fetch-Mode=navigate` / `Sec-Fetch-Site=none` therefore forced navigation-type Sec-Fetch values onto Google Flights' **results XHR**, whose correct values are `Mode=cors`, `Site=same-origin`, `Dest=empty`. Google's backend never resolves that inconsistent fetch → the page hangs forever on "Loading results". Common routes sometimes slipped through, which is why it looked intermittent.

## Fix

Remove the four `Sec-Fetch-*` headers. Chromium already sets correct per-request `Sec-Fetch-*` values on its own, so overriding them added no stealth value.

## Verification

- Bisection isolated the Sec-Fetch group as the sole cause: all headers → hang; `Sec-Fetch-*` alone → hang; everything **except** `Sec-Fetch-*` → prices in ~4s.
- After the fix, the real stealth context renders MEL→TWU in ~4s, and a full one-way preview completes with real fares (from **A$642**).
- `tsc --noEmit` and `eslint` clean.
