### PR TITLE
feat(ui): move chart tracker controls above the price chart

### DIFF
--- a/apps/web/src/app/q/[id]/page.module.css
+++ b/apps/web/src/app/q/[id]/page.module.css
@@ -34,8 +34,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.75rem;
 }
 
 .route {
@@ -183,18 +182,20 @@
   text-align: center;
 }
 
-/* Footer meta (page-specific tracking info above shared Footer) */
-.footerMeta {
-  padding: 1rem 1.5rem 0;
+/* Top controls (status, check interval, filters, sources) */
+.topControls {
+  padding: 0.25rem 0 1rem;
+  border-bottom: 1px solid var(--border);
+  margin-top: -0.75rem;
 }
 
-.footerText {
+.topControlsText {
   font-size: 0.8125rem;
   color: var(--muted);
   font-family: var(--font-mono);
 }
 
-.footerRow {
+.topControlsRow {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -460,22 +460,9 @@ export default async function ChartPage({ params }: Props) {
         </div>
       </header>
 
-      {expired ? (
-        <div className={styles.expiredNotice}>
-          <p>{t('expiredOn', { date: formatDate(groupExpiresAt) })}</p>
-          <p>{t('expiredSnapshot')}</p>
-        </div>
-      ) : null}
-
-      {isMultiRoute ? (
-        <StackedSortControls items={allQueries.map((q) => buildStackedItem(q, t))} />
-      ) : (
-        renderRouteBlock(primary, false, t)
-      )}
-
-      <div className={styles.footerMeta}>
-        <div className={styles.footerRow}>
-          <p className={styles.footerText}>
+      <div className={styles.topControls}>
+        <div className={styles.topControlsRow}>
+          <p className={styles.topControlsText}>
             <ScrapeStatusDot
               status={scrapeAggregate.status}
               error={scrapeAggregate.error}
@@ -513,6 +500,20 @@ export default async function ChartPage({ params }: Props) {
           )}
         </div>
       </div>
+
+      {expired ? (
+        <div className={styles.expiredNotice}>
+          <p>{t('expiredOn', { date: formatDate(groupExpiresAt) })}</p>
+          <p>{t('expiredSnapshot')}</p>
+        </div>
+      ) : null}
+
+      {isMultiRoute ? (
+        <StackedSortControls items={allQueries.map((q) => buildStackedItem(q, t))} />
+      ) : (
+        renderRouteBlock(primary, false, t)
+      )}
+
       <Footer />
     </main>
   );


### PR DESCRIPTION
## Summary
- Move scrape status, interval, Filters, sources, and delete controls from below the chart to under the route header on `/q/[id]`
- Keep a single bottom border under the control strip so the header + controls read as one top block

## Test plan
- [ ] Open an active tracker chart page and confirm Filters / Sources / interval / refresh appear under the route header (above the chart)
- [ ] Apply a max-stops filter and confirm the chart updates without needing to scroll to the footer
- [ ] Confirm expired trackers still show the expired notice and hide edit controls
- [ ] Spot-check multi-route stacked charts still render correctly below the controls
- [ ] Check mobile wrap of the control row


Made with [Cursor](https://cursor.com)