### PR TITLE
feat(preview): harden long-stay scrapes and wall-clock completion

### DIFF
--- a/apps/web/messages/de/components.json
+++ b/apps/web/messages/de/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "Der ExpressVPN-Sidecar läuft nicht. Starte Flight Finder mit VPN-Unterstützung:",
     "moreRegions": "+ {count} weitere Regionen",
     "edit": "Bearbeiten",
-    "previewTaskCount": "Diese Suche führt {count} Google-Flights-Abfragen aus ({origins} Abflüge × {destinations} Ziele × {dates} Datumspaare).",
+    "previewTaskCount": "Diese Suche führt {count, plural, one {# Google-Flights-Abfrage} other {# Google-Flights-Abfragen}} aus ({origins, plural, one {# Abflug} other {# Abflüge}} × {destinations, plural, one {# Ziel} other {# Ziele}} × {dates, plural, one {# Datumspaar} other {# Datumspaare}}).",
     "previewTaskCountWarn": "Große Vorschau ({count} Abfragen) — Google kann drosseln. Weniger Flughäfen oder Daten versuchen.",
     "previewOverComboCap": "Zu viele Kombinationen ({count}). Limit ist {cap} — Daten oder Flughäfen eingrenzen.",
     "previewFarFutureWarn": "Daten liegen mehr als etwa 4 Monate voraus — Google Flights lädt einige Routen oft nicht. Näher liegende Daten wählen.",

--- a/apps/web/messages/de/components.json
+++ b/apps/web/messages/de/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Zu den Einstellungen",
     "sidecarNotRunning": "Der ExpressVPN-Sidecar läuft nicht. Starte Flight Finder mit VPN-Unterstützung:",
     "moreRegions": "+ {count} weitere Regionen",
-    "edit": "Bearbeiten"
+    "edit": "Bearbeiten",
+    "previewTaskCount": "Diese Suche führt {count} Google-Flights-Abfragen aus ({origins} Abflüge × {destinations} Ziele × {dates} Datumspaare).",
+    "previewTaskCountWarn": "Große Vorschau ({count} Abfragen) — Google kann drosseln. Weniger Flughäfen oder Daten versuchen.",
+    "previewOverComboCap": "Zu viele Kombinationen ({count}). Limit ist {cap} — Daten oder Flughäfen eingrenzen.",
+    "previewFarFutureWarn": "Daten liegen mehr als etwa 4 Monate voraus — Google Flights lädt einige Routen oft nicht. Näher liegende Daten wählen.",
+    "previewFarFutureBlock": "Daten liegen mehr als etwa 9 Monate voraus — Google Flights liefert meist keine Ergebnisse. Näher liegende Daten wählen.",
+    "previewUnequalDates": "Hin- und Rückflugdaten passen nicht zusammen. Ein Hin- oder Rückflugdatum oder gleich lange Listen verwenden."
   },
   "DeleteTracker": {
     "deleteFailed": "Tracker konnte nicht gelöscht werden",

--- a/apps/web/messages/en/components.json
+++ b/apps/web/messages/en/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Go to Settings",
     "sidecarNotRunning": "ExpressVPN sidecar is not running. Start Flight Finder with VPN support:",
     "moreRegions": "+ {count} more regions",
-    "edit": "Edit"
+    "edit": "Edit",
+    "previewTaskCount": "This search runs {count} Google Flights lookups ({origins} origins × {destinations} destinations × {dates} date pairs).",
+    "previewTaskCountWarn": "Large preview ({count} lookups) — Google may throttle. Try one origin or fewer date options.",
+    "previewOverComboCap": "Too many combinations ({count}). Cap is {cap} — edit to narrow dates or airports.",
+    "previewFarFutureWarn": "Dates are more than about 4 months out — Google Flights often won't load results for some routes. Try nearer dates or one date pair.",
+    "previewFarFutureBlock": "Dates are more than about 9 months out — Google Flights usually will not return results. Pick nearer dates.",
+    "previewUnequalDates": "Outbound and return date lists don't line up. Use a single outbound or return date, or matching-length lists."
   },
   "DeleteTracker": {
     "deleteFailed": "Failed to delete tracker",

--- a/apps/web/messages/en/components.json
+++ b/apps/web/messages/en/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "ExpressVPN sidecar is not running. Start Flight Finder with VPN support:",
     "moreRegions": "+ {count} more regions",
     "edit": "Edit",
-    "previewTaskCount": "This search runs {count} Google Flights lookups ({origins} origins × {destinations} destinations × {dates} date pairs).",
+    "previewTaskCount": "This search runs {count, plural, one {# Google Flights lookup} other {# Google Flights lookups}} ({origins, plural, one {# origin} other {# origins}} × {destinations, plural, one {# destination} other {# destinations}} × {dates, plural, one {# date pair} other {# date pairs}}).",
     "previewTaskCountWarn": "Large preview ({count} lookups) — Google may throttle. Try one origin or fewer date options.",
     "previewOverComboCap": "Too many combinations ({count}). Cap is {cap} — edit to narrow dates or airports.",
     "previewFarFutureWarn": "Dates are more than about 4 months out — Google Flights often won't load results for some routes. Try nearer dates or one date pair.",

--- a/apps/web/messages/es/components.json
+++ b/apps/web/messages/es/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "El sidecar de ExpressVPN no está en ejecución. Inicia Flight Finder con soporte de VPN:",
     "moreRegions": "+ {count} regiones más",
     "edit": "Editar",
-    "previewTaskCount": "Esta búsqueda ejecuta {count} consultas en Google Flights ({origins} orígenes × {destinations} destinos × {dates} pares de fechas).",
+    "previewTaskCount": "Esta búsqueda ejecuta {count, plural, one {# consulta en Google Flights} other {# consultas en Google Flights}} ({origins, plural, one {# origen} other {# orígenes}} × {destinations, plural, one {# destino} other {# destinos}} × {dates, plural, one {# par de fechas} other {# pares de fechas}}).",
     "previewTaskCountWarn": "Vista previa grande ({count} consultas) — Google puede limitar. Prueba un origen o menos fechas.",
     "previewOverComboCap": "Demasiadas combinaciones ({count}). El tope es {cap} — reduce fechas o aeropuertos.",
     "previewFarFutureWarn": "Las fechas están a más de unos 4 meses — Google Flights a menudo no carga resultados. Prueba fechas más cercanas.",

--- a/apps/web/messages/es/components.json
+++ b/apps/web/messages/es/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Ir a Configuración",
     "sidecarNotRunning": "El sidecar de ExpressVPN no está en ejecución. Inicia Flight Finder con soporte de VPN:",
     "moreRegions": "+ {count} regiones más",
-    "edit": "Editar"
+    "edit": "Editar",
+    "previewTaskCount": "Esta búsqueda ejecuta {count} consultas en Google Flights ({origins} orígenes × {destinations} destinos × {dates} pares de fechas).",
+    "previewTaskCountWarn": "Vista previa grande ({count} consultas) — Google puede limitar. Prueba un origen o menos fechas.",
+    "previewOverComboCap": "Demasiadas combinaciones ({count}). El tope es {cap} — reduce fechas o aeropuertos.",
+    "previewFarFutureWarn": "Las fechas están a más de unos 4 meses — Google Flights a menudo no carga resultados. Prueba fechas más cercanas.",
+    "previewFarFutureBlock": "Las fechas están a más de unos 9 meses — Google Flights casi nunca devuelve resultados. Elige fechas más cercanas.",
+    "previewUnequalDates": "Las listas de ida y vuelta no coinciden. Usa una sola fecha de ida o vuelta, o listas de la misma longitud."
   },
   "DeleteTracker": {
     "deleteFailed": "No se pudo eliminar el rastreador",

--- a/apps/web/messages/fr/components.json
+++ b/apps/web/messages/fr/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "Le sidecar ExpressVPN n’est pas lancé. Démarre Flight Finder avec la prise en charge VPN :",
     "moreRegions": "+ {count} autres régions",
     "edit": "Modifier",
-    "previewTaskCount": "Cette recherche lance {count} requêtes Google Flights ({origins} origines × {destinations} destinations × {dates} paires de dates).",
+    "previewTaskCount": "Cette recherche lance {count, plural, one {# requête Google Flights} other {# requêtes Google Flights}} ({origins, plural, one {# origine} other {# origines}} × {destinations, plural, one {# destination} other {# destinations}} × {dates, plural, one {# paire de dates} other {# paires de dates}}).",
     "previewTaskCountWarn": "Grande prévisualisation ({count} requêtes) — Google peut limiter. Essayez une origine ou moins de dates.",
     "previewOverComboCap": "Trop de combinaisons ({count}). La limite est {cap} — réduisez les dates ou aéroports.",
     "previewFarFutureWarn": "Les dates sont à plus d’environ 4 mois — Google Flights charge souvent mal. Essayez des dates plus proches.",

--- a/apps/web/messages/fr/components.json
+++ b/apps/web/messages/fr/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Aller aux paramètres",
     "sidecarNotRunning": "Le sidecar ExpressVPN n’est pas lancé. Démarre Flight Finder avec la prise en charge VPN :",
     "moreRegions": "+ {count} autres régions",
-    "edit": "Modifier"
+    "edit": "Modifier",
+    "previewTaskCount": "Cette recherche lance {count} requêtes Google Flights ({origins} origines × {destinations} destinations × {dates} paires de dates).",
+    "previewTaskCountWarn": "Grande prévisualisation ({count} requêtes) — Google peut limiter. Essayez une origine ou moins de dates.",
+    "previewOverComboCap": "Trop de combinaisons ({count}). La limite est {cap} — réduisez les dates ou aéroports.",
+    "previewFarFutureWarn": "Les dates sont à plus d’environ 4 mois — Google Flights charge souvent mal. Essayez des dates plus proches.",
+    "previewFarFutureBlock": "Les dates sont à plus d’environ 9 mois — Google Flights ne renvoie en général aucun résultat. Choisissez des dates plus proches.",
+    "previewUnequalDates": "Les listes aller et retour ne correspondent pas. Utilisez une seule date aller ou retour, ou des listes de même longueur."
   },
   "DeleteTracker": {
     "deleteFailed": "Échec de la suppression du suivi",

--- a/apps/web/messages/pt/components.json
+++ b/apps/web/messages/pt/components.json
@@ -65,7 +65,7 @@
     "sidecarNotRunning": "O sidecar da ExpressVPN não está em execução. Inicie o Flight Finder com suporte a VPN:",
     "moreRegions": "+ {count} outras regiões",
     "edit": "Editar",
-    "previewTaskCount": "Esta busca executa {count} consultas no Google Flights ({origins} origens × {destinations} destinos × {dates} pares de datas).",
+    "previewTaskCount": "Esta busca executa {count, plural, one {# consulta no Google Flights} other {# consultas no Google Flights}} ({origins, plural, one {# origem} other {# origens}} × {destinations, plural, one {# destino} other {# destinos}} × {dates, plural, one {# par de datas} other {# pares de datas}}).",
     "previewTaskCountWarn": "Pré-visualização grande ({count} consultas) — o Google pode limitar. Tente uma origem ou menos datas.",
     "previewOverComboCap": "Demasiadas combinações ({count}). O limite é {cap} — reduza datas ou aeroportos.",
     "previewFarFutureWarn": "As datas estão a mais de cerca de 4 meses — o Google Flights muitas vezes não carrega. Tente datas mais próximas.",

--- a/apps/web/messages/pt/components.json
+++ b/apps/web/messages/pt/components.json
@@ -64,7 +64,13 @@
     "goToSettings": "Ir para Configurações",
     "sidecarNotRunning": "O sidecar da ExpressVPN não está em execução. Inicie o Flight Finder com suporte a VPN:",
     "moreRegions": "+ {count} outras regiões",
-    "edit": "Editar"
+    "edit": "Editar",
+    "previewTaskCount": "Esta busca executa {count} consultas no Google Flights ({origins} origens × {destinations} destinos × {dates} pares de datas).",
+    "previewTaskCountWarn": "Pré-visualização grande ({count} consultas) — o Google pode limitar. Tente uma origem ou menos datas.",
+    "previewOverComboCap": "Demasiadas combinações ({count}). O limite é {cap} — reduza datas ou aeroportos.",
+    "previewFarFutureWarn": "As datas estão a mais de cerca de 4 meses — o Google Flights muitas vezes não carrega. Tente datas mais próximas.",
+    "previewFarFutureBlock": "As datas estão a mais de cerca de 9 meses — o Google Flights normalmente não devolve resultados. Escolha datas mais próximas.",
+    "previewUnequalDates": "As listas de ida e volta não coincidem. Use uma única data de ida ou volta, ou listas com o mesmo comprimento."
   },
   "DeleteTracker": {
     "deleteFailed": "Falha ao excluir o rastreador",

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '@/generated/prisma/client';
 import { NextRequest } from 'next/server';
 import { apiError, apiSuccess } from '@/lib/api-response';
 import { prisma } from '@/lib/prisma';
+import { cached } from '@/lib/redis';
 import { getClientIp } from '@/lib/trusted-ip';
 import {
   ACTIVE_PREVIEW_STATUSES,
@@ -32,13 +33,18 @@ const HEARTBEAT_INTERVAL_MS = 60 * 1000;
 
 /** Public, non-sensitive preview limits for client-side validation. */
 export async function GET() {
-  const config = await prisma.extractionConfig.findFirst({
-    where: { id: 'singleton' },
-    select: { previewMaxCombos: true },
-  });
-  return apiSuccess({
-    previewMaxCombos: config?.previewMaxCombos ?? 24,
-  });
+  const config = await cached(
+    'preview:public-config',
+    async () => {
+      const stored = await prisma.extractionConfig.findFirst({
+        where: { id: 'singleton' },
+        select: { previewMaxCombos: true },
+      });
+      return { previewMaxCombos: stored?.previewMaxCombos ?? 24 };
+    },
+    300,
+  );
+  return apiSuccess(config);
 }
 
 interface PreviewRunRow {

--- a/apps/web/src/app/api/preview/route.ts
+++ b/apps/web/src/app/api/preview/route.ts
@@ -30,6 +30,17 @@ const PREVIEW_RUN_TTL_MS = 24 * 60 * 60 * 1000;
  */
 const HEARTBEAT_INTERVAL_MS = 60 * 1000;
 
+/** Public, non-sensitive preview limits for client-side validation. */
+export async function GET() {
+  const config = await prisma.extractionConfig.findFirst({
+    where: { id: 'singleton' },
+    select: { previewMaxCombos: true },
+  });
+  return apiSuccess({
+    previewMaxCombos: config?.previewMaxCombos ?? 24,
+  });
+}
+
 interface PreviewRunRow {
   id: string;
   requestHash: string;

--- a/apps/web/src/components/ConfirmationCard.module.css
+++ b/apps/web/src/components/ConfirmationCard.module.css
@@ -378,6 +378,24 @@
   color: var(--text);
 }
 
+.previewNotices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.previewNotice {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.previewNoticeWarn {
+  color: var(--warning);
+}
+
 @media (max-width: 480px) {
   .route {
     gap: 1rem;

--- a/apps/web/src/components/ConfirmationCard.tsx
+++ b/apps/web/src/components/ConfirmationCard.tsx
@@ -4,6 +4,14 @@ import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import type { Airport } from '@/lib/scraper/parse-query';
 import { formatCurrency } from '@/lib/currency';
+import {
+  buildPreviewDatePairs,
+  countPreviewTasks,
+  isPreviewFarFutureWarn,
+  isPreviewTooFarInFuture,
+  PREVIEW_COMBO_WARN_THRESHOLD,
+  UNEQUAL_MULTI_DATE_ERROR,
+} from '@/lib/preview-utils';
 import styles from './ConfirmationCard.module.css';
 
 export interface ParsedQuery {
@@ -89,6 +97,7 @@ export function ConfirmationCard({
   loadingLabel,
   vpnCountries,
   onVpnCountriesChange,
+  previewMaxCombos = 24,
 }: {
   parsed: ParsedQuery;
   onTrack: () => void;
@@ -98,6 +107,7 @@ export function ConfirmationCard({
   loadingLabel?: string;
   vpnCountries?: string[];
   onVpnCountriesChange?: (countries: string[]) => void;
+  previewMaxCombos?: number;
 }) {
   const t = useTranslations('ConfirmationCard');
   const [vpnOpen, setVpnOpen] = useState(false);
@@ -120,6 +130,34 @@ export function ConfirmationCard({
       onVpnCountriesChange([...vpnCountries, code]);
     }
   };
+
+  let previewTaskCount = 0;
+  let previewDatePairCount = 0;
+  let unequalDateError = false;
+  try {
+    previewTaskCount = countPreviewTasks(parsed.origins.length, parsed.destinations.length, parsed);
+    previewDatePairCount = buildPreviewDatePairs(
+      parsed.outboundDates,
+      parsed.returnDates,
+      parsed.dateFrom,
+      parsed.dateTo,
+      parsed.tripType === 'one_way',
+    ).length;
+  } catch (error) {
+    unequalDateError = error instanceof Error && error.message === UNEQUAL_MULTI_DATE_ERROR;
+  }
+  const showComboWarn = previewTaskCount >= PREVIEW_COMBO_WARN_THRESHOLD;
+  const showFarFutureWarn = !unequalDateError && isPreviewFarFutureWarn(parsed);
+  const overFarFuture = !unequalDateError && isPreviewTooFarInFuture(parsed);
+  const overComboCap = previewTaskCount > previewMaxCombos;
+  const blockTrack = unequalDateError || overComboCap || overFarFuture;
+  const showNotices =
+    unequalDateError ||
+    previewTaskCount > 1 ||
+    showComboWarn ||
+    showFarFutureWarn ||
+    overFarFuture ||
+    overComboCap;
 
   return (
     <div className={styles.root}>
@@ -320,11 +358,51 @@ export function ConfirmationCard({
         </div>
       )}
 
+      {(showNotices) && (
+        <div className={styles.previewNotices}>
+          {unequalDateError && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewUnequalDates')}
+            </p>
+          )}
+          {!unequalDateError && previewTaskCount > 1 && (
+            <p className={styles.previewNotice}>
+              {t('previewTaskCount', {
+                count: previewTaskCount,
+                origins: parsed.origins.length,
+                destinations: parsed.destinations.length,
+                dates: previewDatePairCount,
+              })}
+            </p>
+          )}
+          {showComboWarn && !overComboCap && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewTaskCountWarn', { count: previewTaskCount })}
+            </p>
+          )}
+          {overComboCap && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewOverComboCap', { count: previewTaskCount, cap: previewMaxCombos })}
+            </p>
+          )}
+          {overFarFuture && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewFarFutureBlock')}
+            </p>
+          )}
+          {showFarFutureWarn && !overFarFuture && (
+            <p className={`${styles.previewNotice} ${styles.previewNoticeWarn}`}>
+              {t('previewFarFutureWarn')}
+            </p>
+          )}
+        </div>
+      )}
+
       <div className={styles.actions}>
         <button
           className={styles.trackButton}
           onClick={onTrack}
-          disabled={loading}
+          disabled={loading || blockTrack}
         >
           {loading ? loadingLabel ?? t('checkingGoogleFlights') : actionLabel ?? t('showAvailableFlights')}
         </button>

--- a/apps/web/src/components/SearchBar.test.tsx
+++ b/apps/web/src/components/SearchBar.test.tsx
@@ -150,8 +150,9 @@ describe('SearchBar preview polling', () => {
     expect(screen.queryByText(/took too long/i)).not.toBeInTheDocument();
   });
 
-  it('fires cutoff error when status is still running past the 30 min window', async () => {
-    // startedAt one second past the 30 min window, status stays running.
+  it('renews the cutoff lease while the backend still reports an active run', async () => {
+    // A final task may continue past the scheduling deadline. A healthy status
+    // response keeps the client attached instead of discarding its later result.
     const past = Date.now() - POLL_TIMEOUT_MS - 1000;
     window.sessionStorage.setItem(PREVIEW_STORAGE_KEY, JSON.stringify(savedPreview({ startedAt: past })));
 
@@ -180,8 +181,10 @@ describe('SearchBar preview polling', () => {
     render(<SearchBar />);
 
     await waitFor(() => {
-      expect(screen.getByText(/took too long/i)).toBeInTheDocument();
+      const saved = JSON.parse(window.sessionStorage.getItem(PREVIEW_STORAGE_KEY) ?? '{}');
+      expect(saved.startedAt).toBeGreaterThan(past);
     });
+    expect(screen.queryByText(/took too long/i)).not.toBeInTheDocument();
   });
 
   it('keeps polling without firing cutoff when status is running within the window', async () => {

--- a/apps/web/src/components/SearchBar.test.tsx
+++ b/apps/web/src/components/SearchBar.test.tsx
@@ -79,6 +79,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         return previewResponse({
           id: PREVIEW_RUN_ID,
@@ -116,6 +122,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         return previewResponse({
           id: PREVIEW_RUN_ID,
@@ -146,6 +158,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         return previewResponse({
           id: PREVIEW_RUN_ID,
@@ -172,6 +190,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         return previewResponse({
           id: PREVIEW_RUN_ID,
@@ -208,6 +232,12 @@ describe('SearchBar preview polling', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === '/api/admin/config') return configResponse();
+      if (url === '/api/preview') {
+        return new Response(JSON.stringify({ ok: true, data: { previewMaxCombos: 24 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/preview/')) {
         // Throw to land in the SearchBar poll's catch branch.
         throw new Error('network down');

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import type { ParseAmbiguity, ParsedFlightQuery } from '@/lib/scraper/parse-query';
 import type { ConversationMessage } from '@/lib/clarification-types';
-import type { PreviewRunStatusPayload } from '@/lib/preview-run';
+import { PREVIEW_WALL_CLOCK_MS, type PreviewRunStatusPayload } from '@/lib/preview-run';
 import type { PriceData } from '@/lib/scraper/extract-prices';
 import { detectLocaleCurrency } from '@/lib/currency';
 import { addSavedTracker } from '@/lib/tracker-storage';
@@ -17,7 +17,7 @@ import { ManualEntryForm, type ManualFormValues } from './ManualEntryForm';
 
 // "ft-" prefix kept across the Flight Finder rename so existing browsers preserve state.
 const PREVIEW_STORAGE_KEY_BASE = 'ft-preview-run';
-const PREVIEW_POLL_TIMEOUT_MS = 30 * 60 * 1000;
+const PREVIEW_POLL_TIMEOUT_MS = PREVIEW_WALL_CLOCK_MS + 2 * 60 * 1000;
 
 function previewStorageKey(surface: SearchSurface): string {
   return surface === 'admin' ? `${PREVIEW_STORAGE_KEY_BASE}-admin` : PREVIEW_STORAGE_KEY_BASE;

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -110,6 +110,7 @@ export function SearchBar({
   const [vpnCountries, setVpnCountries] = useState<string[]>([]);
   const [adminCurrency, setAdminCurrency] = useState<string | null>(null);
   const [maxTrackedPerRoute, setMaxTrackedPerRoute] = useState(10);
+  const [previewMaxCombos, setPreviewMaxCombos] = useState(24);
 
   const [createdTrackers, setCreatedTrackers] = useState<CreatedTracker[] | null>(null);
 
@@ -119,12 +120,23 @@ export function SearchBar({
   const [manualFormValues, setManualFormValues] = useState<ManualFormValues | null>(null);
 
   useEffect(() => {
+    fetch('/api/preview')
+      .then((r) => r.json())
+      .then((d) => {
+        if (!d.ok) return;
+        if (typeof d.data.previewMaxCombos === 'number') setPreviewMaxCombos(d.data.previewMaxCombos);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
     fetch('/api/admin/config')
       .then((r) => r.json())
       .then((d) => {
         if (!d.ok) return;
         if (d.data.defaultCurrency) setAdminCurrency(d.data.defaultCurrency);
         if (typeof d.data.maxTrackedPerRoute === 'number') setMaxTrackedPerRoute(d.data.maxTrackedPerRoute);
+        if (typeof d.data.previewMaxCombos === 'number') setPreviewMaxCombos(d.data.previewMaxCombos);
         const searchMethod = d.data.defaultSearchMethod === 'manual' ? 'manual' : 'ai';
         setActiveSearchMethod(searchMethod);
         setManualMode(searchMethod === 'manual');
@@ -647,6 +659,7 @@ export function SearchBar({
           loading={loading}
           vpnCountries={vpnCountries}
           onVpnCountriesChange={setVpnCountries}
+          previewMaxCombos={previewMaxCombos}
         />
       )}
 

--- a/apps/web/src/components/SearchBar.tsx
+++ b/apps/web/src/components/SearchBar.tsx
@@ -17,6 +17,9 @@ import { ManualEntryForm, type ManualFormValues } from './ManualEntryForm';
 
 // "ft-" prefix kept across the Flight Finder rename so existing browsers preserve state.
 const PREVIEW_STORAGE_KEY_BASE = 'ft-preview-run';
+// This is an inactivity cutoff, not a hard runtime cap. A successful active
+// status response renews the timestamp so an in-flight final task cannot make
+// the client give up while the server is still healthy.
 const PREVIEW_POLL_TIMEOUT_MS = PREVIEW_WALL_CLOCK_MS + 2 * 60 * 1000;
 
 function previewStorageKey(surface: SearchSurface): string {
@@ -264,6 +267,15 @@ export function SearchBar({
           setPreviewRunId(null);
           clearSavedPreview(storageKey);
           return;
+        }
+
+        // The server can finish a task that started just before its 12-minute
+        // scheduling deadline. Keep the client attached while status polling
+        // confirms that run is still active; the cutoff remains effective for
+        // sustained network failures and abandoned saved runs.
+        const saved = readSavedPreview(storageKey);
+        if (saved) {
+          writeSavedPreview(storageKey, { ...saved, startedAt: Date.now() });
         }
 
         if (checkCutoff()) return;

--- a/apps/web/src/lib/preview-run.ts
+++ b/apps/web/src/lib/preview-run.ts
@@ -55,6 +55,10 @@ export interface PreviewRunStatusPayload {
  */
 export const PREVIEW_ACTIVE_TIMEOUT_MS = 30 * 60 * 1000;
 export const PREVIEW_TIMEOUT_ERROR = 'Preview run timed out before completing';
+/** Soft wall-clock for in-process preview worker pool (between tasks). */
+export const PREVIEW_WALL_CLOCK_MS = 12 * 60 * 1000;
+export const PREVIEW_WALL_CLOCK_ERROR =
+  'Preview hit the 12 minute wall-clock limit before all routes finished';
 export const ACTIVE_PREVIEW_STATUSES = ['pending', 'running'] as const;
 export const TERMINAL_PREVIEW_STATUSES = ['completed', 'failed'] as const;
 export type ActivePreviewStatus = typeof ACTIVE_PREVIEW_STATUSES[number];

--- a/apps/web/src/lib/preview-runner.test.ts
+++ b/apps/web/src/lib/preview-runner.test.ts
@@ -82,7 +82,9 @@ import {
   validatePreviewPayload,
   acquirePreviewAdmission,
   releasePreviewAdmission,
+  buildPreviewDatePairs,
 } from './preview-runner';
+import { countPreviewTasks, PREVIEW_MAX_FUTURE_DAYS, UNEQUAL_MULTI_DATE_ERROR } from './preview-utils';
 
 function makePayload(overrides: Partial<PreviewRequestPayload> = {}): PreviewRequestPayload {
   return {
@@ -394,6 +396,145 @@ describe('parsePreviewConcurrency (audit D1)', () => {
     expect(parsePreviewConcurrency('0')).toBe(3);
     expect(parsePreviewConcurrency('-5')).toBe(3);
     expect(parsePreviewConcurrency('')).toBe(3);
+  });
+});
+
+describe('buildPreviewDatePairs', () => {
+  it('broadcasts a single return date across multiple outbound dates', () => {
+    expect(
+      buildPreviewDatePairs(
+        ['2026-08-01', '2026-08-02'],
+        ['2026-08-10'],
+        '2026-08-01',
+        '2026-08-10',
+        false,
+      ),
+    ).toEqual([
+      { outboundDate: '2026-08-01', returnDate: '2026-08-10' },
+      { outboundDate: '2026-08-02', returnDate: '2026-08-10' },
+    ]);
+  });
+
+  it('broadcasts a single outbound date across multiple return dates', () => {
+    expect(
+      buildPreviewDatePairs(
+        ['2026-08-01'],
+        ['2026-08-10', '2026-08-11'],
+        '2026-08-01',
+        '2026-08-11',
+        false,
+      ),
+    ).toEqual([
+      { outboundDate: '2026-08-01', returnDate: '2026-08-10' },
+      { outboundDate: '2026-08-01', returnDate: '2026-08-11' },
+    ]);
+  });
+
+  it('pairs equal-length multi-date legs by index', () => {
+    expect(
+      buildPreviewDatePairs(
+        ['2026-08-05', '2026-08-06'],
+        ['2026-08-20', '2026-08-21'],
+        '2026-08-05',
+        '2026-08-21',
+        false,
+      ),
+    ).toEqual([
+      { outboundDate: '2026-08-05', returnDate: '2026-08-20' },
+      { outboundDate: '2026-08-06', returnDate: '2026-08-21' },
+    ]);
+  });
+
+  it('rejects unequal multi×multi date lists instead of cartesian explosion', () => {
+    expect(() =>
+      buildPreviewDatePairs(
+        ['2026-08-01', '2026-08-02'],
+        ['2026-08-10', '2026-08-11', '2026-08-12'],
+        '2026-08-01',
+        '2026-08-12',
+        false,
+      ),
+    ).toThrow(UNEQUAL_MULTI_DATE_ERROR);
+  });
+});
+
+describe('validatePreviewPayload mismatched date arrays', () => {
+  it('accepts multiple outbound dates with a single return date', () => {
+    expect(() =>
+      validatePreviewPayload(
+        makePayload({
+          tripType: 'round_trip',
+          dateFrom: '2026-08-01',
+          dateTo: '2026-08-10',
+          outboundDates: ['2026-08-01', '2026-08-02'],
+          returnDates: ['2026-08-10'],
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects unequal multi×multi outbound/return lists', () => {
+    expect(() =>
+      validatePreviewPayload(
+        makePayload({
+          tripType: 'round_trip',
+          dateFrom: '2026-08-01',
+          dateTo: '2026-08-12',
+          outboundDates: ['2026-08-01', '2026-08-02'],
+          returnDates: ['2026-08-10', '2026-08-11', '2026-08-12'],
+        }),
+      ),
+    ).toThrow(UNEQUAL_MULTI_DATE_ERROR);
+  });
+});
+
+describe('validatePreviewPayload far-future dates', () => {
+  it(`rejects previews more than ${PREVIEW_MAX_FUTURE_DAYS} days out`, () => {
+    expect(() =>
+      validatePreviewPayload(
+        makePayload({
+          tripType: 'round_trip',
+          dateFrom: '2027-08-01',
+          dateTo: '2027-08-10',
+          outboundDates: ['2027-08-01'],
+          returnDates: ['2027-08-10'],
+        }),
+      ),
+    ).toThrow(/more than 9 months out/);
+  });
+
+  it('accepts dates inside the hard future limit', () => {
+    expect(() =>
+      validatePreviewPayload(
+        makePayload({
+          tripType: 'round_trip',
+          dateFrom: '2026-09-01',
+          dateTo: '2026-09-10',
+          outboundDates: ['2026-09-01'],
+          returnDates: ['2026-09-10'],
+        }),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe('countPreviewTasks parity with validatePreviewPayload', () => {
+  it('matches the server task count for a broadcast round-trip', () => {
+    const payload = makePayload({
+      tripType: 'round_trip',
+      dateFrom: '2026-08-01',
+      dateTo: '2026-08-10',
+      outboundDates: ['2026-08-01', '2026-08-02'],
+      returnDates: ['2026-08-10'],
+      origins: [
+        { code: 'LAX', name: 'Los Angeles' },
+        { code: 'SFO', name: 'San Francisco' },
+      ],
+      destinations: [{ code: 'YOW', name: 'Ottawa' }],
+    });
+    const count = countPreviewTasks(payload.origins.length, payload.destinations.length, payload);
+    expect(count).toBe(4);
+    expect(() => validatePreviewPayload(payload)).not.toThrow();
   });
 });
 

--- a/apps/web/src/lib/preview-runner.test.ts
+++ b/apps/web/src/lib/preview-runner.test.ts
@@ -566,6 +566,70 @@ describe('countPreviewTasks parity with validatePreviewPayload', () => {
   });
 });
 
+describe('runPreview long-stay split one-way failures', () => {
+  it('keeps return-shell errors on the canonical route and logs both extracted legs', async () => {
+    mockExtractionConfigFindFirst.mockResolvedValue({
+      id: 'singleton',
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5-20251001',
+      defaultCurrency: 'USD',
+      previewConcurrency: 1,
+    });
+    mockNavigateGoogleFlights
+      .mockResolvedValueOnce({
+        html: '<html>outbound results</html>',
+        url: 'https://google.com/flights/outbound',
+        source: 'google_flights',
+        resultsFound: true,
+      })
+      .mockResolvedValueOnce({
+        html: '<html>Loading results…</html>',
+        url: 'https://google.com/flights/return',
+        source: 'google_flights',
+        resultsFound: false,
+      });
+    mockExtractPrices
+      .mockResolvedValueOnce({
+        prices: [priceData('AA', 250)],
+        usage: { inputTokens: 100, outputTokens: 50 },
+        failureReason: undefined,
+      })
+      .mockResolvedValueOnce({
+        prices: [],
+        usage: { inputTokens: 80, outputTokens: 20 },
+        failureReason: 'page_not_loaded',
+      });
+
+    await expect(
+      runPreview(
+        makePayload({
+          tripType: 'round_trip',
+          dateFrom: '2026-08-01',
+          dateTo: '2026-09-01',
+          outboundDates: ['2026-08-01', '2026-08-02'],
+          returnDates: ['2026-09-01'],
+          origins: [{ code: 'LAX', name: 'Los Angeles' }],
+          destinations: [{ code: 'YOW', name: 'Ottawa' }],
+        }),
+        { concurrency: 1 },
+      ),
+    ).rejects.toThrow('LAX→YOW');
+
+    expect(mockNavigateGoogleFlights).toHaveBeenCalledTimes(2);
+    expect(mockApiUsageLogCreate).toHaveBeenCalledTimes(2);
+    expect(mockApiUsageLogCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          inputTokens: 80,
+          outputTokens: 20,
+          durationMs: expect.any(Number),
+        }),
+      }),
+    );
+  });
+});
+
 describe('validatePreviewPayload combo cap (issue #89, configurable)', () => {
   // 5 origins x 6 destinations x 1 date = 30 combos.
   const wideFlexPayload = makePayload({

--- a/apps/web/src/lib/preview-runner.test.ts
+++ b/apps/web/src/lib/preview-runner.test.ts
@@ -84,7 +84,12 @@ import {
   releasePreviewAdmission,
   buildPreviewDatePairs,
 } from './preview-runner';
-import { countPreviewTasks, PREVIEW_MAX_FUTURE_DAYS, UNEQUAL_MULTI_DATE_ERROR } from './preview-utils';
+import {
+  countPreviewTasks,
+  isPreviewTooFarInFuture,
+  PREVIEW_MAX_FUTURE_DAYS,
+  UNEQUAL_MULTI_DATE_ERROR,
+} from './preview-utils';
 
 function makePayload(overrides: Partial<PreviewRequestPayload> = {}): PreviewRequestPayload {
   return {
@@ -489,32 +494,55 @@ describe('validatePreviewPayload mismatched date arrays', () => {
 });
 
 describe('validatePreviewPayload far-future dates', () => {
+  const dateFromNow = (days: number): string => {
+    const date = new Date();
+    date.setUTCHours(0, 0, 0, 0);
+    date.setUTCDate(date.getUTCDate() + days);
+    return date.toISOString().split('T')[0]!;
+  };
+
   it(`rejects previews more than ${PREVIEW_MAX_FUTURE_DAYS} days out`, () => {
+    const outbound = dateFromNow(PREVIEW_MAX_FUTURE_DAYS + 30);
+    const returnDate = dateFromNow(PREVIEW_MAX_FUTURE_DAYS + 39);
     expect(() =>
       validatePreviewPayload(
         makePayload({
           tripType: 'round_trip',
-          dateFrom: '2027-08-01',
-          dateTo: '2027-08-10',
-          outboundDates: ['2027-08-01'],
-          returnDates: ['2027-08-10'],
+          dateFrom: outbound,
+          dateTo: returnDate,
+          outboundDates: [outbound],
+          returnDates: [returnDate],
         }),
       ),
     ).toThrow(/more than 9 months out/);
   });
 
   it('accepts dates inside the hard future limit', () => {
+    const outbound = dateFromNow(60);
+    const returnDate = dateFromNow(69);
     expect(() =>
       validatePreviewPayload(
         makePayload({
           tripType: 'round_trip',
-          dateFrom: '2026-09-01',
-          dateTo: '2026-09-10',
-          outboundDates: ['2026-09-01'],
-          returnDates: ['2026-09-10'],
+          dateFrom: outbound,
+          dateTo: returnDate,
+          outboundDates: [outbound],
+          returnDates: [returnDate],
         }),
       ),
     ).not.toThrow();
+  });
+
+  it('rejects an unparseable date instead of bypassing the future guard', () => {
+    expect(
+      isPreviewTooFarInFuture({
+        tripType: 'one_way',
+        dateFrom: 'not-a-date',
+        dateTo: 'not-a-date',
+        outboundDates: ['not-a-date'],
+        returnDates: [],
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/preview-runner.ts
+++ b/apps/web/src/lib/preview-runner.ts
@@ -21,9 +21,13 @@ import { isKnownAirline } from '@/lib/scraper/airline-urls';
 import { extractPrices, type ExtractionFailureReason, type PriceData } from '@/lib/scraper/extract-prices';
 import { navigateAirlineDirect, navigateGoogleFlights } from '@/lib/scraper/navigate';
 import type { Airport } from '@/lib/scraper/parse-query';
-import { expandContinuousRangeToDates } from '@/lib/scraper/scrape-dates';
+import {
+  buildPreviewDatePairs,
+  isPreviewTooFarInFuture,
+  previewTooFarInFutureMessage,
+  type PreviewDatePair,
+} from '@/lib/preview-utils';
 
-const PREVIEW_MAX_DATES = 7;
 const RETRYABLE_FAILURES: ExtractionFailureReason[] = [
   'empty_extraction',
   'page_not_loaded',
@@ -235,6 +239,8 @@ export function buildCacheKey(
   return `preview:${hash}`;
 }
 
+export { buildPreviewDatePairs, type PreviewDatePair };
+
 export function validatePreviewPayload(
   payload: PreviewRequestPayload,
   maxCombos = 24,
@@ -269,22 +275,17 @@ export function validatePreviewPayload(
   }
 
   const combos = origins.length * destinations.length;
-  // For continuous one-way ranges (no enumerated outboundDates), expand
-  // [dateFrom, dateTo] into per-day samples capped at PREVIEW_MAX_DATES so
-  // a +/- N flex query scrapes every day of the window. Round-trip continuous
-  // preview stays single-pair to fit the combos * dates <= 24 budget; the
-  // cron path does the wider grid.
-  const datesToScrape = outboundDates ?? (isOneWay
-    ? expandContinuousRangeToDates(dateFrom, dateTo, PREVIEW_MAX_DATES)
-    : [dateFrom]);
-  const totalTasks = combos * datesToScrape.length;
+  // buildPreviewDatePairs expands one-way continuous ranges and broadcasts
+  // singleton RT legs (common LLM output). Unequal multi×multi still throws.
+  const datePairs = buildPreviewDatePairs(outboundDates, returnDates, dateFrom, dateTo, isOneWay);
+  const totalTasks = combos * datePairs.length;
 
   if (totalTasks > maxCombos) {
     throw new Error(`Too many date/route combinations (${totalTasks}). Cap is ${maxCombos} (combos x dates).`);
   }
 
-  if (returnDates && outboundDates && !isOneWay && returnDates.length !== outboundDates.length) {
-    throw new Error('Return dates must match outbound dates');
+  if (isPreviewTooFarInFuture({ dateFrom, dateTo, tripType, outboundDates, returnDates })) {
+    throw new Error(previewTooFarInFutureMessage());
   }
 
   return { origins, destinations, isOneWay };
@@ -441,8 +442,13 @@ export async function runPreview(
     apiKey: resolveApiKey(provider, config),
     costs: getModelCosts(provider, model),
   };
-  const outboundDates = payload.outboundDates;
-  const returnDates = payload.returnDates;
+  const datePairs = buildPreviewDatePairs(
+    payload.outboundDates,
+    payload.returnDates,
+    dateFrom,
+    dateTo,
+    isOneWay,
+  );
 
   const combos: Array<{ origin: Airport; destination: Airport }> = [];
   for (const origin of origins) {
@@ -451,19 +457,14 @@ export async function runPreview(
     }
   }
 
-  const datesToScrape = outboundDates ?? (isOneWay
-    ? expandContinuousRangeToDates(dateFrom, dateTo, PREVIEW_MAX_DATES)
-    : [dateFrom]);
   const tasks: Array<{ combo: { origin: Airport; destination: Airport }; outboundDate: string; returnDate: string }> = [];
 
   for (const combo of combos) {
-    for (let i = 0; i < datesToScrape.length; i++) {
-      const outboundDate = datesToScrape[i]!;
-      const resolvedReturnDate = isOneWay ? outboundDate : (returnDates?.[i] ?? dateTo);
+    for (const { outboundDate, returnDate } of datePairs) {
       tasks.push({
         combo,
         outboundDate,
-        returnDate: resolvedReturnDate,
+        returnDate,
       });
     }
   }

--- a/apps/web/src/lib/preview-runner.ts
+++ b/apps/web/src/lib/preview-runner.ts
@@ -312,6 +312,7 @@ async function scrapeGoogleOneWayLeg(
   inputTokens: number;
   outputTokens: number;
 }> {
+  const startedAt = Date.now();
   const searchParams = {
     origin,
     destination,
@@ -349,15 +350,31 @@ async function scrapeGoogleOneWayLeg(
     },
   );
 
+  const { provider, model, costs } = params.context;
+  const inputTokens = usage.inputTokens;
+  const outputTokens = usage.outputTokens;
+  const cost = (inputTokens / 1000) * costs.costPer1kInput + (outputTokens / 1000) * costs.costPer1kOutput;
+  await prisma.apiUsageLog.create({
+    data: {
+      provider,
+      model,
+      inputTokens,
+      outputTokens,
+      costUsd: cost,
+      operation: 'preview-flights',
+      durationMs: Date.now() - startedAt,
+    },
+  });
+
   if (failureReason === 'page_not_loaded' && isGoogleFlightsLoadingShell(nav.html, nav.resultsFound)) {
-    throw new GoogleFlightsLoadingShellError(origin, destination);
+    throw new GoogleFlightsLoadingShellError(params.origin, params.destination);
   }
 
   return {
     prices,
     failureReason,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
+    inputTokens,
+    outputTokens,
   };
 }
 
@@ -370,28 +387,11 @@ async function scrapeGoogleOneWayLeg(
 async function scrapeLongStaySplitOneWays(params: ScrapeRouteParams): Promise<PriceData[]> {
   const { origin, destination, dateFrom, dateTo, dateFromStr } = params;
   const dateToStr = dateTo.toISOString().split('T')[0]!;
-  const { provider, model, costs } = params.context;
 
   console.log(`[preview] ${origin}->${destination} using split one-way scrape for long stay (${dateFromStr} / ${dateToStr})`);
 
   const outbound = await scrapeGoogleOneWayLeg(params, origin, destination, dateFrom, dateFromStr);
   const inbound = await scrapeGoogleOneWayLeg(params, destination, origin, dateTo, dateToStr);
-
-  const inputTokens = outbound.inputTokens + inbound.inputTokens;
-  const outputTokens = outbound.outputTokens + inbound.outputTokens;
-  const cost = (inputTokens / 1000) * costs.costPer1kInput + (outputTokens / 1000) * costs.costPer1kOutput;
-
-  await prisma.apiUsageLog.create({
-    data: {
-      provider,
-      model,
-      inputTokens,
-      outputTokens,
-      costUsd: cost,
-      operation: 'preview-flights',
-      durationMs: 0,
-    },
-  });
 
   if (outbound.failureReason || outbound.prices.length === 0) {
     throw new Error(`Could not load outbound flights for ${origin}→${destination}`);

--- a/apps/web/src/lib/preview-runner.ts
+++ b/apps/web/src/lib/preview-runner.ts
@@ -11,6 +11,8 @@ import { prisma } from '@/lib/prisma';
 import { cached, redis } from '@/lib/redis';
 import {
   PREVIEW_ACTIVE_TIMEOUT_MS,
+  PREVIEW_WALL_CLOCK_MS,
+  PREVIEW_WALL_CLOCK_ERROR,
   type PreviewRequestPayload,
   type PreviewResultPayload,
   type RouteResultPayload,
@@ -23,6 +25,10 @@ import { navigateAirlineDirect, navigateGoogleFlights } from '@/lib/scraper/navi
 import type { Airport } from '@/lib/scraper/parse-query';
 import {
   buildPreviewDatePairs,
+  GoogleFlightsLoadingShellError,
+  googleFlightsLoadingShellMessage,
+  isGoogleFlightsLoadingShell,
+  isGoogleFlightsLoadingShellError,
   isPreviewTooFarInFuture,
   previewTooFarInFutureMessage,
   type PreviewDatePair,
@@ -38,6 +44,9 @@ const RETRYABLE_FAILURES: ExtractionFailureReason[] = [
 const MAX_ATTEMPTS = 2;
 const DEBUG_DIR = '/tmp/flight-finder-debug';
 const PREVIEW_MAX_RESULTS = 20;
+/** Google Flights round-trip phrase URLs hang on "Loading results" past this stay length. */
+const GOOGLE_RT_LONG_STAY_DAYS = 14;
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 /**
  * Default max concurrent scrapeRoute calls. Each scrapeRoute launches a
@@ -291,8 +300,129 @@ export function validatePreviewPayload(
   return { origins, destinations, isOneWay };
 }
 
+async function scrapeGoogleOneWayLeg(
+  params: ScrapeRouteParams,
+  origin: string,
+  destination: string,
+  travelDate: Date,
+  travelDateStr: string,
+): Promise<{
+  prices: PriceData[];
+  failureReason?: ExtractionFailureReason;
+  inputTokens: number;
+  outputTokens: number;
+}> {
+  const searchParams = {
+    origin,
+    destination,
+    dateFrom: travelDate,
+    dateTo: travelDate,
+    cabinClass: params.cabinClass,
+    tripType: 'one_way' as const,
+    currency: params.currency,
+  };
+  const filters = {
+    maxPrice: params.maxPrice,
+    maxStops: params.maxStops,
+    maxDurationHours: params.maxDurationHours,
+    preferredAirlines: params.preferredAirlines,
+    timePreference: params.timePreference,
+    cabinClass: params.cabinClass,
+  };
+
+  const nav = await navigateGoogleFlights(searchParams);
+  const { prices, usage, failureReason } = await extractPrices(
+    nav.html,
+    nav.url,
+    travelDateStr,
+    filters,
+    PREVIEW_MAX_RESULTS,
+    nav.resultsFound,
+    nav.source,
+    params.currency,
+    {
+      provider: params.context.provider,
+      model: params.context.model,
+      customBaseUrl: params.context.customBaseUrl,
+      extractTimeoutSeconds: params.context.extractTimeoutSeconds,
+      apiKey: params.context.apiKey,
+    },
+  );
+
+  if (failureReason === 'page_not_loaded' && isGoogleFlightsLoadingShell(nav.html, nav.resultsFound)) {
+    throw new GoogleFlightsLoadingShellError(origin, destination);
+  }
+
+  return {
+    prices,
+    failureReason,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+  };
+}
+
+/**
+ * Google Flights round-trip phrase URLs hang forever on stays longer than
+ * ~14 days. One-way legs for the same dates still load, so we scrape outbound
+ * + return separately and sum the cheapest return into each outbound option
+ * as an approximate round-trip total.
+ */
+async function scrapeLongStaySplitOneWays(params: ScrapeRouteParams): Promise<PriceData[]> {
+  const { origin, destination, dateFrom, dateTo, dateFromStr } = params;
+  const dateToStr = dateTo.toISOString().split('T')[0]!;
+  const { provider, model, costs } = params.context;
+
+  console.log(`[preview] ${origin}->${destination} using split one-way scrape for long stay (${dateFromStr} / ${dateToStr})`);
+
+  const outbound = await scrapeGoogleOneWayLeg(params, origin, destination, dateFrom, dateFromStr);
+  const inbound = await scrapeGoogleOneWayLeg(params, destination, origin, dateTo, dateToStr);
+
+  const inputTokens = outbound.inputTokens + inbound.inputTokens;
+  const outputTokens = outbound.outputTokens + inbound.outputTokens;
+  const cost = (inputTokens / 1000) * costs.costPer1kInput + (outputTokens / 1000) * costs.costPer1kOutput;
+
+  await prisma.apiUsageLog.create({
+    data: {
+      provider,
+      model,
+      inputTokens,
+      outputTokens,
+      costUsd: cost,
+      operation: 'preview-flights',
+      durationMs: 0,
+    },
+  });
+
+  if (outbound.failureReason || outbound.prices.length === 0) {
+    throw new Error(`Could not load outbound flights for ${origin}→${destination}`);
+  }
+  if (inbound.failureReason || inbound.prices.length === 0) {
+    throw new Error(`Could not load return flights for ${destination}→${origin}`);
+  }
+
+  const cheapestReturn = Math.min(...inbound.prices.map((f) => f.price));
+  const returnAirline = inbound.prices.find((f) => f.price === cheapestReturn)?.airline ?? 'return';
+  // Booking URL is outbound-only; OW+OW totals are approximate (true RT may differ).
+  const combined = outbound.prices.map((flight) => ({
+    ...flight,
+    price: flight.price + cheapestReturn,
+    airline: `${flight.airline} + ${returnAirline} (approx OW+OW)`,
+  }));
+
+  console.log(
+    `[preview] ${origin}->${destination} OK via split one-ways - ${combined.length} options (cheapest return $${cheapestReturn})`,
+  );
+  return combined;
+}
+
 async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
   const { origin, destination, dateFrom, dateTo, dateFromStr, cabinClass, tripType } = params;
+
+  const stayDays = Math.round((dateTo.getTime() - dateFrom.getTime()) / MS_PER_DAY);
+  const isLongStayRoundTrip = tripType !== 'one_way' && stayDays > GOOGLE_RT_LONG_STAY_DAYS;
+  if (isLongStayRoundTrip) {
+    return scrapeLongStaySplitOneWays(params);
+  }
 
   const searchParams = { origin, destination, dateFrom, dateTo, cabinClass, tripType, currency: params.currency };
   const airlines = params.preferredAirlines;
@@ -312,6 +442,7 @@ async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
   let totalOutputTokens = 0;
   let lastFailureReason: ExtractionFailureReason | undefined;
   let lastSource = 'google_flights';
+  let hitLoadingShell = false;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     console.log(`[preview] ${origin}->${destination} attempt ${attempt}/${MAX_ATTEMPTS}`);
@@ -372,6 +503,12 @@ async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
 
     lastFailureReason = failureReason;
 
+    if (failureReason === 'page_not_loaded' && isGoogleFlightsLoadingShell(nav.html, nav.resultsFound)) {
+      hitLoadingShell = true;
+      console.log(`[preview] ${origin}->${destination} stuck on Google loading shell — trying split one-way fallback`);
+      break;
+    }
+
     try {
       await mkdir(DEBUG_DIR, { recursive: true });
       const ts = new Date().toISOString().replace(/[:.]/g, '-');
@@ -394,6 +531,12 @@ async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
     }
   }
 
+  // Loading-shell on a shorter RT (or edge-case long stay that slipped past
+  // the proactive path): split into one-ways before surfacing an error.
+  if (hitLoadingShell && tripType !== 'one_way') {
+    return scrapeLongStaySplitOneWays(params);
+  }
+
   const totalCost =
     (totalInputTokens / 1000) * costs.costPer1kInput +
     (totalOutputTokens / 1000) * costs.costPer1kOutput;
@@ -410,6 +553,10 @@ async function scrapeRoute(params: ScrapeRouteParams): Promise<PriceData[]> {
       error: `[${lastFailureReason}] ${origin} -> ${destination}`,
     },
   });
+
+  if (hitLoadingShell && lastFailureReason === 'page_not_loaded') {
+    throw new GoogleFlightsLoadingShellError(origin, destination);
+  }
 
   const sourceName = lastSource === 'airline_direct' ? 'The airline website' : 'Google Flights';
   const messages: Record<string, string> = {
@@ -471,10 +618,34 @@ export async function runPreview(
 
   const routes: RouteResult[] = new Array(tasks.length);
   let nextIndex = 0;
+  const loadingShellRoutes = new Set<string>();
 
   const runOne = async (taskIndex: number): Promise<void> => {
     const task = tasks[taskIndex]!;
     const { combo, outboundDate, returnDate } = task;
+    const routeKey = `${combo.origin.code}-${combo.destination.code}`;
+
+    if (loadingShellRoutes.has(routeKey)) {
+      routes[taskIndex] = {
+        origin: combo.origin.code,
+        originName: combo.origin.name,
+        destination: combo.destination.code,
+        destinationName: combo.destination.name,
+        flights: [],
+        date: outboundDate,
+        returnDate,
+        error: googleFlightsLoadingShellMessage(combo.origin.code, combo.destination.code),
+      };
+      if (options.onTaskComplete) {
+        try {
+          await options.onTaskComplete();
+        } catch (callbackError) {
+          console.error('[preview] onTaskComplete callback threw', callbackError);
+        }
+      }
+      return;
+    }
+
     const taskFrom = new Date(outboundDate + 'T00:00:00Z');
     const taskTo = new Date(returnDate + 'T00:00:00Z');
     const cacheKey = buildCacheKey(
@@ -518,6 +689,9 @@ export async function runPreview(
         returnDate,
       };
     } catch (error) {
+      if (isGoogleFlightsLoadingShellError(error)) {
+        loadingShellRoutes.add(error.routeKey);
+      }
       routes[taskIndex] = {
         origin: combo.origin.code,
         originName: combo.origin.name,
@@ -544,8 +718,10 @@ export async function runPreview(
   // matches input task order regardless of which worker finishes first.
   // JS is single threaded, so nextIndex++ is atomic.
   const concurrency = Math.max(1, Math.min(options.concurrency ?? PREVIEW_CONCURRENCY, tasks.length));
+  const deadline = Date.now() + PREVIEW_WALL_CLOCK_MS;
   const worker = async () => {
     while (true) {
+      if (Date.now() >= deadline) return;
       const taskIndex = nextIndex++;
       if (taskIndex >= tasks.length) return;
       await runOne(taskIndex);
@@ -553,7 +729,26 @@ export async function runPreview(
   };
   await Promise.all(Array.from({ length: concurrency }, worker));
 
-  if (!routes.some((route) => route.flights.length > 0)) {
+  for (let i = 0; i < routes.length; i++) {
+    if (routes[i]) continue;
+    const task = tasks[i]!;
+    routes[i] = {
+      origin: task.combo.origin.code,
+      originName: task.combo.origin.name,
+      destination: task.combo.destination.code,
+      destinationName: task.combo.destination.name,
+      flights: [],
+      date: task.outboundDate,
+      returnDate: task.returnDate,
+      error: PREVIEW_WALL_CLOCK_ERROR,
+    };
+  }
+
+  if (Date.now() >= deadline && !routes.some((route) => (route?.flights?.length ?? 0) > 0)) {
+    throw new Error(PREVIEW_WALL_CLOCK_ERROR);
+  }
+
+  if (!routes.some((route) => (route?.flights?.length ?? 0) > 0)) {
     const firstError = routes.find((route) => route.error)?.error ?? 'No flights found for any route';
     throw new Error(firstError);
   }

--- a/apps/web/src/lib/preview-utils.test.ts
+++ b/apps/web/src/lib/preview-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GoogleFlightsLoadingShellError,
+  isGoogleFlightsLoadingShell,
+} from './preview-utils';
+
+describe('isGoogleFlightsLoadingShell', () => {
+  it('returns true for a short loading shell with no prices', () => {
+    expect(isGoogleFlightsLoadingShell('Loading results…')).toBe(true);
+  });
+
+  it('returns false when resultsFound is true', () => {
+    expect(isGoogleFlightsLoadingShell('Loading results…', true)).toBe(false);
+  });
+
+  it('returns false when price tokens appear in the head', () => {
+    expect(isGoogleFlightsLoadingShell('Loading results… from $499 round trip')).toBe(false);
+  });
+
+  it('returns true for long chrome that only mentions Loading results', () => {
+    const chrome = `${'x'.repeat(3500)}Loading results${'y'.repeat(500)}`;
+    expect(isGoogleFlightsLoadingShell(chrome)).toBe(true);
+  });
+});
+
+describe('GoogleFlightsLoadingShellError', () => {
+  it('sets routeKey from origin and destination', () => {
+    const error = new GoogleFlightsLoadingShellError('LAX', 'YOW');
+    expect(error.routeKey).toBe('LAX-YOW');
+    expect(error.name).toBe('GoogleFlightsLoadingShellError');
+  });
+});

--- a/apps/web/src/lib/preview-utils.test.ts
+++ b/apps/web/src/lib/preview-utils.test.ts
@@ -17,6 +17,11 @@ describe('isGoogleFlightsLoadingShell', () => {
     expect(isGoogleFlightsLoadingShell('Loading results… from $499 round trip')).toBe(false);
   });
 
+  it('recognizes price signals from non-Western currencies', () => {
+    expect(isGoogleFlightsLoadingShell('Loading results… from ¥49,900 round trip')).toBe(false);
+    expect(isGoogleFlightsLoadingShell('Loading results… from 4 990 NOK round trip')).toBe(false);
+  });
+
   it('returns true for long chrome that only mentions Loading results', () => {
     const chrome = `${'x'.repeat(3500)}Loading results${'y'.repeat(500)}`;
     expect(isGoogleFlightsLoadingShell(chrome)).toBe(true);

--- a/apps/web/src/lib/preview-utils.ts
+++ b/apps/web/src/lib/preview-utils.ts
@@ -117,3 +117,35 @@ export function previewTooFarInFutureMessage(maxDays = PREVIEW_MAX_FUTURE_DAYS):
   const months = Math.round(maxDays / 30);
   return `Preview searches more than ${months} months out often fail on Google Flights. Pick nearer dates or fewer options.`;
 }
+
+/** Google returned the empty shell with a spinner but no price cards. */
+export function isGoogleFlightsLoadingShell(text: string, resultsFound?: boolean): boolean {
+  if (resultsFound === true) return false;
+  if (!/loading results/i.test(text)) return false;
+  // Prefer phrase + lack of price/result signal over a brittle length gate.
+  // Short shells still match; longer chrome with only the spinner phrase also matches
+  // when resultsFound is false/undefined and no price-like tokens appear early.
+  const head = text.slice(0, 4000);
+  if (/[€$£]\s?\d|\d[\d,]*(?:\.\d+)?\s*(?:USD|EUR|GBP|CAD|AUD)/i.test(head)) return false;
+  if (/\b(?:nonstop|1 stop|2 stops|\d+\s*stops?)\b/i.test(head) && /\d{1,2}:\d{2}\s*[AP]M/i.test(head)) {
+    return false;
+  }
+  return true;
+}
+
+export function googleFlightsLoadingShellMessage(origin: string, destination: string): string {
+  return `Google Flights did not return results for ${origin}→${destination} on these dates. Try a shorter stay (under ~2 weeks), nearer dates, or one outbound/return pair.`;
+}
+
+export class GoogleFlightsLoadingShellError extends Error {
+  readonly routeKey: string;
+  constructor(origin: string, destination: string) {
+    super(googleFlightsLoadingShellMessage(origin, destination));
+    this.name = 'GoogleFlightsLoadingShellError';
+    this.routeKey = `${origin}-${destination}`;
+  }
+}
+
+export function isGoogleFlightsLoadingShellError(error: unknown): error is GoogleFlightsLoadingShellError {
+  return error instanceof GoogleFlightsLoadingShellError;
+}

--- a/apps/web/src/lib/preview-utils.ts
+++ b/apps/web/src/lib/preview-utils.ts
@@ -1,0 +1,119 @@
+import { expandContinuousRangeToDates } from '@/lib/scraper/scrape-dates';
+
+const PREVIEW_MAX_DATES = 7;
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/** Google Flights preview often stalls beyond ~9 months out. */
+export const PREVIEW_MAX_FUTURE_DAYS = 270;
+/** Show a UI warning when dates are far enough out that Google often stalls. */
+export const PREVIEW_FAR_FUTURE_WARN_DAYS = 120;
+
+/** Warn in the UI when a preview would fan out to this many scrapes. */
+export const PREVIEW_COMBO_WARN_THRESHOLD = 8;
+
+export const UNEQUAL_MULTI_DATE_ERROR =
+  'Unequal multi-date outbound and return lists are not supported. Use a single outbound or return date, or matching-length lists.';
+
+export interface PreviewDatePair {
+  outboundDate: string;
+  returnDate: string;
+}
+
+export interface PreviewDateFields {
+  dateFrom: string;
+  dateTo: string;
+  tripType: string;
+  outboundDates?: string[];
+  returnDates?: string[];
+}
+
+/**
+ * Build outbound/return date pairs for preview scraping.
+ *
+ * Policy:
+ * - one-way: enumerated outs, or expand continuous range (capped)
+ * - round-trip 1×N / N×1: broadcast the singleton leg (parser often returns this)
+ * - equal lengths: zip by index
+ * - unequal multi×multi: reject (avoids surprise cartesian explosion under the combo cap)
+ */
+export function buildPreviewDatePairs(
+  outboundDates: string[] | undefined,
+  returnDates: string[] | undefined,
+  dateFrom: string,
+  dateTo: string,
+  isOneWay: boolean,
+): PreviewDatePair[] {
+  if (isOneWay) {
+    const outbound = outboundDates ?? expandContinuousRangeToDates(dateFrom, dateTo, PREVIEW_MAX_DATES);
+    return outbound.map((outboundDate) => ({ outboundDate, returnDate: outboundDate }));
+  }
+
+  const outbound = outboundDates?.length ? outboundDates : [dateFrom];
+  const returns = returnDates?.length ? returnDates : [dateTo];
+
+  if (outbound.length === 1) {
+    return returns.map((returnDate) => ({ outboundDate: outbound[0]!, returnDate }));
+  }
+  if (returns.length === 1) {
+    return outbound.map((outboundDate) => ({ outboundDate, returnDate: returns[0]! }));
+  }
+  if (outbound.length === returns.length) {
+    return outbound.map((outboundDate, i) => ({ outboundDate, returnDate: returns[i]! }));
+  }
+
+  throw new Error(UNEQUAL_MULTI_DATE_ERROR);
+}
+
+export function countPreviewTasks(
+  originsCount: number,
+  destinationsCount: number,
+  fields: PreviewDateFields,
+): number {
+  const isOneWay = fields.tripType === 'one_way';
+  const datePairs = buildPreviewDatePairs(
+    fields.outboundDates,
+    fields.returnDates,
+    fields.dateFrom,
+    fields.dateTo,
+    isOneWay,
+  );
+  return originsCount * destinationsCount * datePairs.length;
+}
+
+export function farthestPreviewDate(fields: PreviewDateFields): Date {
+  const isOneWay = fields.tripType === 'one_way';
+  const datePairs = buildPreviewDatePairs(
+    fields.outboundDates,
+    fields.returnDates,
+    fields.dateFrom,
+    fields.dateTo,
+    isOneWay,
+  );
+  const allDates = datePairs.flatMap((pair) =>
+    isOneWay ? [pair.outboundDate] : [pair.outboundDate, pair.returnDate],
+  );
+  if (allDates.length === 0) {
+    return new Date(fields.dateTo + 'T00:00:00Z');
+  }
+  const sorted = [...allDates].sort();
+  return new Date(sorted[sorted.length - 1]! + 'T00:00:00Z');
+}
+
+export function daysUntilPreviewDate(date: Date, now = new Date()): number {
+  const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const targetUtc = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  return Math.ceil((targetUtc - todayUtc) / MS_PER_DAY);
+}
+
+export function isPreviewTooFarInFuture(fields: PreviewDateFields, now = new Date()): boolean {
+  return daysUntilPreviewDate(farthestPreviewDate(fields), now) > PREVIEW_MAX_FUTURE_DAYS;
+}
+
+export function isPreviewFarFutureWarn(fields: PreviewDateFields, now = new Date()): boolean {
+  return daysUntilPreviewDate(farthestPreviewDate(fields), now) > PREVIEW_FAR_FUTURE_WARN_DAYS;
+}
+
+export function previewTooFarInFutureMessage(maxDays = PREVIEW_MAX_FUTURE_DAYS): string {
+  const months = Math.round(maxDays / 30);
+  return `Preview searches more than ${months} months out often fail on Google Flights. Pick nearer dates or fewer options.`;
+}

--- a/apps/web/src/lib/preview-utils.ts
+++ b/apps/web/src/lib/preview-utils.ts
@@ -106,7 +106,8 @@ export function daysUntilPreviewDate(date: Date, now = new Date()): number {
 }
 
 export function isPreviewTooFarInFuture(fields: PreviewDateFields, now = new Date()): boolean {
-  return daysUntilPreviewDate(farthestPreviewDate(fields), now) > PREVIEW_MAX_FUTURE_DAYS;
+  const daysUntil = daysUntilPreviewDate(farthestPreviewDate(fields), now);
+  return !Number.isFinite(daysUntil) || daysUntil > PREVIEW_MAX_FUTURE_DAYS;
 }
 
 export function isPreviewFarFutureWarn(fields: PreviewDateFields, now = new Date()): boolean {

--- a/apps/web/src/lib/preview-utils.ts
+++ b/apps/web/src/lib/preview-utils.ts
@@ -127,7 +127,13 @@ export function isGoogleFlightsLoadingShell(text: string, resultsFound?: boolean
   // Short shells still match; longer chrome with only the spinner phrase also matches
   // when resultsFound is false/undefined and no price-like tokens appear early.
   const head = text.slice(0, 4000);
-  if (/[€$£]\s?\d|\d[\d,]*(?:\.\d+)?\s*(?:USD|EUR|GBP|CAD|AUD)/i.test(head)) return false;
+  if (
+    /(?:[€$£¥₹₩₱₽]|R\$)\s?\d|\d[\d,.\u00a0 ]*\s*(?:USD|EUR|GBP|CAD|AUD|JPY|CNY|SEK|NOK|DKK|INR|KRW|BRL|MXN|NZD|CHF|SGD|HKD)\b/i.test(
+      head,
+    )
+  ) {
+    return false;
+  }
   if (/\b(?:nonstop|1 stop|2 stops|\d+\s*stops?)\b/i.test(head) && /\d{1,2}:\d{2}\s*[AP]M/i.test(head)) {
     return false;
   }


### PR DESCRIPTION
## Summary
- **Depends on #188** (preview date-pair guardrails / `preview-utils`). Merge that first, or review this as stacked.
- Long round-trips (stay > 14 days) scrape as split Google one-ways; prices labeled `(approx OW+OW)` (outbound booking URL only)
- Detect Google “Loading results” shells (phrase + no price signal / `resultsFound`) and throw `GoogleFlightsLoadingShellError` so later date tasks for the same OD short-circuit
- 12-minute scheduling wall-clock; unfinished slots are explicit errors, and successful active polls renew the client lease so a final in-flight task cannot finish after the client has timed out

## Review follow-ups
- Split-leg shell errors retain the canonical outbound route key, including return-leg failures
- Usage and wall-clock duration are logged per extracted split leg, including a leg that returns a loading shell
- Price-signal detection includes additional symbols and currency codes

## Deferred
- CLI preview parity is intentionally deferred. `packages/cli/src/lib/preview.ts` has an independent synchronous scrape loop; this PR is scoped to the web async preview runner and client. A follow-up should share the hardened runner behavior rather than duplicating it again.

## Out of scope (kept local)
- ExpressVPN SOCKS forcing for preview
- Gemini model bumps

## Test plan
- [x] Return-leg shell reports the canonical route and skips later date tasks
- [x] Split-leg usage is recorded when the return leg fails
- [x] Active backend status renews the client polling lease
- [x] `npx vitest run src/lib/preview-runner.test.ts src/lib/preview-utils.test.ts src/components/SearchBar.test.tsx` passes

Made with [Cursor](https://cursor.com)