### PR TITLE
fix(ui): contain sources picker on narrow screens, drop spacing offsets

### DIFF
--- a/apps/web/src/app/q/[id]/page.module.css
+++ b/apps/web/src/app/q/[id]/page.module.css
@@ -34,7 +34,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding-bottom: 0.75rem;
 }
 
 .route {
@@ -186,7 +185,6 @@
 .topControls {
   padding: 0.25rem 0 1rem;
   border-bottom: 1px solid var(--border);
-  margin-top: -0.75rem;
 }
 
 .topControlsText {

--- a/apps/web/src/components/AggregatorPicker.module.css
+++ b/apps/web/src/components/AggregatorPicker.module.css
@@ -2,6 +2,8 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .label {
@@ -16,7 +18,8 @@
   gap: 0;
   border: 1px solid var(--border);
   border-radius: 100px;
-  overflow: hidden;
+  overflow-x: auto;
+  min-width: 0;
 }
 
 .option {


### PR DESCRIPTION
Follow up to #185. Two small cleanups now that the controls sit above the chart: the sources picker could push the page wider than the screen on phones, and the top strip used a header padding and negative margin that cancelled each other out.

The pill group now shrinks and scrolls inside its own row, and the offsets are gone since the flex gap already provides the same distance. Desktop renders identically.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/affromero/flight-finder/media/chart-controls/before-mobile.png) | ![after](https://raw.githubusercontent.com/affromero/flight-finder/media/chart-controls/after-mobile.png) |

Verified at 390px: document scrollWidth matches the viewport.
