### PR TITLE
fix(ui): wrap sources picker as standalone chips on narrow screens

### DIFF
--- a/apps/web/src/components/AggregatorPicker.module.css
+++ b/apps/web/src/components/AggregatorPicker.module.css
@@ -78,3 +78,19 @@
   color: var(--muted);
   opacity: 0.7;
 }
+
+@media (max-width: 640px) {
+  .options {
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    border: none;
+    border-radius: 0;
+    overflow: visible;
+  }
+
+  .option,
+  .option:last-child {
+    border: 1px solid var(--border);
+    border-radius: 100px;
+  }
+}


### PR DESCRIPTION
Follow up to #186. The scrollable pill strip on phones read as a cut off control. Below 640px the sources now wrap as individual chips, matching the other pill buttons. Desktop keeps the segmented strip.

![mobile](https://raw.githubusercontent.com/affromero/flight-finder/media/chart-controls/wrap-mobile.png)

Verified at 390px: all four sources visible, no horizontal scroll.