### PR TITLE
feat(preview): broadcast unequal date pairs and surface combo guardrails

### DIFF
--- a/apps/web/messages/de/components.json
+++ b/apps/web/messages/de/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "Der ExpressVPN-Sidecar läuft nicht. Starte Flight Finder mit VPN-Unterstützung:",
     "moreRegions": "+ {count} weitere Regionen",
     "edit": "Bearbeiten",
-    "previewTaskCount": "Diese Suche führt {count} Google-Flights-Abfragen aus ({origins} Abflüge × {destinations} Ziele × {dates} Datumspaare).",
+    "previewTaskCount": "Diese Suche führt {count, plural, one {# Google-Flights-Abfrage} other {# Google-Flights-Abfragen}} aus ({origins, plural, one {# Abflug} other {# Abflüge}} × {destinations, plural, one {# Ziel} other {# Ziele}} × {dates, plural, one {# Datumspaar} other {# Datumspaare}}).",
     "previewTaskCountWarn": "Große Vorschau ({count} Abfragen) — Google kann drosseln. Weniger Flughäfen oder Daten versuchen.",
     "previewOverComboCap": "Zu viele Kombinationen ({count}). Limit ist {cap} — Daten oder Flughäfen eingrenzen.",
     "previewFarFutureWarn": "Daten liegen mehr als etwa 4 Monate voraus — Google Flights lädt einige Routen oft nicht. Näher liegende Daten wählen.",

--- a/apps/web/messages/de/components.json
+++ b/apps/web/messages/de/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Zu den Einstellungen",
     "sidecarNotRunning": "Der ExpressVPN-Sidecar läuft nicht. Starte Flight Finder mit VPN-Unterstützung:",
     "moreRegions": "+ {count} weitere Regionen",
-    "edit": "Bearbeiten"
+    "edit": "Bearbeiten",
+    "previewTaskCount": "Diese Suche führt {count} Google-Flights-Abfragen aus ({origins} Abflüge × {destinations} Ziele × {dates} Datumspaare).",
+    "previewTaskCountWarn": "Große Vorschau ({count} Abfragen) — Google kann drosseln. Weniger Flughäfen oder Daten versuchen.",
+    "previewOverComboCap": "Zu viele Kombinationen ({count}). Limit ist {cap} — Daten oder Flughäfen eingrenzen.",
+    "previewFarFutureWarn": "Daten liegen mehr als etwa 4 Monate voraus — Google Flights lädt einige Routen oft nicht. Näher liegende Daten wählen.",
+    "previewFarFutureBlock": "Daten liegen mehr als etwa 9 Monate voraus — Google Flights liefert meist keine Ergebnisse. Näher liegende Daten wählen.",
+    "previewUnequalDates": "Hin- und Rückflugdaten passen nicht zusammen. Ein Hin- oder Rückflugdatum oder gleich lange Listen verwenden."
   },
   "DeleteTracker": {
     "deleteFailed": "Tracker konnte nicht gelöscht werden",

--- a/apps/web/messages/en/components.json
+++ b/apps/web/messages/en/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Go to Settings",
     "sidecarNotRunning": "ExpressVPN sidecar is not running. Start Flight Finder with VPN support:",
     "moreRegions": "+ {count} more regions",
-    "edit": "Edit"
+    "edit": "Edit",
+    "previewTaskCount": "This search runs {count} Google Flights lookups ({origins} origins × {destinations} destinations × {dates} date pairs).",
+    "previewTaskCountWarn": "Large preview ({count} lookups) — Google may throttle. Try one origin or fewer date options.",
+    "previewOverComboCap": "Too many combinations ({count}). Cap is {cap} — edit to narrow dates or airports.",
+    "previewFarFutureWarn": "Dates are more than about 4 months out — Google Flights often won't load results for some routes. Try nearer dates or one date pair.",
+    "previewFarFutureBlock": "Dates are more than about 9 months out — Google Flights usually will not return results. Pick nearer dates.",
+    "previewUnequalDates": "Outbound and return date lists don't line up. Use a single outbound or return date, or matching-length lists."
   },
   "DeleteTracker": {
     "deleteFailed": "Failed to delete tracker",

--- a/apps/web/messages/en/components.json
+++ b/apps/web/messages/en/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "ExpressVPN sidecar is not running. Start Flight Finder with VPN support:",
     "moreRegions": "+ {count} more regions",
     "edit": "Edit",
-    "previewTaskCount": "This search runs {count} Google Flights lookups ({origins} origins × {destinations} destinations × {dates} date pairs).",
+    "previewTaskCount": "This search runs {count, plural, one {# Google Flights lookup} other {# Google Flights lookups}} ({origins, plural, one {# origin} other {# origins}} × {destinations, plural, one {# destination} other {# destinations}} × {dates, plural, one {# date pair} other {# date pairs}}).",
     "previewTaskCountWarn": "Large preview ({count} lookups) — Google may throttle. Try one origin or fewer date options.",
     "previewOverComboCap": "Too many combinations ({count}). Cap is {cap} — edit to narrow dates or airports.",
     "previewFarFutureWarn": "Dates are more than about 4 months out — Google Flights often won't load results for some routes. Try nearer dates or one date pair.",

--- a/apps/web/messages/es/components.json
+++ b/apps/web/messages/es/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "El sidecar de ExpressVPN no está en ejecución. Inicia Flight Finder con soporte de VPN:",
     "moreRegions": "+ {count} regiones más",
     "edit": "Editar",
-    "previewTaskCount": "Esta búsqueda ejecuta {count} consultas en Google Flights ({origins} orígenes × {destinations} destinos × {dates} pares de fechas).",
+    "previewTaskCount": "Esta búsqueda ejecuta {count, plural, one {# consulta en Google Flights} other {# consultas en Google Flights}} ({origins, plural, one {# origen} other {# orígenes}} × {destinations, plural, one {# destino} other {# destinos}} × {dates, plural, one {# par de fechas} other {# pares de fechas}}).",
     "previewTaskCountWarn": "Vista previa grande ({count} consultas) — Google puede limitar. Prueba un origen o menos fechas.",
     "previewOverComboCap": "Demasiadas combinaciones ({count}). El tope es {cap} — reduce fechas o aeropuertos.",
     "previewFarFutureWarn": "Las fechas están a más de unos 4 meses — Google Flights a menudo no carga resultados. Prueba fechas más cercanas.",

--- a/apps/web/messages/es/components.json
+++ b/apps/web/messages/es/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Ir a Configuración",
     "sidecarNotRunning": "El sidecar de ExpressVPN no está en ejecución. Inicia Flight Finder con soporte de VPN:",
     "moreRegions": "+ {count} regiones más",
-    "edit": "Editar"
+    "edit": "Editar",
+    "previewTaskCount": "Esta búsqueda ejecuta {count} consultas en Google Flights ({origins} orígenes × {destinations} destinos × {dates} pares de fechas).",
+    "previewTaskCountWarn": "Vista previa grande ({count} consultas) — Google puede limitar. Prueba un origen o menos fechas.",
+    "previewOverComboCap": "Demasiadas combinaciones ({count}). El tope es {cap} — reduce fechas o aeropuertos.",
+    "previewFarFutureWarn": "Las fechas están a más de unos 4 meses — Google Flights a menudo no carga resultados. Prueba fechas más cercanas.",
+    "previewFarFutureBlock": "Las fechas están a más de unos 9 meses — Google Flights casi nunca devuelve resultados. Elige fechas más cercanas.",
+    "previewUnequalDates": "Las listas de ida y vuelta no coinciden. Usa una sola fecha de ida o vuelta, o listas de la misma longitud."
   },
   "DeleteTracker": {
     "deleteFailed": "No se pudo eliminar el rastreador",

--- a/apps/web/messages/fr/components.json
+++ b/apps/web/messages/fr/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "Le sidecar ExpressVPN n’est pas lancé. Démarre Flight Finder avec la prise en charge VPN :",
     "moreRegions": "+ {count} autres régions",
     "edit": "Modifier",
-    "previewTaskCount": "Cette recherche lance {count} requêtes Google Flights ({origins} origines × {destinations} destinations × {dates} paires de dates).",
+    "previewTaskCount": "Cette recherche lance {count, plural, one {# requête Google Flights} other {# requêtes Google Flights}} ({origins, plural, one {# origine} other {# origines}} × {destinations, plural, one {# destination} other {# destinations}} × {dates, plural, one {# paire de dates} other {# paires de dates}}).",
     "previewTaskCountWarn": "Grande prévisualisation ({count} requêtes) — Google peut limiter. Essayez une origine ou moins de dates.",
     "previewOverComboCap": "Trop de combinaisons ({count}). La limite est {cap} — réduisez les dates ou aéroports.",
     "previewFarFutureWarn": "Les dates sont à plus d’environ 4 mois — Google Flights charge souvent mal. Essayez des dates plus proches.",

--- a/apps/web/messages/fr/components.json
+++ b/apps/web/messages/fr/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Aller aux paramètres",
     "sidecarNotRunning": "Le sidecar ExpressVPN n’est pas lancé. Démarre Flight Finder avec la prise en charge VPN :",
     "moreRegions": "+ {count} autres régions",
-    "edit": "Modifier"
+    "edit": "Modifier",
+    "previewTaskCount": "Cette recherche lance {count} requêtes Google Flights ({origins} origines × {destinations} destinations × {dates} paires de dates).",
+    "previewTaskCountWarn": "Grande prévisualisation ({count} requêtes) — Google peut limiter. Essayez une origine ou moins de dates.",
+    "previewOverComboCap": "Trop de combinaisons ({count}). La limite est {cap} — réduisez les dates ou aéroports.",
+    "previewFarFutureWarn": "Les dates sont à plus d’environ 4 mois — Google Flights charge souvent mal. Essayez des dates plus proches.",
+    "previewFarFutureBlock": "Les dates sont à plus d’environ 9 mois — Google Flights ne renvoie en général aucun résultat. Choisissez des dates plus proches.",
+    "previewUnequalDates": "Les listes aller et retour ne correspondent pas. Utilisez une seule date aller ou retour, ou des listes de même longueur."
   },
   "DeleteTracker": {
     "deleteFailed": "Échec de la suppression du suivi",

--- a/apps/web/messages/pt/components.json
+++ b/apps/web/messages/pt/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "O sidecar da ExpressVPN não está em execução. Inicie o Flight Finder com suporte a VPN:",
     "moreRegions": "+ {count} outras regiões",
     "edit": "Editar",
-    "previewTaskCount": "Esta busca executa {count} consultas no Google Flights ({origins} origens × {destinations} destinos × {dates} pares de datas).",
+    "previewTaskCount": "Esta busca executa {count, plural, one {# consulta no Google Flights} other {# consultas no Google Flights}} ({origins, plural, one {# origem} other {# origens}} × {destinations, plural, one {# destino} other {# destinos}} × {dates, plural, one {# par de datas} other {# pares de datas}}).",
     "previewTaskCountWarn": "Pré-visualização grande ({count} consultas) — o Google pode limitar. Tente uma origem ou menos datas.",
     "previewOverComboCap": "Demasiadas combinações ({count}). O limite é {cap} — reduza datas ou aeroportos.",
     "previewFarFutureWarn": "As datas estão a mais de cerca de 4 meses — o Google Flights muitas vezes não carrega. Tente datas mais próximas.",

--- a/apps/web/messages/pt/components.json
+++ b/apps/web/messages/pt/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Ir para Configurações",
     "sidecarNotRunning": "O sidecar da ExpressVPN não está em execução. Inicie o Flight Finder com suporte a VPN:",
     "moreRegions": "+ {count} outras regiões",
-    "edit": "Editar"
+    "edit": "Editar",
+    "previewTaskCount": "Esta busca executa {count} consultas no Google Flights ({origins} origens × {destinations} destinos × {dates} pares de datas).",
+    "previewTaskCountWarn": "Pré-visualização grande ({count} consultas) — o Google pode limitar. Tente uma origem ou menos datas.",
+    "previewOverComboCap": "Demasiadas combinações ({count}). O limite é {cap} — reduza datas ou aeroportos.",
+    "previewFarFutureWarn": "As datas estão a mais de cerca de 4 meses — o Google Flights muitas vezes não carrega. Tente datas mais próximas.",
+    "previewFarFutureBlock": "As datas estão a mais de cerca de 9 meses — o Google Flights normalmente não devolve resultados. Escolha datas mais próximas.",
+    "previewUnequalDates": "As listas de ida e volta não coincidem. Use uma única data de ida ou volta, ou listas com o mesmo comprimento."
   },
   "DeleteTracker": {
     "deleteFailed": "Falha ao excluir o rastreador",

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '@/generated/prisma/client';
 import { NextRequest } from 'next/server';
 import { apiError, apiSuccess } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
+import { cached } from '@/lib/redis';
 import { getClientIp } from '@/lib/trusted-ip';
 import {
   ACTIVE_PREVIEW_STATUSES,
@@ -32,13 +33,18 @@ const HEARTBEAT_INTERVAL_MS = 60 * 1000;
 
 /** Public, non-sensitive preview limits for client-side validation. */
 export async function GET() {
-  const config = await prisma.extractionConfig.findFirst({
-    where: { id: 'singleton' },
-    select: { previewMaxCombos: true },
-  });
-  return apiSuccess({
-    previewMaxCombos: config?.previewMaxCombos ?? 24,
-  });
+  const config = await cached(
+    'preview:public-config',
+    async () => {
+      const stored = await prisma.extractionConfig.findFirst({
+        where: { id: 'singleton' },
+        select: { previewMaxCombos: true },
+      });
+      return { previewMaxCombos: stored?.previewMaxCombos ?? 24 };
+    },
+    300,
+  );
+  return apiSuccess(config);
 }
 
 interface PreviewRunRow {

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -30,6 +30,17 @@ const PREVIEW_RUN_TTL_MS = 24 * 60 * 60 * 1000;
  */
 const HEARTBEAT_INTERVAL_MS = 60 * 1000;
 
+/** Public, non-sensitive preview limits for client-side validation. */
+export async function GET() {
+  const config = await prisma.extractionConfig.findFirst({
+    where: { id: 'singleton' },
+    select: { previewMaxCombos: true },
+  });
+  return apiSuccess({
+    previewMaxCombos: config?.previewMaxCombos ?? 24,
+  });
+}
+
 interface PreviewRunRow {
   id: string;
   requestHash: string;

--- a/apps/web/src/components/ConfirmationCard.module.css
+++ b/apps/web/src/components/ConfirmationCard.module.css
@@ -378,6 +378,24 @@
   color: var(--text);
 }
 
+.previewNotices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.previewNotice {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.previewNoticeWarn {
+  color: var(--warning);
+}
+
 @media (max-width: 480px) {
   .route {
     gap: 1rem;

--- a/apps/web/src/components/ConfirmationCard.tsx
+++ b/apps/web/src/components/ConfirmationCard.tsx
@@ -4,6 +4,14 @@ import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import type { Airport } from '@/lib/scraper/parse-query';
 import { formatCurrency } from '@/lib/currency';
+import {
+  buildPreviewDatePairs,
+  countPreviewTasks,
+  isPreviewFarFutureWarn,
+  isPreviewTooFarInFuture,
+  PREVIEW_COMBO_WARN_THRESHOLD,
+  UNEQUAL_MULTI_DATE_ERROR,
+} from '@/lib/preview-utils';
 import styles from './ConfirmationCard.module.css';
 
 export interface ParsedQuery {
@@ -89,6 +97,7 @@ export function ConfirmationCard({
   loadingLabel,
   vpnCountries,
   onVpnCountriesChange,
+  previewMaxCombos = 24,
 }: {
   parsed: ParsedQuery;
   onTrack: () => void;
@@ -98,6 +107,7 @@ export function ConfirmationCard({
   loadingLabel?: string;
   vpnCountries?: string[];
   onVpnCountriesChange?: (countries: string[]) => void;
+  previewMaxCombos?: number;
 }) {
   const t = useTranslations('ConfirmationCard');
   const [vpnOpen, setVpnOpen] = useState(false);
@@ -120,6 +130,34 @@ export function ConfirmationCard({
       onVpnCountriesChange([...vpnCountries, code]);
     }
   };
+
+  let previewTaskCount = 0;
+  let previewDatePairCount = 0;
+  let unequalDateError = false;
+  try {
+    previewTaskCount = countPreviewTasks(parsed.origins.length, parsed.destinations.length, parsed);
+    previewDatePairCount = buildPreviewDatePairs(
+      parsed.outboundDates,
+      parsed.returnDates,
+      parsed.dateFrom,
+      parsed.dateTo,
+      parsed.tripType === 'one_way',
+    ).length;
+  } catch (error) {
+    unequalDateError = error instanceof Error && error.message === UNEQUAL_MULTI_DATE_ERROR;
+  }
+  const showComboWarn = previewTaskCount >= PREVIEW_COMBO_WARN_THRESHOLD;
+  const showFarFutureWarn = !unequalDateError && isPreviewFarFutureWarn(parsed);
+  const overFarFuture = !unequalDateError && isPreviewTooFarInFuture(parsed);
+  const overComboCap = previewTaskCount > previewMaxCombos;
+  const blockTrack = unequalDateError || overComboCap || overFarFuture;
+  const showNotices =
+    unequalDateError ||
+    previewTaskCount > 1 ||
+    showComboWarn ||
+    showFarFutureWarn ||
+    overFarFuture ||
+    overComboCap;
 
   return (
     <div className={styles.root}>
@@ -320,11 +358,51 @@ export function ConfirmationCard({
         </div>
       )}
 
+      {(showNotices) && (
+        <div className={styles.previewNotices}>
+          {unequalDateError && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewUnequalDates')}
+            </p>
+          )}
+          {!unequalDateError && previewTaskCount > 1 && (
+            <p className={styles.previewNotice}>
+              {t('previewTaskCount', {
+                count: previewTaskCount,
+                origins: parsed.origins.length,
+                destinations: parsed.destinations.length,
+                dates: previewDatePairCount,
+              })}
+            </p>
+          )}
+          {showComboWarn && !overComboCap && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewTaskCountWarn', { count: previewTaskCount })}
+            </p>
+          )}
+          {overComboCap && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewOverComboCap', { count: previewTaskCount, cap: previewMaxCombos })}
+            </p>
+          )}
+          {overFarFuture && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewFarFutureBlock')}
+            </p>
+          )}
+          {showFarFutureWarn && !overFarFuture && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewFarFutureWarn')}
+            </p>
+          )}
+        </div>
+      )}
+
       <div className={styles.actions}>
         <button
           className={styles.trackButton}
           onClick={onTrack}
-          disabled={loading}
+          disabled={loading || blockTrack}
         >
           {loading ? loadingLabel ?? t('checkingGoogleFlights') : actionLabel ?? t('showAvailableFlights')}
         </button>

--- a/apps/web/src/components/SearchBar.test.tsx
+++ b/apps/web/src/components/SearchBar.test.tsx
@@ -79,6 +79,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         return previewResponse({
           id: PREVIEW_RUN_ID,
@@ -116,6 +122,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         return previewResponse({
           id: PREVIEW_RUN_ID,
@@ -146,6 +158,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         return previewResponse({
           id: PREVIEW_RUN_ID,
@@ -172,6 +190,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         return previewResponse({
           id: PREVIEW_RUN_ID,
@@ -208,6 +232,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         // Throw to land in the SearchBar poll's catch branch.
         throw new Error('network down');

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -110,6 +110,7 @@ export function SearchBar({
   const [vpnCountries, setVpnCountries] = useState<string[]>([]);
   const [adminCurrency, setAdminCurrency] = useState<string | null>(null);
   const [maxTrackedPerRoute, setMaxTrackedPerRoute] = useState(10);
+  const [previewMaxCombos, setPreviewMaxCombos] = useState(24);
 
   const [createdTrackers, setCreatedTrackers] = useState<CreatedTracker[] | null>(null);
 
@@ -119,12 +120,23 @@ export function SearchBar({
   const [manualFormValues, setManualFormValues] = useState<ManualFormValues | null>(null);
 
   useEffect(() => {
+    fetch('/api/preview')
+      .then((r) => r.json())
+      .then((d) => {
+        if (!d.ok) return;
+        if (typeof d.data.previewMaxCombos === 'number') setPreviewMaxCombos(d.data.previewMaxCombos);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
     fetch('/api/admin/config')
       .then((r) => r.json())
       .then((d) => {
         if (!d.ok) return;
         if (d.data.defaultCurrency) setAdminCurrency(d.data.defaultCurrency);
         if (typeof d.data.maxTrackedPerRoute === 'number') setMaxTrackedPerRoute(d.data.maxTrackedPerRoute);
+        if (typeof d.data.previewMaxCombos === 'number') setPreviewMaxCombos(d.data.previewMaxCombos);
         const searchMethod = d.data.defaultSearchMethod === 'manual' ? 'manual' : 'ai';
         setActiveSearchMethod(searchMethod);
         setManualMode(searchMethod === 'manual');
@@ -647,6 +659,7 @@ export function SearchBar({
           loading={loading}
           vpnCountries={vpnCountries}
           onVpnCountriesChange={setVpnCountries}
+          previewMaxCombos={previewMaxCombos}
         />
       )}
 

--- a/apps/web/src/lib/preview-runner.test.ts
+++ b/apps/web/src/lib/preview-runner.test.ts
@@ -82,7 +82,9 @@ import {
   validatePreviewPayload,
   acquirePreviewAdmission,
   releasePreviewAdmission,
+  buildPreviewDatePairs,
 } from './preview-runner';
+import { countPreviewTasks, PREVIEW_MAX_FUTURE_DAYS, UNEQUAL_MULTI_DATE_ERROR } from './preview-utils';
 
 function makePayload(overrides: Partial<PreviewRequestPayload> = {}): PreviewRequestPayload {
   return {
@@ -394,6 +396,145 @@ describe('parsePreviewConcurrency (audit D1)', () => {
     expect(parsePreviewConcurrency('0')).toBe(3);
     expect(parsePreviewConcurrency('-5')).toBe(3);
     expect(parsePreviewConcurrency('')).toBe(3);
+  });
+});
+
+describe('buildPreviewDatePairs', () => {
+  it('broadcasts a single return date across multiple outbound dates', () => {
+    expect(
+      buildPreviewDatePairs(
+        ['2026-08-01', '2026-08-02'],
+        ['2026-08-10'],
+        '2026-08-01',
+        '2026-08-10',
+        false,
+      ),
+    ).toEqual([
+      { outboundDate: '2026-08-01', returnDate: '2026-08-10' },
+      { outboundDate: '2026-08-02', returnDate: '2026-08-10' },
+    ]);
+  });
+
+  it('broadcasts a single outbound date across multiple return dates', () => {
+    expect(
+      buildPreviewDatePairs(
+        ['2026-08-01'],
+        ['2026-08-10', '2026-08-11'],
+        '2026-08-01',
+        '2026-08-11',
+        false,
+      ),
+    ).toEqual([
+      { outboundDate: '2026-08-01', returnDate: '2026-08-10' },
+      { outboundDate: '2026-08-01', returnDate: '2026-08-11' },
+    ]);
+  });
+
+  it('pairs equal-length multi-date legs by index', () => {
+    expect(
+      buildPreviewDatePairs(
+        ['2026-08-05', '2026-08-06'],
+        ['2026-08-20', '2026-08-21'],
+        '2026-08-05',
+        '2026-08-21',
+        false,
+      ),
+    ).toEqual([
+      { outboundDate: '2026-08-05', returnDate: '2026-08-20' },
+      { outboundDate: '2026-08-06', returnDate: '2026-08-21' },
+    ]);
+  });
+
+  it('rejects unequal multi×multi date lists instead of cartesian explosion', () => {
+    expect(() =>
+      buildPreviewDatePairs(
+        ['2026-08-01', '2026-08-02'],
+        ['2026-08-10', '2026-08-11', '2026-08-12'],
+        '2026-08-01',
+        '2026-08-12',
+        false,
+      ),
+    ).toThrow(UNEQUAL_MULTI_DATE_ERROR);
+  });
+});
+
+describe('validatePreviewPayload mismatched date arrays', () => {
+  it('accepts multiple outbound dates with a single return date', () => {
+    expect(() =>
+      validatePreviewPayload(
+        makePayload({
+          tripType: 'round_trip',
+          dateFrom: '2026-08-01',
+          dateTo: '2026-08-10',
+          outboundDates: ['2026-08-01', '2026-08-02'],
+          returnDates: ['2026-08-10'],
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects unequal multi×multi outbound/return lists', () => {
+    expect(() =>
+      validatePreviewPayload(
+        makePayload({
+          tripType: 'round_trip',
+          dateFrom: '2026-08-01',
+          dateTo: '2026-08-12',
+          outboundDates: ['2026-08-01', '2026-08-02'],
+          returnDates: ['2026-08-10', '2026-08-11', '2026-08-12'],
+        }),
+      ),
+    ).toThrow(UNEQUAL_MULTI_DATE_ERROR);
+  });
+});
+
+describe('validatePreviewPayload far-future dates', () => {
+  it(`rejects previews more than ${PREVIEW_MAX_FUTURE_DAYS} days out`, () => {
+    expect(() =>
+      validatePreviewPayload(
+        makePayload({
+          tripType: 'round_trip',
+          dateFrom: '2027-08-01',
+          dateTo: '2027-08-10',
+          outboundDates: ['2027-08-01'],
+          returnDates: ['2027-08-10'],
+        }),
+      ),
+    ).toThrow(/more than 9 months out/);
+  });
+
+  it('accepts dates inside the hard future limit', () => {
+    expect(() =>
+      validatePreviewPayload(
+        makePayload({
+          tripType: 'round_trip',
+          dateFrom: '2026-09-01',
+          dateTo: '2026-09-10',
+          outboundDates: ['2026-09-01'],
+          returnDates: ['2026-09-10'],
+        }),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe('countPreviewTasks parity with validatePreviewPayload', () => {
+  it('matches the server task count for a broadcast round-trip', () => {
+    const payload = makePayload({
+      tripType: 'round_trip',
+      dateFrom: '2026-08-01',
+      dateTo: '2026-08-10',
+      outboundDates: ['2026-08-01', '2026-08-02'],
+      returnDates: ['2026-08-10'],
+      origins: [
+        { code: 'LAX', name: 'Los Angeles' },
+        { code: 'SFO', name: 'San Francisco' },
+      ],
+      destinations: [{ code: 'YOW', name: 'Ottawa' }],
+    });
+    const count = countPreviewTasks(payload.origins.length, payload.destinations.length, payload);
+    expect(count).toBe(4);
+    expect(() => validatePreviewPayload(payload)).not.toThrow();
   });
 });
 

--- a/apps/web/src/lib/preview-runner.test.ts
+++ b/apps/web/src/lib/preview-runner.test.ts
@@ -84,7 +84,12 @@ import {
   releasePreviewAdmission,
   buildPreviewDatePairs,
 } from './preview-runner';
-import { countPreviewTasks, PREVIEW_MAX_FUTURE_DAYS, UNEQUAL_MULTI_DATE_ERROR } from './preview-utils';
+import {
+  countPreviewTasks,
+  isPreviewTooFarInFuture,
+  PREVIEW_MAX_FUTURE_DAYS,
+  UNEQUAL_MULTI_DATE_ERROR,
+} from './preview-utils';
 
 function makePayload(overrides: Partial<PreviewRequestPayload> = {}): PreviewRequestPayload {
   return {
@@ -489,32 +494,55 @@ describe('validatePreviewPayload mismatched date arrays', () => {
 });
 
 describe('validatePreviewPayload far-future dates', () => {
+  const dateFromNow = (days: number): string => {
+    const date = new Date();
+    date.setUTCHours(0, 0, 0, 0);
+    date.setUTCDate(date.getUTCDate() + days);
+    return date.toISOString().split('T')[0]!;
+  };
+
   it(`rejects previews more than ${PREVIEW_MAX_FUTURE_DAYS} days out`, () => {
+    const outbound = dateFromNow(PREVIEW_MAX_FUTURE_DAYS + 30);
+    const returnDate = dateFromNow(PREVIEW_MAX_FUTURE_DAYS + 39);
     expect(() =>
       validatePreviewPayload(
         makePayload({
           tripType: 'round_trip',
-          dateFrom: '2027-08-01',
-          dateTo: '2027-08-10',
-          outboundDates: ['2027-08-01'],
-          returnDates: ['2027-08-10'],
+          dateFrom: outbound,
+          dateTo: returnDate,
+          outboundDates: [outbound],
+          returnDates: [returnDate],
         }),
       ),
     ).toThrow(/more than 9 months out/);
   });
 
   it('accepts dates inside the hard future limit', () => {
+    const outbound = dateFromNow(60);
+    const returnDate = dateFromNow(69);
     expect(() =>
       validatePreviewPayload(
         makePayload({
           tripType: 'round_trip',
-          dateFrom: '2026-09-01',
-          dateTo: '2026-09-10',
-          outboundDates: ['2026-09-01'],
-          returnDates: ['2026-09-10'],
+          dateFrom: outbound,
+          dateTo: returnDate,
+          outboundDates: [outbound],
+          returnDates: [returnDate],
         }),
       ),
     ).not.toThrow();
+  });
+
+  it('rejects an unparseable date instead of bypassing the future guard', () => {
+    expect(
+      isPreviewTooFarInFuture({
+        tripType: 'one_way',
+        dateFrom: 'not-a-date',
+        dateTo: 'not-a-date',
+        outboundDates: ['not-a-date'],
+        returnDates: [],
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/preview-runner.ts
+++ b/apps/web/src/lib/preview-runner.ts
@@ -21,9 +21,13 @@ import { isKnownAirline } from '@/lib/scraper/airline-urls';
 import { extractPrices, type ExtractionFailureReason, type PriceData } from '@/lib/scraper/extract-prices';
 import { navigateAirlineDirect, navigateGoogleFlights } from '@/lib/scraper/navigate';
 import type { Airport } from '@/lib/scraper/parse-query';
-import { expandContinuousRangeToDates } from '@/lib/scraper/scrape-dates';
+import {
+  buildPreviewDatePairs,
+  isPreviewTooFarInFuture,
+  previewTooFarInFutureMessage,
+  type PreviewDatePair,
+} from '@/lib/preview-utils';
 
-const PREVIEW_MAX_DATES = 7;
 const RETRYABLE_FAILURES: ExtractionFailureReason[] = [
   'empty_extraction',
   'page_not_loaded',
@@ -235,6 +239,8 @@ export function buildCacheKey(
   return `preview:${hash}`;
 }
 
+export { buildPreviewDatePairs, type PreviewDatePair };
+
 export function validatePreviewPayload(
   payload: PreviewRequestPayload,
   maxCombos = 24,
@@ -269,22 +275,17 @@ export function validatePreviewPayload(
   }
 
   const combos = origins.length * destinations.length;
-  // For continuous one-way ranges (no enumerated outboundDates), expand
-  // [dateFrom, dateTo] into per-day samples capped at PREVIEW_MAX_DATES so
-  // a +/- N flex query scrapes every day of the window. Round-trip continuous
-  // preview stays single-pair to fit the combos * dates <= 24 budget; the
-  // cron path does the wider grid.
-  const datesToScrape = outboundDates ?? (isOneWay
-    ? expandContinuousRangeToDates(dateFrom, dateTo, PREVIEW_MAX_DATES)
-    : [dateFrom]);
-  const totalTasks = combos * datesToScrape.length;
+  // buildPreviewDatePairs expands one-way continuous ranges and broadcasts
+  // singleton RT legs (common LLM output). Unequal multi×multi still throws.
+  const datePairs = buildPreviewDatePairs(outboundDates, returnDates, dateFrom, dateTo, isOneWay);
+  const totalTasks = combos * datePairs.length;
 
   if (totalTasks > maxCombos) {
     throw new Error(`Too many date/route combinations (${totalTasks}). Cap is ${maxCombos} (combos x dates).`);
   }
 
-  if (returnDates && outboundDates && !isOneWay && returnDates.length !== outboundDates.length) {
-    throw new Error('Return dates must match outbound dates');
+  if (isPreviewTooFarInFuture({ dateFrom, dateTo, tripType, outboundDates, returnDates })) {
+    throw new Error(previewTooFarInFutureMessage());
   }
 
   return { origins, destinations, isOneWay };
@@ -441,8 +442,13 @@ export async function runPreview(
     apiKey: resolveApiKey(provider, config),
     costs: getModelCosts(provider, model),
   };
-  const outboundDates = payload.outboundDates;
-  const returnDates = payload.returnDates;
+  const datePairs = buildPreviewDatePairs(
+    payload.outboundDates,
+    payload.returnDates,
+    dateFrom,
+    dateTo,
+    isOneWay,
+  );
 
   const combos: Array<{ origin: Airport; destination: Airport }> = [];
   for (const origin of origins) {
@@ -451,19 +457,14 @@ export async function runPreview(
     }
   }
 
-  const datesToScrape = outboundDates ?? (isOneWay
-    ? expandContinuousRangeToDates(dateFrom, dateTo, PREVIEW_MAX_DATES)
-    : [dateFrom]);
   const tasks: Array<{ combo: { origin: Airport; destination: Airport }; outboundDate: string; returnDate: string }> = [];
 
   for (const combo of combos) {
-    for (let i = 0; i < datesToScrape.length; i++) {
-      const outboundDate = datesToScrape[i]!;
-      const resolvedReturnDate = isOneWay ? outboundDate : (returnDates?.[i] ?? dateTo);
+    for (const { outboundDate, returnDate } of datePairs) {
       tasks.push({
         combo,
         outboundDate,
-        returnDate: resolvedReturnDate,
+        returnDate,
       });
     }
   }

--- a/apps/web/src/lib/preview-utils.ts
+++ b/apps/web/src/lib/preview-utils.ts
@@ -1,0 +1,119 @@
+import { expandContinuousRangeToDates } from '@/lib/scraper/scrape-dates';
+
+const PREVIEW_MAX_DATES = 7;
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/** Google Flights preview often stalls beyond ~9 months out. */
+export const PREVIEW_MAX_FUTURE_DAYS = 270;
+/** Show a UI warning when dates are far enough out that Google often stalls. */
+export const PREVIEW_FAR_FUTURE_WARN_DAYS = 120;
+
+/** Warn in the UI when a preview would fan out to this many scrapes. */
+export const PREVIEW_COMBO_WARN_THRESHOLD = 8;
+
+export const UNEQUAL_MULTI_DATE_ERROR =
+  'Unequal multi-date outbound and return lists are not supported. Use a single outbound or return date, or matching-length lists.';
+
+export interface PreviewDatePair {
+  outboundDate: string;
+  returnDate: string;
+}
+
+export interface PreviewDateFields {
+  dateFrom: string;
+  dateTo: string;
+  tripType: string;
+  outboundDates?: string[];
+  returnDates?: string[];
+}
+
+/**
+ * Build outbound/return date pairs for preview scraping.
+ *
+ * Policy:
+ * - one-way: enumerated outs, or expand continuous range (capped)
+ * - round-trip 1×N / N×1: broadcast the singleton leg (parser often returns this)
+ * - equal lengths: zip by index
+ * - unequal multi×multi: reject (avoids surprise cartesian explosion under the combo cap)
+ */
+export function buildPreviewDatePairs(
+  outboundDates: string[] | undefined,
+  returnDates: string[] | undefined,
+  dateFrom: string,
+  dateTo: string,
+  isOneWay: boolean,
+): PreviewDatePair[] {
+  if (isOneWay) {
+    const outbound = outboundDates ?? expandContinuousRangeToDates(dateFrom, dateTo, PREVIEW_MAX_DATES);
+    return outbound.map((outboundDate) => ({ outboundDate, returnDate: outboundDate }));
+  }
+
+  const outbound = outboundDates?.length ? outboundDates : [dateFrom];
+  const returns = returnDates?.length ? returnDates : [dateTo];
+
+  if (outbound.length === 1) {
+    return returns.map((returnDate) => ({ outboundDate: outbound[0]!, returnDate }));
+  }
+  if (returns.length === 1) {
+    return outbound.map((outboundDate) => ({ outboundDate, returnDate: returns[0]! }));
+  }
+  if (outbound.length === returns.length) {
+    return outbound.map((outboundDate, i) => ({ outboundDate, returnDate: returns[i]! }));
+  }
+
+  throw new Error(UNEQUAL_MULTI_DATE_ERROR);
+}
+
+export function countPreviewTasks(
+  originsCount: number,
+  destinationsCount: number,
+  fields: PreviewDateFields,
+): number {
+  const isOneWay = fields.tripType === 'one_way';
+  const datePairs = buildPreviewDatePairs(
+    fields.outboundDates,
+    fields.returnDates,
+    fields.dateFrom,
+    fields.dateTo,
+    isOneWay,
+  );
+  return originsCount * destinationsCount * datePairs.length;
+}
+
+export function farthestPreviewDate(fields: PreviewDateFields): Date {
+  const isOneWay = fields.tripType === 'one_way';
+  const datePairs = buildPreviewDatePairs(
+    fields.outboundDates,
+    fields.returnDates,
+    fields.dateFrom,
+    fields.dateTo,
+    isOneWay,
+  );
+  const allDates = datePairs.flatMap((pair) =>
+    isOneWay ? [pair.outboundDate] : [pair.outboundDate, pair.returnDate],
+  );
+  if (allDates.length === 0) {
+    return new Date(fields.dateTo + 'T00:00:00Z');
+  }
+  const sorted = [...allDates].sort();
+  return new Date(sorted[sorted.length - 1]! + 'T00:00:00Z');
+}
+
+export function daysUntilPreviewDate(date: Date, now = new Date()): number {
+  const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const targetUtc = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  return Math.ceil((targetUtc - todayUtc) / MS_PER_DAY);
+}
+
+export function isPreviewTooFarInFuture(fields: PreviewDateFields, now = new Date()): boolean {
+  return daysUntilPreviewDate(farthestPreviewDate(fields), now) > PREVIEW_MAX_FUTURE_DAYS;
+}
+
+export function isPreviewFarFutureWarn(fields: PreviewDateFields, now = new Date()): boolean {
+  return daysUntilPreviewDate(farthestPreviewDate(fields), now) > PREVIEW_FAR_FUTURE_WARN_DAYS;
+}
+
+export function previewTooFarInFutureMessage(maxDays = PREVIEW_MAX_FUTURE_DAYS): string {
+  const months = Math.round(maxDays / 30);
+  return `Preview searches more than ${months} months out often fail on Google Flights. Pick nearer dates or fewer options.`;
+}

--- a/apps/web/src/lib/preview-utils.ts
+++ b/apps/web/src/lib/preview-utils.ts
@@ -106,7 +106,8 @@ export function daysUntilPreviewDate(date: Date, now = new Date()): number {
 }
 
 export function isPreviewTooFarInFuture(fields: PreviewDateFields, now = new Date()): boolean {
-  return daysUntilPreviewDate(farthestPreviewDate(fields), now) > PREVIEW_MAX_FUTURE_DAYS;
+  const daysUntil = daysUntilPreviewDate(farthestPreviewDate(fields), now);
+  return !Number.isFinite(daysUntil) || daysUntil > PREVIEW_MAX_FUTURE_DAYS;
 }
 
 export function isPreviewFarFutureWarn(fields: PreviewDateFields, now = new Date()): boolean {


### PR DESCRIPTION
## Summary
- Accept 1×N / N×1 outbound/return date arrays in preview (common LLM output); zip equal-length lists; **reject** unequal multi×multi to avoid surprise cartesian combo blowups
- Hard-reject previews more than ~9 months out; soft-warn (~4 months) and disable Track on hard reject / over-cap / unequal multi dates
- ConfirmationCard shows lookup count + warnings (i18n’d in en/de/es/fr/pt)
- Public `GET /api/preview` returns `previewMaxCombos` so non-admin SearchBar surfaces match the server cap

## Test plan
- [ ] Round-trip with 2 outbound + 1 return dates starts preview (no “must match” error)
- [ ] 2×3 unequal multi date lists show unequal-dates notice and Track disabled
- [ ] Dates ~5 months out: soft warn, Track still enabled; dates ~10 months out: block
- [ ] Over `previewMaxCombos`: Track disabled with i18n message; anon landing page still loads the configured cap via `GET /api/preview`
- [ ] `npx vitest run src/lib/preview-runner.test.ts` passes


Made with [Cursor](https://cursor.com)