### PR TITLE
scraper: capture layover legs per itinerary

### DIFF
--- a/API.md
+++ b/API.md
@@ -165,8 +165,9 @@ GET /api/queries/{id}/prices
         "price": 487,
         "currency": "USD",
         "airline": "Delta",
-        "stops": 0,
+        "stops": 1,
         "duration": "7h 30m",
+        "layovers": [{ "duration": "1h 35m", "airport": "ORD" }],
         "bookingUrl": "https://...",
         "scrapedAt": "2026-03-08T12:00:00Z"
       }

--- a/apps/web/messages/de/components.json
+++ b/apps/web/messages/de/components.json
@@ -18,7 +18,8 @@
     "bestPriceFound": "Bester gefundener Preis",
     "nonstop": "Direktflug",
     "stops": "{count, plural, one {# Zwischenstopp} other {# Zwischenstopps}}",
-    "bookOn": "Bei {airline} buchen"
+    "bookOn": "Bei {airline} buchen",
+    "airTime": "{time} in der Luft"
   },
   "ChartActions": {
     "copyShareableLink": "Teilbaren Link kopieren",
@@ -96,7 +97,8 @@
     "creatingTrackers": "Tracker werden erstellt...",
     "trackFlights": "{count, plural, one {# Flug verfolgen} other {# Flüge verfolgen}}",
     "back": "Zurück",
-    "editSearch": "Suche bearbeiten"
+    "editSearch": "Suche bearbeiten",
+    "layover": "{time} Umsteigezeit"
   },
   "Footer": {
     "tagline": "deine Daten, nicht ihre",
@@ -196,7 +198,9 @@
     "noPriceData": "Noch keine Preisdaten",
     "noPriceDataHint": "Preise erscheinen nach dem ersten Abruf. Schau bald wieder vorbei.",
     "noViewData": "Keine Preisdaten für diese Ansicht",
-    "noViewDataHint": "Wechsle die Ansicht oder warte auf den nächsten Abruf, um Preise mit den aktuellen Filtern zu sammeln."
+    "noViewDataHint": "Wechsle die Ansicht oder warte auf den nächsten Abruf, um Preise mit den aktuellen Filtern zu sammeln.",
+    "layover": "{time} Umsteigezeit",
+    "airTime": "{time} in der Luft"
   },
   "PriceHistory": {
     "title": "Preisverlauf",
@@ -219,7 +223,8 @@
     "book": "Buchen",
     "hideHistory": "Verlauf ausblenden",
     "showHistory": "Gesamten Verlauf anzeigen ({count} Prüfungen)",
-    "truncation": "Angezeigt werden die letzten {shown} von {total} Prüfungen."
+    "truncation": "Angezeigt werden die letzten {shown} von {total} Prüfungen.",
+    "layover": "{time} Umsteigezeit"
   },
   "ProfileMenu": {
     "yourTrackers": "Deine Tracker",

--- a/apps/web/messages/en/components.json
+++ b/apps/web/messages/en/components.json
@@ -18,7 +18,8 @@
     "bestPriceFound": "Best price found",
     "nonstop": "Nonstop",
     "stops": "{count, plural, one {# stop} other {# stops}}",
-    "bookOn": "Book on {airline}"
+    "bookOn": "Book on {airline}",
+    "airTime": "{time} in air"
   },
   "ChartActions": {
     "copyShareableLink": "Copy shareable link",
@@ -96,7 +97,8 @@
     "creatingTrackers": "Creating trackers...",
     "trackFlights": "Track {count, plural, one {# flight} other {# flights}}",
     "back": "Back",
-    "editSearch": "Edit search"
+    "editSearch": "Edit search",
+    "layover": "{time} layover"
   },
   "Footer": {
     "tagline": "your data, not theirs",
@@ -196,7 +198,9 @@
     "noPriceData": "No price data yet",
     "noPriceDataHint": "Prices will appear after the first scrape runs. Check back soon.",
     "noViewData": "No price data for this view",
-    "noViewDataHint": "Switch views or wait for the next scrape to collect prices under the current filters."
+    "noViewDataHint": "Switch views or wait for the next scrape to collect prices under the current filters.",
+    "layover": "{time} layover",
+    "airTime": "{time} in air"
   },
   "PriceHistory": {
     "title": "Price History",
@@ -219,7 +223,8 @@
     "book": "Book",
     "hideHistory": "Hide full history",
     "showHistory": "Show full history ({count} checks)",
-    "truncation": "Showing the latest {shown} of {total} checks."
+    "truncation": "Showing the latest {shown} of {total} checks.",
+    "layover": "{time} layover"
   },
   "ProfileMenu": {
     "yourTrackers": "Your trackers",

--- a/apps/web/messages/es/components.json
+++ b/apps/web/messages/es/components.json
@@ -18,7 +18,8 @@
     "bestPriceFound": "Mejor precio encontrado",
     "nonstop": "Directo",
     "stops": "{count, plural, one {# escala} other {# escalas}}",
-    "bookOn": "Reservar en {airline}"
+    "bookOn": "Reservar en {airline}",
+    "airTime": "{time} en vuelo"
   },
   "ChartActions": {
     "copyShareableLink": "Copiar enlace para compartir",
@@ -96,7 +97,8 @@
     "creatingTrackers": "Creando rastreadores...",
     "trackFlights": "Rastrear {count, plural, one {# vuelo} other {# vuelos}}",
     "back": "Atrás",
-    "editSearch": "Editar búsqueda"
+    "editSearch": "Editar búsqueda",
+    "layover": "escala de {time}"
   },
   "Footer": {
     "tagline": "tus datos, no los de ellos",
@@ -196,7 +198,9 @@
     "noPriceData": "Aún no hay datos de precios",
     "noPriceDataHint": "Los precios aparecerán después de la primera extracción. Vuelve pronto.",
     "noViewData": "No hay datos de precios para esta vista",
-    "noViewDataHint": "Cambia de vista o espera a la próxima extracción para recopilar precios con los filtros actuales."
+    "noViewDataHint": "Cambia de vista o espera a la próxima extracción para recopilar precios con los filtros actuales.",
+    "layover": "escala de {time}",
+    "airTime": "{time} en vuelo"
   },
   "PriceHistory": {
     "title": "Historial de precios",
@@ -219,7 +223,8 @@
     "book": "Reservar",
     "hideHistory": "Ocultar historial completo",
     "showHistory": "Ver historial completo ({count} revisiones)",
-    "truncation": "Mostrando las últimas {shown} de {total} revisiones."
+    "truncation": "Mostrando las últimas {shown} de {total} revisiones.",
+    "layover": "escala de {time}"
   },
   "ProfileMenu": {
     "yourTrackers": "Tus rastreadores",

--- a/apps/web/messages/fr/components.json
+++ b/apps/web/messages/fr/components.json
@@ -18,7 +18,8 @@
     "bestPriceFound": "Meilleur prix trouvé",
     "nonstop": "Direct",
     "stops": "{count, plural, one {# escale} other {# escales}}",
-    "bookOn": "Réserver sur {airline}"
+    "bookOn": "Réserver sur {airline}",
+    "airTime": "{time} en vol"
   },
   "ChartActions": {
     "copyShareableLink": "Copier le lien partageable",
@@ -96,7 +97,8 @@
     "creatingTrackers": "Création des suivis...",
     "trackFlights": "Suivre {count, plural, one {# vol} other {# vols}}",
     "back": "Retour",
-    "editSearch": "Modifier la recherche"
+    "editSearch": "Modifier la recherche",
+    "layover": "escale de {time}"
   },
   "Footer": {
     "tagline": "tes données, pas les leurs",
@@ -196,7 +198,9 @@
     "noPriceData": "Pas encore de données de prix",
     "noPriceDataHint": "Les prix apparaîtront après la première extraction. Reviens bientôt.",
     "noViewData": "Aucune donnée de prix pour cette vue",
-    "noViewDataHint": "Change de vue ou attends la prochaine extraction pour collecter des prix avec les filtres actuels."
+    "noViewDataHint": "Change de vue ou attends la prochaine extraction pour collecter des prix avec les filtres actuels.",
+    "layover": "escale de {time}",
+    "airTime": "{time} en vol"
   },
   "PriceHistory": {
     "title": "Historique des prix",
@@ -219,7 +223,8 @@
     "book": "Réserver",
     "hideHistory": "Masquer l’historique complet",
     "showHistory": "Afficher l’historique complet ({count} vérifications)",
-    "truncation": "Affichage des {shown} dernières vérifications sur {total}."
+    "truncation": "Affichage des {shown} dernières vérifications sur {total}.",
+    "layover": "escale de {time}"
   },
   "ProfileMenu": {
     "yourTrackers": "Tes suivis",

--- a/apps/web/messages/pt/components.json
+++ b/apps/web/messages/pt/components.json
@@ -18,7 +18,8 @@
     "bestPriceFound": "Melhor preço encontrado",
     "nonstop": "Direto",
     "stops": "{count, plural, one {# escala} other {# escalas}}",
-    "bookOn": "Reservar na {airline}"
+    "bookOn": "Reservar na {airline}",
+    "airTime": "{time} em voo"
   },
   "ChartActions": {
     "copyShareableLink": "Copiar link compartilhável",
@@ -96,7 +97,8 @@
     "creatingTrackers": "Criando rastreadores...",
     "trackFlights": "Rastrear {count, plural, one {# voo} other {# voos}}",
     "back": "Voltar",
-    "editSearch": "Editar busca"
+    "editSearch": "Editar busca",
+    "layover": "escala de {time}"
   },
   "Footer": {
     "tagline": "seus dados, não os deles",
@@ -196,7 +198,9 @@
     "noPriceData": "Ainda não há dados de preços",
     "noPriceDataHint": "Os preços aparecerão após a primeira extração. Volte em breve.",
     "noViewData": "Sem dados de preços para esta visualização",
-    "noViewDataHint": "Troque de visualização ou aguarde a próxima extração coletar preços com os filtros atuais."
+    "noViewDataHint": "Troque de visualização ou aguarde a próxima extração coletar preços com os filtros atuais.",
+    "layover": "escala de {time}",
+    "airTime": "{time} em voo"
   },
   "PriceHistory": {
     "title": "Histórico de Preços",
@@ -219,7 +223,8 @@
     "book": "Reservar",
     "hideHistory": "Ocultar histórico completo",
     "showHistory": "Mostrar histórico completo ({count} verificações)",
-    "truncation": "Mostrando as {shown} verificações mais recentes de {total}."
+    "truncation": "Mostrando as {shown} verificações mais recentes de {total}.",
+    "layover": "escala de {time}"
   },
   "ProfileMenu": {
     "yourTrackers": "Seus rastreadores",

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -78,6 +78,7 @@ model PriceSnapshot {
   bookingUrl        String?
   stops             Int      @default(0)
   duration          String?
+  layovers          Json?    // [{ duration: "1h 35m", airport: "ORD" }] in travel order
   flightId          String?  // stable identity: airline-(flightNumber|HHMM)-origin-dest-date
   flightNumber      String?  // human-readable flight identifier (e.g. "DL 345")
   departureTime     String?

--- a/apps/web/src/app/api/queries/[id]/prices/route.ts
+++ b/apps/web/src/app/api/queries/[id]/prices/route.ts
@@ -71,6 +71,7 @@ export async function GET(
           bookingUrl: true,
           stops: true,
           duration: true,
+          layovers: true,
           flightId: true,
           flightNumber: true,
           departureTime: true,

--- a/apps/web/src/app/api/queries/route.ts
+++ b/apps/web/src/app/api/queries/route.ts
@@ -9,6 +9,7 @@ import { getClientIp } from '@/lib/trusted-ip';
 import { redis } from '@/lib/redis';
 import { safeHttpUrl } from '@/lib/safe-url';
 import { isValidPriceAmount } from '@/lib/limits';
+import { coerceLayovers } from '@/lib/scraper/duration';
 
 const MAX_ROUTES = 20;
 const MAX_FLIGHTS_PER_ROUTE = 50;
@@ -47,6 +48,7 @@ interface RouteInput {
     bookingUrl: string | null;
     stops?: number;
     duration?: string | null;
+    layovers?: unknown; // shape-checked by coerceLayovers before persistence
     flightNumber?: string | null;
   }>;
 }
@@ -363,20 +365,27 @@ export async function POST(request: NextRequest) {
 
     if (flights.length > 0) {
       await prisma.priceSnapshot.createMany({
-        data: flights.map((f) => ({
-          queryId: query.id,
-          travelDate: new Date(f.travelDate + 'T00:00:00Z'),
-          // Store the coerced numeric values (validated above), not the raw
-          // input, so a numeric string like "300" cannot reach Prisma as a string.
-          price: Number(f.price),
-          currency: f.currency || 'USD',
-          airline: f.airline,
-          // safeHttpUrl drops non-http(s) URLs to prevent javascript:/data:/file: injection
-          bookingUrl: safeHttpUrl(f.bookingUrl) || '',
-          stops: f.stops != null ? Number(f.stops) : 0,
-          duration: f.duration ?? null,
-          flightNumber: f.flightNumber ?? null,
-        })),
+        data: flights.map((f) => {
+          // coerceLayovers bounds the client-supplied value (entry count, field
+          // types, string lengths) before it reaches the Json column. Prisma
+          // treats an explicit null on Json as ambiguous, so omit it instead.
+          const layovers = coerceLayovers(f.layovers);
+          return {
+            queryId: query.id,
+            travelDate: new Date(f.travelDate + 'T00:00:00Z'),
+            // Store the coerced numeric values (validated above), not the raw
+            // input, so a numeric string like "300" cannot reach Prisma as a string.
+            price: Number(f.price),
+            currency: f.currency || 'USD',
+            airline: f.airline,
+            // safeHttpUrl drops non-http(s) URLs to prevent javascript:/data:/file: injection
+            bookingUrl: safeHttpUrl(f.bookingUrl) || '',
+            stops: f.stops != null ? Number(f.stops) : 0,
+            duration: f.duration ?? null,
+            ...(layovers ? { layovers } : {}),
+            flightNumber: f.flightNumber ?? null,
+          };
+        }),
       });
     }
 

--- a/apps/web/src/app/q/[id]/page.tsx
+++ b/apps/web/src/app/q/[id]/page.tsx
@@ -82,6 +82,7 @@ interface ChartSnapshot {
   bookingUrl: string | null;
   stops: number;
   duration: string | null;
+  layovers?: unknown;
   flightId: string | null;
   flightNumber: string | null;
   departureTime: string | null;
@@ -243,6 +244,7 @@ async function loadQueryWithSnapshots(id: string): Promise<QueryWithSnapshots | 
       bookingUrl: true,
       stops: true,
       duration: true,
+      layovers: true,
       flightId: true,
       flightNumber: true,
       departureTime: true,

--- a/apps/web/src/components/BestPrice.test.tsx
+++ b/apps/web/src/components/BestPrice.test.tsx
@@ -12,6 +12,7 @@ interface Snap {
   departureTime: string | null;
   arrivalTime: string | null;
   duration: string | null;
+  layovers?: unknown;
   vpnCountry: string | null;
   scrapedAt: string;
   status?: string;
@@ -96,5 +97,28 @@ describe('BestPrice — sold-out exclusion (issue #64)', () => {
       </>,
     );
     expect(screen.getByText(/90/)).toBeTruthy();
+  });
+});
+
+describe('BestPrice — air time (issue #190)', () => {
+  it('breaks the gate-to-gate duration down into time actually in the air', async () => {
+    render(
+      <>
+        {await BestPrice({
+          snapshots: [
+            snap({ stops: 1, duration: '5h 55m', layovers: [{ duration: '1h 35m', airport: 'ORD' }] }),
+          ],
+        })}
+      </>
+    );
+    expect(screen.getByText(/5h 55m/)).toBeTruthy();
+    expect(screen.getByText(/4h 20m in air/)).toBeTruthy();
+  });
+
+  it('shows the duration alone when there is no layover data', async () => {
+    render(
+      <>{await BestPrice({ snapshots: [snap({ stops: 0, duration: '3h 05m' })] })}</>
+    );
+    expect(screen.queryByText(/in air/)).toBeNull();
   });
 });

--- a/apps/web/src/components/BestPrice.tsx
+++ b/apps/web/src/components/BestPrice.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 import { formatCurrency } from '@/lib/currency';
 import { safeHttpUrl } from '@/lib/safe-url';
+import { airTimeMinutes, formatMinutes } from '@/lib/scraper/duration';
 import styles from './BestPrice.module.css';
 
 interface Snapshot {
@@ -9,6 +10,7 @@ interface Snapshot {
   airline: string;
   bookingUrl: string | null;
   stops: number;
+  layovers?: unknown;
   departureTime: string | null;
   arrivalTime: string | null;
   duration: string | null;
@@ -27,6 +29,9 @@ export async function BestPrice({ snapshots }: { snapshots: Snapshot[] }) {
   if (bookable.length === 0) return null;
 
   const best = bookable.reduce((min, s) => (s.price < min.price ? s : min), bookable[0]!);
+  // Duration is gate-to-gate, so on a connecting fare most of the difference
+  // between two similar itineraries is ground time. Issue #190.
+  const airTime = airTimeMinutes(best.duration, best.layovers);
 
   return (
     <div className={styles.root}>
@@ -42,6 +47,7 @@ export async function BestPrice({ snapshots }: { snapshots: Snapshot[] }) {
           <span className={styles.meta}>
             {best.stops === 0 ? t('nonstop') : t('stops', { count: best.stops })}
             {best.duration && ` · ${best.duration}`}
+            {airTime !== null && ` (${t('airTime', { time: formatMinutes(airTime) })})`}
             {(best.departureTime || best.arrivalTime) && ` · ${best.departureTime ?? '?'} - ${best.arrivalTime ?? '?'}`}
           </span>
         </div>

--- a/apps/web/src/components/FlightPicker.module.css
+++ b/apps/web/src/components/FlightPicker.module.css
@@ -200,8 +200,13 @@
 }
 
 .stops,
-.duration {
+.duration,
+.layover {
   white-space: nowrap;
+}
+
+.layover {
+  opacity: 0.75;
 }
 
 .actions {

--- a/apps/web/src/components/FlightPicker.test.tsx
+++ b/apps/web/src/components/FlightPicker.test.tsx
@@ -17,6 +17,7 @@ function flight(n: number): PriceData {
     bookingUrl: null,
     stops: 0,
     duration: '5h 30m',
+    layovers: null,
     departureTime: null,
     arrivalTime: null,
     seatsLeft: null,

--- a/apps/web/src/components/FlightPicker.tsx
+++ b/apps/web/src/components/FlightPicker.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { PriceData } from '@/lib/scraper/extract-prices';
 import { formatCurrency } from '@/lib/currency';
+import { layoverLabel } from '@/lib/scraper/duration';
 import styles from './FlightPicker.module.css';
 
 export interface RouteFlights {
@@ -163,6 +164,11 @@ export function FlightPicker({
                       <span className={styles.stops}>{flight.stops === 0 ? t('nonstop') : t('stops', { count: flight.stops })}</span>
                       {flight.duration && (
                         <span className={styles.duration}>{flight.duration}</span>
+                      )}
+                      {layoverLabel(flight.layovers) && (
+                        <span className={styles.layover}>
+                          {t('layover', { time: layoverLabel(flight.layovers)! })}
+                        </span>
                       )}
                     </div>
                   </button>

--- a/apps/web/src/components/PriceChart.tsx
+++ b/apps/web/src/components/PriceChart.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import dynamic from 'next/dynamic';
 import { formatCurrency } from '@/lib/currency';
 import { safeHttpUrl } from '@/lib/safe-url';
+import { airTimeMinutes, formatMinutes, layoverLabel } from '@/lib/scraper/duration';
 import styles from './PriceChart.module.css';
 
 const Plot = dynamic(() => import('react-plotly.js'), { ssr: false });
@@ -18,6 +19,7 @@ interface Snapshot {
   bookingUrl: string | null;
   stops: number;
   duration: string | null;
+  layovers?: unknown;
   flightId: string | null;
   departureTime: string | null;
   arrivalTime: string | null;
@@ -161,6 +163,10 @@ function buildDetailTraces(snapshots: Snapshot[], currency: string, hasVpnData: 
           lines.push(`${p.departureTime ?? '?'} - ${p.arrivalTime ?? '?'}`);
         }
         if (p.duration) lines.push(p.duration);
+        const layover = layoverLabel(p.layovers);
+        if (layover) lines.push(t('layover', { time: layover }));
+        const air = airTimeMinutes(p.duration, p.layovers);
+        if (air !== null) lines.push(t('airTime', { time: formatMinutes(air) }));
         if (p.seatsLeft) lines.push(t('seatsLeft', { count: p.seatsLeft }));
         if (p.vpnCountry) lines.push(`${countryFlag(p.vpnCountry)} ${t('scrapedFrom', { country: p.vpnCountry })}`);
         return lines.join('<br>');

--- a/apps/web/src/components/PriceHistory.module.css
+++ b/apps/web/src/components/PriceHistory.module.css
@@ -85,6 +85,15 @@
   color: var(--text-secondary);
 }
 
+.layover {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-tertiary, var(--text-secondary));
+  opacity: 0.8;
+  white-space: nowrap;
+}
+
 .trendUp {
   color: var(--price-up);
   font-family: var(--font-mono);

--- a/apps/web/src/components/PriceHistory.test.tsx
+++ b/apps/web/src/components/PriceHistory.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { PriceHistory, type Snapshot } from './PriceHistory';
+import { PriceHistorySection } from './PriceHistorySection';
 
 // Issue #89: the grouped-by-flight view ordered parent rows by lifetime-cheapest
 // price, so a flight last seen days ago (or a stale "cheapest ever") interleaved
@@ -37,6 +38,39 @@ const SNAPSHOTS: Snapshot[] = [
   snap({ id: 'b3', flightId: 'B', airline: 'Beta', price: 200, scrapedAt: '2026-05-03T08:00:00.000Z' }),
   snap({ id: 'c1', flightId: 'C', airline: 'Gamma', price: 150, scrapedAt: '2026-05-01T08:00:00.000Z' }),
 ];
+
+describe('layover capture (issue #190)', () => {
+  it('shows total ground time and where it is spent next to the stop count', () => {
+    render(
+      <PriceHistorySection
+        snapshots={[
+          snap({
+            id: 'l1',
+            flightId: 'L',
+            airline: 'American',
+            price: 300,
+            scrapedAt: '2026-05-03T08:00:00.000Z',
+            stops: 1,
+            duration: '5h 55m',
+            layovers: [{ duration: '1h 35m', airport: 'ORD' }],
+          }),
+        ]}
+      />
+    );
+    expect(screen.getByText('1h 35m ORD layover')).toBeTruthy();
+  });
+
+  it('says nothing for a nonstop flight', () => {
+    render(
+      <PriceHistorySection
+        snapshots={[
+          snap({ id: 'n1', flightId: 'N', airline: 'Delta', price: 300, scrapedAt: '2026-05-03T08:00:00.000Z' }),
+        ]}
+      />
+    );
+    expect(screen.queryByText(/layover/)).toBeNull();
+  });
+});
 
 describe('PriceHistory: latest snapshot + full history (issue #89)', () => {
   it('shows only the latest scrape by default, hiding earlier checks', async () => {

--- a/apps/web/src/components/PriceHistory.tsx
+++ b/apps/web/src/components/PriceHistory.tsx
@@ -10,6 +10,7 @@ export interface Snapshot {
   bookingUrl: string | null;
   stops: number;
   duration: string | null;
+  layovers?: unknown;
   flightId: string | null;
   flightNumber: string | null;
   departureTime: string | null;

--- a/apps/web/src/components/PriceHistorySection.tsx
+++ b/apps/web/src/components/PriceHistorySection.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { formatCurrency } from '@/lib/currency';
 import { safeHttpUrl } from '@/lib/safe-url';
 import { useHydrated } from '@/lib/use-hydrated';
+import { layoverLabel } from '@/lib/scraper/duration';
 import styles from './PriceHistory.module.css';
 import type { Snapshot } from './PriceHistory';
 
@@ -100,6 +101,7 @@ function FlightRow({
   showDate: boolean;
 }) {
   const t = useTranslations('PriceHistorySection');
+  const layover = layoverLabel(s.layovers);
   return (
     <tr>
       {showDate && <td className={styles.date}><ScrapeTime iso={s.scrapedAt} /></td>}
@@ -109,7 +111,10 @@ function FlightRow({
         {formatCurrency(s.price, s.currency)}
       </td>
       <TrendCell current={s} previous={previous} />
-      <td className={styles.stops}>{s.stops === 0 ? t('direct') : t('stopCount', { count: s.stops })}</td>
+      <td className={styles.stops}>
+        {s.stops === 0 ? t('direct') : t('stopCount', { count: s.stops })}
+        {layover && <span className={styles.layover}>{t('layover', { time: layover })}</span>}
+      </td>
       <td className={styles.seats}>
         {s.status === 'sold_out' ? (
           <span className={styles.soldOut}>{t('soldOut')}</span>

--- a/apps/web/src/lib/scraper/duration.test.ts
+++ b/apps/web/src/lib/scraper/duration.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { parseDurationToMinutes } from './duration';
+import {
+  airTimeMinutes,
+  coerceLayovers,
+  formatMinutes,
+  layoverLabel,
+  layoverMinutes,
+  parseDurationToMinutes,
+} from './duration';
 
 describe('parseDurationToMinutes', () => {
   it('parses hours and minutes', () => {
@@ -38,5 +45,84 @@ describe('parseDurationToMinutes', () => {
 
   it('handles uppercase H and M', () => {
     expect(parseDurationToMinutes('5H 10M')).toBe(310);
+  });
+});
+
+describe('formatMinutes', () => {
+  it('renders hours and minutes, dropping the zero part', () => {
+    expect(formatMinutes(95)).toBe('1h 35m');
+    expect(formatMinutes(120)).toBe('2h');
+    expect(formatMinutes(45)).toBe('45m');
+  });
+});
+
+describe('coerceLayovers', () => {
+  it('keeps well-formed objects, normalizing the duration', () => {
+    expect(coerceLayovers([{ duration: '1 hr 35 min', airport: 'ORD' }])).toEqual([
+      { duration: '1h 35m', airport: 'ORD' },
+    ]);
+  });
+
+  it('parses the raw layover line straight off the page', () => {
+    expect(coerceLayovers(['1 hr 35 min layover · Chicago ORD'])).toEqual([
+      { duration: '1h 35m', airport: 'Chicago ORD' },
+    ]);
+    expect(coerceLayovers('55 min in ATL')).toEqual([{ duration: '55m', airport: 'ATL' }]);
+  });
+
+  it('accepts the aliases and numeric minutes models actually emit', () => {
+    expect(coerceLayovers([{ layoverDuration: '2h', city: 'Dallas' }])).toEqual([
+      { duration: '2h', airport: 'Dallas' },
+    ]);
+    expect(coerceLayovers([{ duration: 95, code: 'ORD' }])).toEqual([{ duration: '1h 35m', airport: 'ORD' }]);
+  });
+
+  it('returns null when nothing usable is there', () => {
+    expect(coerceLayovers(null)).toBeNull();
+    expect(coerceLayovers([])).toBeNull();
+    expect(coerceLayovers('nonstop')).toBeNull();
+    expect(coerceLayovers([{ airport: 'ORD' }])).toBeNull();
+    expect(coerceLayovers([{ duration: '0m', airport: 'ORD' }])).toBeNull();
+  });
+
+  it('drops unusable entries but keeps the rest of the itinerary', () => {
+    expect(coerceLayovers([{ duration: '1h', airport: 'ORD' }, 'no idea', { duration: '40m' }])).toEqual([
+      { duration: '1h', airport: 'ORD' },
+      { duration: '40m', airport: null },
+    ]);
+  });
+
+  it('bounds entry count and airport length against hostile input', () => {
+    const many = Array.from({ length: 20 }, () => ({ duration: '1h', airport: 'X' }));
+    expect(coerceLayovers(many)).toHaveLength(6);
+    expect(coerceLayovers([{ duration: '1h', airport: 'A'.repeat(500) }])![0]!.airport).toHaveLength(40);
+  });
+});
+
+describe('layover totals', () => {
+  const twoStop = [
+    { duration: '1h 35m', airport: 'ORD' },
+    { duration: '45m', airport: 'DFW' },
+  ];
+
+  it('sums ground time across connections', () => {
+    expect(layoverMinutes(twoStop)).toBe(140);
+    expect(layoverMinutes(null)).toBeNull();
+  });
+
+  it('reports air time as duration minus ground time', () => {
+    expect(airTimeMinutes('5h 55m', [{ duration: '1h 35m', airport: 'ORD' }])).toBe(4 * 60 + 20);
+  });
+
+  it('refuses to report air time when the numbers cannot both be right', () => {
+    expect(airTimeMinutes('1h', [{ duration: '2h', airport: 'ORD' }])).toBeNull();
+    expect(airTimeMinutes(null, twoStop)).toBeNull();
+    expect(airTimeMinutes('5h', null)).toBeNull();
+  });
+
+  it('labels the total with the airports it knows', () => {
+    expect(layoverLabel(twoStop)).toBe('2h 20m ORD, DFW');
+    expect(layoverLabel([{ duration: '1h', airport: null }])).toBe('1h');
+    expect(layoverLabel(null)).toBeNull();
   });
 });

--- a/apps/web/src/lib/scraper/duration.ts
+++ b/apps/web/src/lib/scraper/duration.ts
@@ -13,3 +13,109 @@ export function parseDurationToMinutes(s: string | null | undefined): number | n
   const mins = m ? parseInt(m[1]!, 10) : 0;
   return hours * 60 + mins;
 }
+
+/** Render minutes back into the "11h 20m" form the rest of the app uses. */
+export function formatMinutes(total: number): string {
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
+
+/** One connection on an itinerary, in travel order. */
+export type Layover = {
+  duration: string; // normalized, e.g. "1h 35m"
+  airport: string | null; // IATA code or city as shown, e.g. "ORD"
+};
+
+// A one-stop itinerary has one layover; the cap is a sanity bound on model
+// output, not a real-world limit anyone will hit.
+const MAX_LAYOVERS = 6;
+const MAX_AIRPORT_LENGTH = 40;
+
+/**
+ * Parse the layover line Google Flights renders per itinerary, e.g.
+ * "1 hr 35 min layover · Chicago ORD" or "55 min in ATL". The duration is
+ * whatever precedes the separator; anything after it is the connection point.
+ */
+function parseLayoverText(text: string): Layover | null {
+  const [durationPart, ...rest] = text.split(/·|\||\bin\b|\bat\b/i);
+  const minutes = parseDurationToMinutes(durationPart);
+  if (minutes === null || minutes <= 0) return null;
+  const airport = rest
+    .join(' ')
+    .replace(/layover|connection|stop/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return { duration: formatMinutes(minutes), airport: airport ? airport.slice(0, MAX_AIRPORT_LENGTH) : null };
+}
+
+/**
+ * Normalize whatever a model (or a client POST, or a Prisma Json column) offers
+ * as layovers into a clean `Layover[]`, or null when nothing usable is there.
+ *
+ * This is the single trust boundary for the field: the same tolerance the rest
+ * of extraction applies to loosely-typed model output (see normalizeEntry in
+ * extract-prices.ts), and what bounds client-supplied values before they reach
+ * the database. Accepted shapes: an array of objects, an array of raw layover
+ * strings, or a single string/object for a one-stop itinerary.
+ */
+export function coerceLayovers(value: unknown): Layover[] | null {
+  const items = Array.isArray(value) ? value : value == null ? [] : [value];
+  const out: Layover[] = [];
+  for (const item of items) {
+    if (out.length >= MAX_LAYOVERS) break;
+    if (typeof item === 'string') {
+      const parsed = parseLayoverText(item);
+      if (parsed) out.push(parsed);
+      continue;
+    }
+    if (typeof item !== 'object' || item === null) continue;
+    const e = item as Record<string, unknown>;
+    const rawDuration = e.duration ?? e.layoverDuration ?? e.layover ?? e.time ?? e.length;
+    const minutes =
+      typeof rawDuration === 'number' && Number.isFinite(rawDuration)
+        ? Math.trunc(rawDuration)
+        : parseDurationToMinutes(typeof rawDuration === 'string' ? rawDuration : null);
+    if (minutes === null || minutes <= 0) continue;
+    const rawAirport = e.airport ?? e.airportCode ?? e.code ?? e.city ?? e.location;
+    out.push({
+      duration: formatMinutes(minutes),
+      airport:
+        typeof rawAirport === 'string' && rawAirport.trim()
+          ? rawAirport.trim().slice(0, MAX_AIRPORT_LENGTH)
+          : null,
+    });
+  }
+  return out.length > 0 ? out : null;
+}
+
+/** Total time on the ground across all connections, or null when unknown. */
+export function layoverMinutes(value: unknown): number | null {
+  const layovers = coerceLayovers(value);
+  if (!layovers) return null;
+  return layovers.reduce((sum, l) => sum + (parseDurationToMinutes(l.duration) ?? 0), 0);
+}
+
+/**
+ * Time actually in the air: gate-to-gate duration minus every layover. Null
+ * when either side is unknown, or when the two disagree (a layover total at or
+ * above the trip duration means one of them was misread, and a negative air
+ * time is worse than no air time).
+ */
+export function airTimeMinutes(duration: string | null | undefined, layovers: unknown): number | null {
+  const total = parseDurationToMinutes(duration);
+  const ground = layoverMinutes(layovers);
+  if (total === null || ground === null || ground <= 0 || ground >= total) return null;
+  return total - ground;
+}
+
+/** "1h 35m ORD" / "2h 10m" — compact label for the total ground time. */
+export function layoverLabel(value: unknown): string | null {
+  const layovers = coerceLayovers(value);
+  const minutes = layoverMinutes(value);
+  if (!layovers || minutes === null || minutes <= 0) return null;
+  const airports = layovers.map((l) => l.airport).filter((a): a is string => !!a);
+  return airports.length > 0 ? `${formatMinutes(minutes)} ${airports.join(', ')}` : formatMinutes(minutes);
+}

--- a/apps/web/src/lib/scraper/extract-prices.live.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.live.test.ts
@@ -42,6 +42,15 @@ const fixture = readFileSync(
   'utf-8',
 );
 
+// A real ALB->CMH capture (issue #190). Google's compact result list writes the
+// connection as a bare duration plus airport under the stop count ("55 min
+// DTW") — no "layover" wording at all — and the one 2-stop itinerary has no
+// connection line whatsoever. Both shapes are what the prompt has to survive.
+const layoverFixture = readFileSync(
+  join(__dirname, '../../test/fixtures/google-flights-layovers.txt'),
+  'utf-8',
+);
+
 const CONFIG = {
   provider: 'claude-code',
   model: process.env.LLM_INTEGRATION_MODEL ?? 'sonnet',
@@ -128,6 +137,40 @@ describe.skipIf(!claudeIsUsable())('extractPrices live (claude-code) — issue #
     // 7h cap keeps the ~6h15m nonstops, drops the 8h30m / 9h45m one-stops.
     for (const p of result.prices) {
       expect(p.stops).toBe(0);
+    }
+  }, 120_000);
+
+  it('reads layovers off a real connecting-route page, and invents none (issue #190)', async () => {
+    const result = await extractPrices(
+      layoverFixture,
+      'https://www.google.com/travel/flights?q=flights+from+ALB+to+CMH',
+      '2026-09-14',
+      noFilters,
+      10,
+      true,
+      'google_flights',
+      'USD',
+      CONFIG,
+    );
+
+    expect(result.failureReason).toBeUndefined();
+    const oneStop = result.prices.filter((p) => p.stops === 1);
+    expect(oneStop.length).toBeGreaterThanOrEqual(4);
+
+    // Every one-stop row on this page has a connection line, and each layover
+    // must match one that is actually printed — not one derived from the total
+    // duration or the departure/arrival times.
+    const onPage = new Set(['55m DTW', '59m ORD', '2h 5m BNA', '1h 17m PHL', '1h 43m ATL', '1h 30m ORD', '1h 15m ORD', '1h 8m PHL', '2h 50m ORD', '1h 50m BWI', '1h 14m IAD']);
+    for (const p of oneStop) {
+      expect(p.layovers).toHaveLength(1);
+      const [leg] = p.layovers!;
+      expect(onPage).toContain(`${leg!.duration} ${leg!.airport}`);
+    }
+
+    // The 11h 35m two-stop itinerary prints no connection line at all, so the
+    // model must leave it empty rather than guess at one.
+    for (const p of result.prices.filter((x) => x.stops === 2)) {
+      expect(p.layovers ?? []).toHaveLength(0);
     }
   }, 120_000);
 });

--- a/apps/web/src/lib/scraper/extract-prices.test.ts
+++ b/apps/web/src/lib/scraper/extract-prices.test.ts
@@ -106,6 +106,33 @@ describe('extractPrices', () => {
     expect(result.failureReason).toBeUndefined();
   });
 
+  it('captures layovers, tolerating the shapes models drift into (issue #190)', async () => {
+    mockExtract.mockResolvedValue({
+      content: JSON.stringify([
+        // Clean, as prompted.
+        { travelDate: '2026-06-15', price: 300, currency: 'USD', airline: 'American', stops: 1, duration: '5h 55m', layovers: [{ duration: '1 hr 35 min', airport: 'ORD' }] },
+        // The raw page line, unparsed, under an aliased key.
+        { travelDate: '2026-06-15', price: 310, currency: 'USD', airline: 'United', stops: 1, duration: '6h 10m', layover: '55 min layover · Chicago ORD' },
+        // Nonstop: no layover data at all.
+        { travelDate: '2026-06-15', price: 320, currency: 'USD', airline: 'Delta', stops: 0, duration: '3h 05m', layovers: [] },
+      ]),
+      usage: { inputTokens: 400, outputTokens: 100 },
+    });
+
+    const result = await extractPrices('page content', 'https://flights.google.com', '2026-06-15');
+    expect(result.prices.map((p) => p.layovers)).toEqual([
+      [{ duration: '1h 35m', airport: 'ORD' }],
+      [{ duration: '55m', airport: 'Chicago ORD' }],
+      null,
+    ]);
+  });
+
+  it('asks the model for layovers', async () => {
+    mockExtract.mockResolvedValue({ content: '[]', usage: { inputTokens: 1, outputTokens: 1 } });
+    await extractPrices('page content', 'https://flights.google.com', '2026-06-15');
+    expect(mockExtract.mock.calls[0]![2] as string).toContain('layovers');
+  });
+
   it('filters out entries with zero price', async () => {
     mockExtract.mockResolvedValue({
       content: JSON.stringify([

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -148,7 +148,7 @@ ${currencyInstruction}
 ${bookingUrlRule}
 - stops: 0 for nonstop, 1 for 1 stop, etc.
 - duration: human-readable format like "8h 30m" — the full gate-to-gate time as shown, including time spent connecting
-- layovers: one entry per stop, in travel order, read from the connection text on the result (e.g. "1 hr 35 min layover · Chicago ORD"). duration in "1h 35m" form; airport is the IATA code when shown, otherwise the city name, otherwise null. Use [] for nonstop flights and when no layover text is visible
+- layovers: one entry per stop, in travel order. The connection line sits right under the stop count and is usually just a duration plus the airport ("55 min DTW", "1 hr 35 min layover · Chicago ORD"). duration in "1h 35m" form; airport is the IATA code when shown, otherwise the city name, otherwise null. Use [] for nonstop flights and whenever no connection line is visible — never infer a layover from the total duration or the departure and arrival times
 - departureTime: the departure time as shown (e.g. "10:25 AM", "7:50 PM"). Use null if not visible
 - arrivalTime: the arrival time as shown (e.g. "4:45 PM", "11:30 AM"). Use null if not visible
 - seatsLeft: if the page shows "N seats left" or "N seats left at this price", extract the number. Use null if not shown

--- a/apps/web/src/lib/scraper/extract-prices.ts
+++ b/apps/web/src/lib/scraper/extract-prices.ts
@@ -1,7 +1,7 @@
 import { EXTRACTION_PROVIDERS, CLI_PROVIDERS, LOCAL_PROVIDERS, resolveApiKey, type ExtractionUsage } from './ai-registry';
 import { MAX_PRICE_VALUE } from '@/lib/limits';
 import { prisma } from '@/lib/prisma';
-import { parseDurationToMinutes } from './duration';
+import { coerceLayovers, parseDurationToMinutes, type Layover } from './duration';
 import type { NavigationSource } from './navigate';
 import { acquireProviderToken } from './rate-limit';
 
@@ -13,6 +13,7 @@ export interface PriceData {
   bookingUrl: string | null;
   stops: number;
   duration: string | null;
+  layovers: Layover[] | null; // one entry per stop, in travel order
   departureTime: string | null; // e.g. "10:25 AM"
   arrivalTime: string | null; // e.g. "4:45 PM"
   seatsLeft: number | null; // e.g. 3 when "3 seats left" shown
@@ -131,6 +132,7 @@ Return ONLY valid JSON — an array of UP TO ${maxResults} objects with this exa
     "bookingUrl": "https://...",
     "stops": 1,
     "duration": "11h 20m",
+    "layovers": [{ "duration": "1h 35m", "airport": "ORD" }],
     "departureTime": "10:25 AM",
     "arrivalTime": "4:45 PM",
     "seatsLeft": 3,
@@ -145,7 +147,8 @@ General rules:
 ${currencyInstruction}
 ${bookingUrlRule}
 - stops: 0 for nonstop, 1 for 1 stop, etc.
-- duration: human-readable format like "8h 30m"
+- duration: human-readable format like "8h 30m" — the full gate-to-gate time as shown, including time spent connecting
+- layovers: one entry per stop, in travel order, read from the connection text on the result (e.g. "1 hr 35 min layover · Chicago ORD"). duration in "1h 35m" form; airport is the IATA code when shown, otherwise the city name, otherwise null. Use [] for nonstop flights and when no layover text is visible
 - departureTime: the departure time as shown (e.g. "10:25 AM", "7:50 PM"). Use null if not visible
 - arrivalTime: the arrival time as shown (e.g. "4:45 PM", "11:30 AM"). Use null if not visible
 - seatsLeft: if the page shows "N seats left" or "N seats left at this price", extract the number. Use null if not shown
@@ -374,6 +377,7 @@ function normalizeEntry(entry: unknown, travelDateFallback: string, currency: st
     bookingUrl: typeof bookingUrl === 'string' ? bookingUrl : '',
     stops: coerceStops(readField(e, 'stops', ['stopCount', 'numStops'])),
     duration: typeof duration === 'string' ? duration : null,
+    layovers: coerceLayovers(readField(e, 'layovers', ['layover', 'connections', 'stopDetails'])),
     departureTime: typeof departureTime === 'string' ? departureTime : null,
     arrivalTime: typeof arrivalTime === 'string' ? arrivalTime : null,
     seatsLeft: coerceSeatsLeft(readField(e, 'seatsLeft', ['seats', 'seatsRemaining'])),

--- a/apps/web/src/lib/scraper/run-scrape.ts
+++ b/apps/web/src/lib/scraper/run-scrape.ts
@@ -408,7 +408,7 @@ async function scrapeQueryForCountry(
     },
     orderBy: { scrapedAt: 'desc' },
     distinct: ['flightId'],
-    select: { flightId: true, price: true, airline: true, travelDate: true, currency: true, bookingUrl: true, stops: true, duration: true, departureTime: true, arrivalTime: true, flightNumber: true, status: true },
+    select: { flightId: true, price: true, airline: true, travelDate: true, currency: true, bookingUrl: true, stops: true, duration: true, layovers: true, departureTime: true, arrivalTime: true, flightNumber: true, status: true },
   });
 
   // Match prior rows against BOTH the new and the legacy id forms so the
@@ -437,6 +437,9 @@ async function scrapeQueryForCountry(
       bookingUrl: prev.bookingUrl,
       stops: prev.stops,
       duration: prev.duration,
+      // Prisma treats an explicit null on a Json column as ambiguous, so carry
+      // the value only when the prior row had one.
+      ...(prev.layovers == null ? {} : { layovers: prev.layovers }),
       departureTime: prev.departureTime,
       arrivalTime: prev.arrivalTime,
       flightId: prev.flightId,
@@ -459,6 +462,7 @@ async function scrapeQueryForCountry(
         bookingUrl: p.bookingUrl,
         stops: p.stops,
         duration: p.duration,
+        ...(p.layovers ? { layovers: p.layovers } : {}),
         departureTime: p.departureTime ?? null,
         arrivalTime: p.arrivalTime ?? null,
         flightId: p.flightId,

--- a/apps/web/src/test/fixtures/google-flights-layovers.txt
+++ b/apps/web/src/test/fixtures/google-flights-layovers.txt
@@ -1,0 +1,216 @@
+Skip to main content
+Accessibility feedback
+Explore
+Flights
+Hotels
+Vacation rentals
+Change appearance
+Sign in
+Loading results
+Flight search
+Round trip
+1
+Economy (include Basic)
+Albany ALB
+Columbus CMH
+Filters
+All filters
+Stops
+Airlines
+Bags
+Price
+Times
+Emissions
+Connecting airports
+Duration
+Search results
+12 results returned.
+Best
+Cheapest
+from $363
+Top departing flights
+Ranked based on price and conveniencePrices include required taxes + fees for 1 adult. Optional charges and bag fees may apply. Passenger assistance info.
+Sorted by top flights
+6:00 AM
+ – 
+9:52 AM
+DeltaOperated by SkyWest DBA Delta Connection
+3 hr 52 min
+ALB–CMH
+1 stop
+55 min DTW
+161 kg CO2e
+Avg emissions
+1
+0
+$363
+round trip
+9:55 AM
+ – 
+3:01 PM
+United
+5 hr 6 min
+ALB–CMH
+1 stop
+59 min ORD
+206 kg CO2e
++35% emissions
+$364
+round trip
+5:05 PM
+ – 
+10:55 PM
+Southwest
+5 hr 50 min
+ALB–CMH
+1 stop
+2 hr 5 min BNA
+185 kg CO2e
++21% emissions
+$364
+round trip
+7:18 PM
+ – 
+11:37 PM
+AmericanOperated by Piedmont Airlines as American Eagle, Republic Airways as American Eagle
+4 hr 19 min
+ALB–CMH
+1 stop
+1 hr 17 min PHL
+211 kg CO2e
++38% emissions
+1
+0
+$394
+round trip
+Price insights
+Prices are currently typical
+View price history
+Track prices
+Track prices from Albany to Columbus departing 2026-09-14 and returning 2026-09-21
+Sep 14 – 21
+Track prices from Albany to Columbus - Any dates
+Any dates
+Date grid
+Price graph
+Other departing flights
+6:23 PM
+ – 
+12:15 AM+1
+Delta
+5 hr 52 min
+ALB–CMH
+1 stop
+1 hr 43 min ATL
+220 kg CO2e
++44% emissions
+1
+0
+$363
+round trip
+6:00 AM
+ – 
+11:40 AM
+UnitedOperated by SkyWest DBA United Express
+5 hr 40 min
+ALB–CMH
+1 stop
+1 hr 30 min ORD
+212 kg CO2e
++39% emissions
+$364
+round trip
+4:53 PM
+ – 
+10:23 PM
+UnitedOperated by Republic Airways DBA United Express
+5 hr 30 min
+ALB–CMH
+1 stop
+1 hr 15 min ORD
+223 kg CO2e
++46% emissions
+$364
+round trip
+5:25 AM
+ – 
+5:00 PM
+Southwest
+11 hr 35 min
+ALB–CMH
+2 stops
+BWI, ATL
+332 kg CO2e
++117% emissions
+1
+0
+$460
+round trip
+8:00 AM
+ – 
+12:22 PM
+AmericanOperated by Piedmont Airlines as American Eagle
+4 hr 22 min
+ALB–CMH
+1 stop
+1 hr 8 min PHL
+199 kg CO2e
++30% emissions
+1
+0
+$549
+round trip
+9:55 AM
+ – 
+4:55 PM
+United
+7 hr
+ALB–CMH
+1 stop
+2 hr 50 min ORD
+202 kg CO2e
++32% emissions
+1
+0
+$587
+round trip
+1:15 PM
+ – 
+5:45 PM
+Southwest
+4 hr 30 min
+ALB–CMH
+1 stop
+1 hr 50 min BWI
+146 kg CO2e
+Avg emissions
+1
+0
+$609
+round trip
+7:35 PM
+ – 
+11:59 PM
+UnitedOperated by Commuteair DBA United Express, Republic Airways DBA United Express
+4 hr 24 min
+ALB–CMH
+1 stop
+1 hr 14 min IAD
+210 kg CO2e
++37% emissions
+1
+0
+$620
+round trip
+View more flights
+Language​English (United States)
+Location​United States
+CurrencyUSD
+About
+Privacy
+Terms
+Join user studies
+Feedback
+Help Center
+
+Displayed currencies may differ from the currencies used to purchase flights. Learn more

--- a/packages/cli/src/__tests__/create-queries.test.ts
+++ b/packages/cli/src/__tests__/create-queries.test.ts
@@ -65,7 +65,7 @@ describe('createTrackedQueries', () => {
       [{
         route: { ...baseRoute, flights: [] },
         flights: [
-          { travelDate: '2026-11-07', price: 431, currency: 'EUR', airline: 'Turkish Airlines', bookingUrl: 'https://turkishairlines.com', stops: 1, duration: '12h 30m', departureTime: '10:25 AM', arrivalTime: '4:45 PM', seatsLeft: null, flightNumber: 'TK 1' },
+          { travelDate: '2026-11-07', price: 431, currency: 'EUR', airline: 'Turkish Airlines', bookingUrl: 'https://turkishairlines.com', stops: 1, duration: '12h 30m', layovers: [{ duration: '2h', airport: 'IST' }], departureTime: '10:25 AM', arrivalTime: '4:45 PM', seatsLeft: null, flightNumber: 'TK 1' },
         ],
       }],
     );
@@ -80,7 +80,7 @@ describe('createTrackedQueries', () => {
       [{
         route: { ...baseRoute, flights: [] },
         flights: [
-          { travelDate: '2026-11-07', price: 431, currency: 'EUR', airline: 'Turkish Airlines', bookingUrl: 'https://turkishairlines.com', stops: 1, duration: '12h 30m', departureTime: '10:25 AM', arrivalTime: '4:45 PM', seatsLeft: null, flightNumber: 'TK 1' },
+          { travelDate: '2026-11-07', price: 431, currency: 'EUR', airline: 'Turkish Airlines', bookingUrl: 'https://turkishairlines.com', stops: 1, duration: '12h 30m', layovers: [{ duration: '2h', airport: 'IST' }], departureTime: '10:25 AM', arrivalTime: '4:45 PM', seatsLeft: null, flightNumber: 'TK 1' },
         ],
       }],
     );

--- a/packages/cli/src/lib/create-queries.ts
+++ b/packages/cli/src/lib/create-queries.ts
@@ -96,6 +96,8 @@ export async function createTrackedQueries(
           bookingUrl: f.bookingUrl || '',
           stops: f.stops ?? 0,
           duration: f.duration ?? null,
+          // Prisma treats an explicit null on a Json column as ambiguous.
+          ...(f.layovers ? { layovers: f.layovers } : {}),
         })),
       });
     }


### PR DESCRIPTION
Closes #190.

For a connecting fare we stored the stop count and the gate to gate `duration`, so a one stop that flies 3 hours with a 50 minute connection looked the same as one that sits 4 hours in an airport. The layover text was already on the page we scrape; the prompt just never asked for it.

## What changed

Nullable `layovers` Json column on `PriceSnapshot`, one `{ duration, airport }` entry per stop in travel order. A single `coerceLayovers` in `scraper/duration.ts` is the only door into that column: it normalizes what a model emits (clean objects, aliased keys, numeric minutes, or the raw connection line) and bounds what a client POSTs (entry count, field types, string lengths).

Air time is derived, not stored: `duration` minus the layover total. `airTimeMinutes` returns null when the two disagree rather than showing a negative.

Shows up wherever `duration` already did: the stops column in price history, the chart hover, the create time flight picker, and the best price line (which adds the air time breakdown). Five locales updated.

Existing rows read as null and the startup `db push` only adds a nullable column, so nothing needs backfilling.

## On the format

The issue quotes `1 hr 35 min layover, Chicago ORD`. A live capture shows Google's compact result list has no "layover" wording at all, just `55 min DTW` under the stop count. The prompt describes that form first and forbids inferring a connection from the total duration when no line is printed. The real capture is committed as a fixture, and the gated live suite asserts every extracted layover matches a line actually on the page, so a hallucinated connection fails.

## Verification

Live ALB to CMH scrape through the production `runScrapeForQuery` path into Postgres: 6 of 7 connecting snapshots persisted layovers, the one 2 stop itinerary (no connection line on the page) stored null. Rendered `/q/[id]` in a browser and confirmed all three surfaces, no console errors.

```
Delta      USD 363  1 stop   3h 52m   55m DTW layover     2h 57m in air
Southwest  USD 364  1 stop   5h 50m   2h 5m BNA layover   3h 45m in air
Southwest  USD 460  2 stops  11h 35m  (none)
```

`npm run ci` green: 1375 web + 43 CLI. Gated live suite green against the real model.
